### PR TITLE
fix(fantasy): add label & hint props to calendar-input

### DIFF
--- a/docs/calendar-input/README.md
+++ b/docs/calendar-input/README.md
@@ -15,7 +15,6 @@ import CalendarInput from 'arui-feather/calendar-input';
 | Prop  | Тип  | По умолчанию | Обязательный | Описание |
 | ----- | ---- | ------------ | ------------ |----------|
 | value | String |  |  | Содержимое поля ввода, указанное по умолчанию |
-| error | Node |  |  | Отображение попапа с ошибкой в момент когда фокус находится в поле ввода |
 | calendar | [CalendarType](#CalendarType) |  |  | Свойства компонента [Calendar](../calendar/) |
 | opened | Boolean |  |  | Управление возможностью раскрытия календаря |
 | width | [WidthEnum](#WidthEnum) |  |  | Управление возможностью компонента занимать всю ширину родителя |
@@ -24,7 +23,10 @@ import CalendarInput from 'arui-feather/calendar-input';
 | size | [SizeEnum](#SizeEnum) |  |  | Размер компонента |
 | tabIndex | Number |  |  | Последовательность перехода между контролами при нажатии на Tab |
 | withIcon | Boolean | `true`  |  | Показывать иконку календаря в инпуте |
-| placeholder | String | `'00.00.0000'`  |  | Подсказка в текстовом поле |
+| label | Node |  |  | Лейбл для поля |
+| placeholder | String | `'00.00.0000'`  |  | Подсказка в поле |
+| hint | Node |  |  | Подсказка под полем |
+| error | Node |  |  | Отображение ошибки |
 | id | String |  |  | Идентификатор компонента в DOM |
 | name | String |  |  | Имя компонента в DOM |
 | theme | [ThemeEnum](#ThemeEnum) |  |  | Тема компонента |

--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -81,8 +81,6 @@ class CalendarInput extends React.Component {
     static propTypes = {
         /** Содержимое поля ввода, указанное по умолчанию */
         value: Type.string,
-        /** Отображение попапа с ошибкой в момент когда фокус находится в поле ввода */
-        error: Type.node,
         /** Свойства компонента [Calendar](../calendar/) */
         calendar: Type.shape({
             value: Type.number,
@@ -124,8 +122,14 @@ class CalendarInput extends React.Component {
         tabIndex: Type.number,
         /** Показывать иконку календаря в инпуте */
         withIcon: Type.bool,
-        /** Подсказка в текстовом поле */
+        /** Лейбл для поля */
+        label: Type.node,
+        /** Подсказка в поле */
         placeholder: Type.string,
+        /** Подсказка под полем */
+        hint: Type.node,
+        /** Отображение ошибки */
+        error: Type.node,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Имя компонента в DOM */
@@ -246,12 +250,14 @@ class CalendarInput extends React.Component {
                     { ...commonProps }
                     className={ cn('custom-field') }
                     disabledAttr={ this.state.isNativeInputEnabled }
-                    error={ this.props.error }
                     focused={ this.state.isInputFocused || this.state.isCalendarFocused }
                     mask='11.11.1111'
                     size={ this.props.size }
                     type='text'
+                    label={ this.props.label }
                     placeholder={ this.props.placeholder }
+                    hint={ this.props.hint }
+                    error={ this.props.error }
                     value={ value }
                     width={ this.props.width }
                     id={ this.props.id }

--- a/src/input/input-test.jsx
+++ b/src/input/input-test.jsx
@@ -129,10 +129,10 @@ describe('input', () => {
 
     it('should render with `label` from props', () => {
         let input = render(<Input label='Label' />);
-        let labelNode = input.node.querySelector('.input__top');
+        let topNode = input.node.querySelector('.input__top');
 
-        expect(labelNode).to.exist;
-        expect(labelNode).to.have.html('Label');
+        expect(topNode).to.exist;
+        expect(topNode).to.have.text('Label');
     });
 
     it('should render with `placeholder` from props', () => {
@@ -147,7 +147,7 @@ describe('input', () => {
         let subNode = input.node.querySelector('.input__sub');
 
         expect(subNode).to.exist;
-        expect(subNode).to.have.html('Hint');
+        expect(subNode).to.have.text('Hint');
     });
 
     it('should render with `error` from props', () => {
@@ -155,7 +155,7 @@ describe('input', () => {
         let subNode = input.node.querySelector('.input__sub');
 
         expect(subNode).to.exist;
-        expect(subNode).to.have.html('Error');
+        expect(subNode).to.have.text('Error');
     });
 
     it('should render with `off` autocomplete attribute', () => {

--- a/src/input/input-test.jsx
+++ b/src/input/input-test.jsx
@@ -127,6 +127,37 @@ describe('input', () => {
         expect(input.node).to.have.class('input_focused');
     });
 
+    it('should render with `label` from props', () => {
+        let input = render(<Input label='Label' />);
+        let labelNode = input.node.querySelector('.input__top');
+
+        expect(labelNode).to.exist;
+        expect(labelNode).to.have.html('Label');
+    });
+
+    it('should render with `placeholder` from props', () => {
+        let input = render(<Input placeholder='Placeholder' />);
+        let controlNode = input.node.querySelector('input');
+
+        expect(controlNode).to.have.attr('placeholder', 'Placeholder');
+    });
+
+    it('should render with `hint` from props', () => {
+        let input = render(<Input hint='Hint' />);
+        let subNode = input.node.querySelector('.input__sub');
+
+        expect(subNode).to.exist;
+        expect(subNode).to.have.html('Hint');
+    });
+
+    it('should render with `error` from props', () => {
+        let input = render(<Input error='Error' />);
+        let subNode = input.node.querySelector('.input__sub');
+
+        expect(subNode).to.exist;
+        expect(subNode).to.have.html('Error');
+    });
+
     it('should render with `off` autocomplete attribute', () => {
         let input = render(<Input autocomplete={ false } />);
         let controlNode = input.node.querySelector('input');


### PR DESCRIPTION
Добавление забытых `label` и `hint` свойств в `CalendarInput`.