### PR TITLE
fix(package.json): add babel-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "array-from": "^2.1.1",
     "array.prototype.fill": "^1.0.1",
     "array.prototype.find": "^2.0.4",
+    "babel-runtime": "^6.23.0",
     "bezier-easing": "^2.0.3",
     "cn-decorator": "^1.0.4",
     "core-decorators": "^0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,7 +433,7 @@ async@0.2.x, async@~0.2.6:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
-async@1.x, async@^1.3.0, async@^1.4.0, async@^1.4.2, async@^1.5.0:
+async@1.x, async@^1.3.0, async@^1.4.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -1183,7 +1183,7 @@ babel-runtime@^5.5.5:
   dependencies:
     core-js "^1.0.0"
 
-babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.9.2:
+babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.9.2:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -8369,19 +8369,7 @@ react-docgen-displayname-handler@^1.0.0:
   dependencies:
     recast "0.11.12"
 
-react-docgen@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.13.0.tgz#7fcc4a3104ea8d4fd428383ba38df11166837be9"
-  dependencies:
-    async "^1.4.2"
-    babel-runtime "^6.9.2"
-    babylon "~5.8.3"
-    commander "^2.9.0"
-    doctrine "^2.0.0"
-    node-dir "^0.1.10"
-    recast "^0.11.5"
-
-react-docgen@^2.15.0:
+react-docgen@^2.13.0, react-docgen@^2.15.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.15.0.tgz#11aced462256e4862b14e6af6e46bdcefacb28bb"
   dependencies:


### PR DESCRIPTION
Добавление зависимости от babel-runtime

## Мотивация и контекст
В `arui-presets` был добавлен плагин `transform-runtime`, который позволяет использовать полифилы из пакета `babel-runtime` вместо того, чтобы инлайнить их в каждом файле.