### PR TITLE
feat(popup): add data-for attr

### DIFF
--- a/docs/popup/README.md
+++ b/docs/popup/README.md
@@ -34,6 +34,7 @@ import Popup from 'arui-feather/popup';
 | onClickOutside | Function |  |  | Обработчик клика вне компонента |
 | minWidth | Number |  |  | Минимальная ширина попапа |
 | maxWidth | Number |  |  | Максимальная ширина попапа |
+| for | String |  |  | Указатель на родительский элемент |
 
 
 

--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -306,6 +306,7 @@ class CalendarInput extends React.Component {
         return (
             <Popup
                 ref={ (calendarPopup) => { this.calendarPopup = calendarPopup; } }
+                for={ this.props.name }
                 autoclosable={ true }
                 visible={ opened }
                 directions={ this.props.directions }

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -128,6 +128,7 @@ class InputAutocomplete extends React.Component {
                 className={ cn('popup') }
                 size={ this.props.size }
                 ref={ (popup) => { this.popup = popup; } }
+                for={ this.props.name }
                 visible={ opened }
                 autoclosable={ true }
                 onClickOutside={ this.handleClickOutside }

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -261,6 +261,7 @@ class Input extends React.Component {
             <Popup
                 directions={ this.props.errorDirections }
                 ref={ (errorPopup) => { this.errorPopup = errorPopup; } }
+                for={ this.props.name }
                 size={ this.props.size }
                 type='tooltip'
                 mainOffset={ 13 }

--- a/src/popup/popup-test.jsx
+++ b/src/popup/popup-test.jsx
@@ -96,6 +96,12 @@ describe('popup', () => {
         expect(popup.node).to.have.text('Popup');
     });
 
+    it('should set data-for when `for` prop is set', () => {
+        let { popup } = renderPopup({ for: 'example' }, {});
+
+        expect(popup.node.dataset.for).to.equal('example');
+    });
+
     it('should have tooltip with target=`anchor` and type=`tooltip`', () => {
         let { popup } = renderPopup({ type: 'tooltip' }, {});
 

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -99,7 +99,9 @@ class Popup extends React.Component {
         /** Минимальная ширина попапа */
         minWidth: Type.number,
         /** Максимальная ширина попапа */
-        maxWidth: Type.number
+        maxWidth: Type.number,
+        /** Указатель на родительский элемент */
+        for: Type.string
     };
 
     static defaultProps = {
@@ -214,6 +216,7 @@ class Popup extends React.Component {
             <RenderInContainer container={ this.getRenderContainer() }>
                 <div
                     ref={ (popup) => { this.popup = popup; } }
+                    data-for={ this.props.for }
                     className={ cn({
                         direction: this.state.direction,
                         type: (this.props.target === 'anchor') && (this.props.type === 'tooltip') && this.props.type,

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -316,6 +316,7 @@ class Select extends React.Component {
             <Popup
                 key='popup'
                 ref={ (popup) => { this.popup = popup; } }
+                for={ this.props.name }
                 autoclosable={ true }
                 className={ cn('popup') }
                 directions={ this.props.directions }

--- a/src/textarea/textarea.jsx
+++ b/src/textarea/textarea.jsx
@@ -148,6 +148,7 @@ class Textarea extends React.Component {
                     && <Popup
                         directions={ this.props.errorDirections }
                         ref={ (errorPopup) => { this.errorPopup = errorPopup; } }
+                        for={ this.props.name }
                         size={ this.props.size }
                         type='tooltip'
                         mainOffset={ 13 }


### PR DESCRIPTION
Добавление в Popup аттрибута `data-for`

При e2e тестировании невозможно найти в DOM попапы, относящиеся к конкретному инпуту тк они рендерятся в `body`

Карточка: https://trello.com/c/5gOyfebl/231--
