### PR TITLE
fix(slide-down): add width parent element for right behavior

### DIFF
--- a/src/slide-down/slide-down.css
+++ b/src/slide-down/slide-down.css
@@ -6,6 +6,7 @@
     overflow: hidden;
     transition: height .3s ease;
     position: relative;
+    width: 100%;
 
     &__content {
         position: absolute;


### PR DESCRIPTION
Ошибка в том что slide-down разлетался на весь экран а потом схлопывался была из-за того что родитель не имеел четких рамок. wiidth 100% исправило это!
