### PR TITLE
fix(popup): replace deprecated debounce decorator

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "es6-weak-map": "^2.0.2",
     "ima-babel6-polyfill": "^0.12.0",
     "inputmask-core": "^2.1.1",
+    "lodash.debounce": "^4.0.8",
     "lodash.sortedindexof": "^4.1.0",
     "matches-selector-polyfill": "^1.0.0",
     "modernizr": "^3.4.0",

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind, debounce } from 'core-decorators';
+import { autobind } from 'core-decorators';
+import debounce from 'lodash.debounce';
 import React from 'react';
 import Type from 'prop-types';
 
@@ -146,6 +147,12 @@ class Popup extends React.Component {
     popup;
     inner;
     content;
+
+    handleResizeWindow = debounce(() => {
+        if (this.isPropsToPositionCorrect()) {
+            this.redraw();
+        }
+    }, 200);
 
     componentWillMount() {
         if (this.context.isInCustomContainer
@@ -310,14 +317,6 @@ class Popup extends React.Component {
         }
 
         this.redraw();
-    }
-
-    @autobind
-    @debounce(200)
-    handleResizeWindow() {
-        if (this.isPropsToPositionCorrect()) {
-            this.redraw();
-        }
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,6 +1754,10 @@ chai@^3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
+chain-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
+
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -3024,6 +3028,10 @@ dom-converter@~0.1:
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
   dependencies:
     utila "~0.3"
+
+dom-helpers@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -8478,9 +8486,11 @@ react-styleguidist@^5.0.6:
     webpack-dev-server "^1.16.3"
     webpack-merge "^4.1.0"
 
-react-textarea-autosize@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-4.0.5.tgz#55379f6a6fa575fc87d1b8de2756e57e3b6c995d"
+react-textarea-autosize@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-4.3.2.tgz#962a52c68caceae408c18acecec29049b81e42fa"
+  dependencies:
+    prop-types "^15.5.8"
 
 react-to-typescript-definitions@^0.18.1:
   version "0.18.1"
@@ -8492,6 +8502,15 @@ react-to-typescript-definitions@^0.18.1:
     get-stdin "5.0.1"
     meow "3.7.0"
     pascal-case "2.0.0"
+
+react-transition-group@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.1.3.tgz#5e02cf6e44a863314ff3c68a0c826c2d9d70b221"
+  dependencies:
+    chain-function "^1.0.0"
+    dom-helpers "^3.2.0"
+    prop-types "^15.5.6"
+    warning "^3.0.0"
 
 react@^15.5.3:
   version "15.5.4"


### PR DESCRIPTION
В core-decorators@0.18.0 декоратор debounce был объявлен устаревшим.

## Мотивация и контекст
К сожалению, лодэшевский debounce несовместим с autobind (и "родным" лодэшевским bind), поэтому было решено объявить функцию через стрелку.
