### PR TITLE
fix(package): up presets version

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-textarea-autosize": "^4.3.2"
   },
   "devDependencies": {
-    "arui-presets": "2.4.0",
+    "arui-presets": "2.5.0",
     "babel-core": "^6.24.1",
     "bowser": "^1.7.0",
     "chai": "^3.5.0",


### PR DESCRIPTION
новая версия arui-presets

## Мотивация и контекст
в новых пресетах вырезаются кооментарии из импортируемых файлов цсс, теперь не будет некольких блоков с лицензией и комментариев к переменным при импорте