### PR TITLE
fix(input-autocomplete): default size

### DIFF
--- a/docs/input-autocomplete/README.md
+++ b/docs/input-autocomplete/README.md
@@ -17,7 +17,7 @@ import InputAutocomplete from 'arui-feather/input-autocomplete';
 | options | Array.<[OptionsType](#OptionsType)> | `[]`  |  | Список вариантов выбора |
 | disabled | Boolean | `false`  |  | Управление возможностью изменения атрибута компонента, установка соответствующего класса-модификатора для оформления |
 | opened | Boolean |  |  | Управление видимостью выпадающего списка |
-| size | [SizeEnum](#SizeEnum) | `'s'`  |  | Размер компонента |
+| size | [SizeEnum](#SizeEnum) | `'m'`  |  | Размер компонента |
 | width | [WidthEnum](#WidthEnum) | `'default'`  |  | Управление возможностью компонента занимать всю ширину родителя |
 | onItemSelect | Function |  |  | Обработчик выбора пункта в выпадающем меню |
 
@@ -74,6 +74,3 @@ import InputAutocomplete from 'arui-feather/input-autocomplete';
 
  * `'default'`
  * `'available'`
-
-
-

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -55,7 +55,7 @@ class InputAutocomplete extends React.Component {
 
     static defaultProps = {
         disabled: false,
-        size: 's',
+        size: 'm',
         width: 'default',
         options: []
     };


### PR DESCRIPTION
Поправил дефолтный размер input-autocomplete.
У него был `s`, а у всех остальных `m`.