### PR TITLE
fix(input-autocomplete): add missing proptypes

### DIFF
--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -28,6 +28,7 @@ import { SCROLL_TO_NORMAL_DURATION } from '../vars';
 @performance(true)
 class InputAutocomplete extends React.Component {
     static propTypes = {
+        ...Input.propTypes,
         /** Список вариантов выбора */
         options: Type.arrayOf(Type.shape({
             /** Тип списка вариантов */


### PR DESCRIPTION
Добавлены недостающие проптайпы в InputAutocomplete

## Мотивация и контекст
Нужно для правильных доков/проптайпов