### PR TITLE
fix(input-autocomplete): ability to work with masks

### DIFF
--- a/docs/input/README.md
+++ b/docs/input/README.md
@@ -66,8 +66,9 @@ import Input from 'arui-feather/input';
 | ------ | -------- |
 | getNode(): HTMLElement | Возвращает корневой `HTMLElement` компонента. |
 | getBoxNode(): HTMLSpanElement | Возвращает ссылку на инстанс контейнера для контрола. |
-| getControl(): union | Возвращает ссылку на инстанс контрола.
-Для полей ввода с маской ссылку на объект `MaskedInput`. |
+| getControl(): HTMLInputElement | Возвращает ссылку на HTMLElement инпута. |
+| getMaskedInputInstance(): union | Возвращает ссылку на инстанс MaskedInput.
+Если маска не была установлена, возвращает null. |
 | focus() | Устанавливает фокус на поле ввода. |
 | blur() | Убирает фокус с поля ввода. |
 | scrollTo() | Скроллит страницу до поля ввода. |

--- a/docs/masked-input/README.md
+++ b/docs/masked-input/README.md
@@ -29,6 +29,7 @@ import MaskedInput from 'arui-feather/masked-input';
 | ------ | -------- |
 | focus() | Устанавливает фокус на поле ввода. |
 | blur() | Снимает фокус с поля ввода. |
+| getControl(): HTMLInputElement | Возвращает ссылку на HTMLElement инпута. |
 | setMask(newMask: String, formatCharacters) | Синхронно обновляет маску на поле ввода. |
 
 

--- a/src/input/input-test.jsx
+++ b/src/input/input-test.jsx
@@ -9,6 +9,7 @@ import bowser from 'bowser';
 import { render, cleanUp, simulate } from '../test-utils';
 
 import Input from './input';
+import MaskedInput from '../masked-input';
 import Icon from '../icon/icon';
 
 import { SCROLL_TO_CORRECTION } from '../vars';
@@ -350,6 +351,34 @@ describe('input', () => {
         let controlNode = input.node.querySelector('input');
 
         expect(controlNode.value).to.equal('А 456 ИТ');
+    });
+
+    it('should return `HTMLInputElement` when `getControl` method called', () => {
+        let input = render(<Input />);
+        let controlNode = input.instance.getControl();
+
+        expect(controlNode).to.be.instanceOf(HTMLInputElement);
+    });
+
+    it('should return `HTMLInputElement` when `getControl` method called and mask is set', () => {
+        let input = render(<Input mask='111' />);
+        let controlNode = input.instance.getControl();
+
+        expect(controlNode).to.be.instanceOf(HTMLInputElement);
+    });
+
+    it('should return null when `getMaskedInputInstance` method is called and mask is not set', () => {
+        let input = render(<Input />);
+        let maskedInputInstance = input.instance.getMaskedInputInstance();
+
+        expect(maskedInputInstance).to.be.null;
+    });
+
+    it('should return MaskedInput instance when getMaskedInputInstance method is called and mask is set', () => {
+        let input = render(<Input mask='111' />);
+        let maskedInputInstance = input.instance.getMaskedInputInstance();
+
+        expect(maskedInputInstance).to.be.instanceOf(MaskedInput);
     });
 
     if (bowser.mobile) {

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -378,14 +378,32 @@ class Input extends React.Component {
     }
 
     /**
-     * Возвращает ссылку на инстанс контрола.
-     * Для полей ввода с маской ссылку на объект `MaskedInput`.
+     * Возвращает ссылку на HTMLElement инпута.
      *
      * @public
-     * @returns {HTMLInputElement|MaskedInput}
+     * @returns {HTMLInputElement}
      */
     getControl() {
+        if (this.props.mask !== undefined) {
+            return this.control.getControl();
+        }
+
         return this.control;
+    }
+
+    /**
+     * Возвращает ссылку на инстанс MaskedInput.
+     * Если маска не была установлена, возвращает null.
+     *
+     * @public
+     * @returns {MaskedInput|null}
+     */
+    getMaskedInputInstance() {
+        if (this.props.mask !== undefined) {
+            return this.control;
+        }
+
+        return null;
     }
 
     /**

--- a/src/masked-input/masked-input-test.jsx
+++ b/src/masked-input/masked-input-test.jsx
@@ -181,4 +181,11 @@ describe('masked-input', () => {
             done();
         }, 0);
     });
+
+    it('should return `HTMLInputElement` when `getControl` method called', () => {
+        let maskedInput = render(<MaskedInput mask='111' />);
+        let controlNode = maskedInput.instance.getControl();
+
+        expect(controlNode).to.be.instanceOf(HTMLInputElement);
+    });
 });

--- a/src/masked-input/masked-input.jsx
+++ b/src/masked-input/masked-input.jsx
@@ -192,6 +192,16 @@ class MaskedInput extends React.Component {
     }
 
     /**
+     * Возвращает ссылку на HTMLElement инпута.
+     *
+     * @public
+     * @returns {HTMLInputElement}
+     */
+    getControl() {
+        return this.input;
+    }
+
+    /**
      * Синхронно обновляет маску на поле ввода.
      *
      * @public

--- a/src/money-input/money-input.jsx
+++ b/src/money-input/money-input.jsx
@@ -192,7 +192,7 @@ class MoneyInput extends React.Component {
         this.mask = new Mask(this.maskPattern);
 
         if (this.root) {
-            this.root.getControl().setMask(this.maskPattern);
+            this.root.getMaskedInputInstance().setMask(this.maskPattern);
         }
     }
 


### PR DESCRIPTION
Починил работу маскирования для компонента `InputAutocomplete`

## Мотивация и контекст
`InputAutocomplete` получал неправильную ссылку на `HTMLElement` инпута, когда последний рендерился через `MaskedInput`. Это ломало `onBlur` и `onFocus` в `InputAutocomlete`, делая его совершенно беспомощным.