### PR TITLE
test(header): fix resizing test

### DIFF
--- a/src/header/header-test.jsx
+++ b/src/header/header-test.jsx
@@ -74,7 +74,7 @@ describe('header', () => {
             setTimeout(() => {
                 expect(onResize).to.have.been.called.twice;
                 done();
-            }, 0);
+            }, 100);
         }, 0);
     });
 


### PR DESCRIPTION
Лечение периодических фейлов с этим кейсом. `ResizeSensor` не всегда успевает отрабатывать в заданный таймаут. Новое значение взял из:
https://github.com/alfa-laboratory/arui-feather/blob/master/src/resize-sensor/resize-sensor-test.jsx#L34