### PR TITLE
feat(scroll-to): set default duration to 0

### DIFF
--- a/src/lib/scroll-to.js
+++ b/src/lib/scroll-to.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import easings from './easings';
-import { SCROLL_TO_NORMAL_DURATION, SCROLL_TO_EASING } from '../vars';
+import { SCROLL_TO_EASING } from '../vars';
 
 /**
  * Скроллит по элементу или странице.
@@ -20,7 +20,7 @@ export default function scrollTo(options) {
     let {
         targetY,
         container,
-        duration = SCROLL_TO_NORMAL_DURATION,
+        duration = 0,
         easing = SCROLL_TO_EASING
     } = options;
 


### PR DESCRIPTION
Возвращение дефолтного значения в 0 — при предустановленном `SCROLL_TO_NORMAL_DURATION` аффектились тесты компонентов со `scrollTo` и не было возможности переопределить значение в 0. Плюс `SCROLL_TO_NORMAL_DURATION` оптимален не для всех случаев — при скроллинге на большие дистанции значение слишком мало.