### PR TITLE
feat(radio-group): add disabled attribute

### DIFF
--- a/docs/radio-group/README.md
+++ b/docs/radio-group/README.md
@@ -19,6 +19,7 @@ import RadioGroup from 'arui-feather/radio-group';
 | error | Node |  |  | Отображение попапа с ошибкой в момент когда фокус находится на компоненте |
 | width | [WidthEnum](#WidthEnum) |  |  | Управление шириной группы кнопок для типа 'button'. При значении 'available' растягивает группу на ширину родителя |
 | name | String |  |  | Уникальное имя блока |
+| disabled | Boolean |  |  | Управление возможностью изменения состояния 'checked' дочерних компонентов `Radio` |
 | children | Array.<Node>\|Node |  |  | Дочерние элементы `RadioGroup`, как правило, компоненты `Radio` |
 | theme | [ThemeEnum](#ThemeEnum) |  |  | Тема компонента |
 | className | Function\|String |  |  | Дополнительный класс |

--- a/src/radio-group/radio-group-test.jsx
+++ b/src/radio-group/radio-group-test.jsx
@@ -191,4 +191,31 @@ describe('radio-group', () => {
 
         expect(onChange).to.have.been.called.once;
     });
+
+    it('should disable all child radios when disabled=true', () => {
+        let radioGroup = render(
+            <RadioGroup disabled={ true }>
+                <Radio key='1' />
+                <Radio key='2' />
+                <Radio key='3' />
+            </RadioGroup>
+        );
+
+        let disabledRadioNodes = radioGroup.node.querySelectorAll('.radio_disabled');
+        expect(disabledRadioNodes.length).to.equal(3);
+    });
+
+    it('shouldn\'t call `onChange` callback when disabled=true', function () {
+        let onChange = chai.spy();
+        let radioGroup = render(
+            <RadioGroup onChange={ onChange } disabled={ true }>
+                <Radio key='1' />
+            </RadioGroup>
+        );
+        let radio = radioGroup.node.querySelector('.radio');
+
+        simulate(radio, 'change');
+
+        expect(onChange).to.have.not.been.called;
+    });
 });

--- a/src/radio-group/radio-group.jsx
+++ b/src/radio-group/radio-group.jsx
@@ -27,6 +27,8 @@ class RadioGroup extends React.Component {
         width: Type.oneOf(['default', 'available']),
         /** Уникальное имя блока */
         name: Type.string,
+        /** Управление возможностью изменения состояния 'checked' дочерних компонентов `Radio` */
+        disabled: Type.bool,
         /** Дочерние элементы `RadioGroup`, как правило, компоненты `Radio` */
         children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
         /** Тема компонента */
@@ -54,6 +56,10 @@ class RadioGroup extends React.Component {
         let children = null;
         let props = { name: this.props.name };
         let radioGroupParts = {};
+
+        if (this.props.disabled !== undefined) {
+            props.disabled = this.props.disabled;
+        }
 
         if (this.props.children) {
             children = this.props.children.length ? this.props.children : [this.props.children];

--- a/src/radio/radio_theme_alfa-on-color.css
+++ b/src/radio/radio_theme_alfa-on-color.css
@@ -42,12 +42,14 @@
         box-shadow: 0 0 0 1px rgba(255, 255, 255, .9);
     }
 
-    &.radio_disabled {
+    &.radio_disabled,
+    &.radio_disabled.radio_hovered {
         color: var(--color-content-minor-alfa-on-color);
 
         .radio__box {
             border-color: transparent;
             background: var(--color-background-control-disabled-alfa-on-color);
+            box-shadow: none;
 
             &:after {
                 background: var(--color-accent-content-minor);

--- a/src/radio/radio_theme_alfa-on-white.css
+++ b/src/radio/radio_theme_alfa-on-white.css
@@ -42,12 +42,14 @@
         box-shadow: 0 0 0 1px rgba(0, 0, 0, .9);
     }
 
-    &.radio_disabled {
+    &.radio_disabled,
+    &.radio_disabled.radio_hovered {
         color: var(--color-content-minor-alfa-on-white);
 
         .radio__box {
             border-color: transparent;
             background: var(--color-background-control-disabled-alfa-on-white);
+            box-shadow: none;
         }
 
         &.radio_checked .radio__box:after {


### PR DESCRIPTION
Добавил проп `disabled` в `RadioGroup`

## Мотивация и контекст
`RadioGroup` фактически полностью берет на себя взаимодействие с радиокнопками, через него прокидываются все колбеки, он управляет отображением (`type`), значением (`value`), ошибками и тд для дочерних радиокнопок.
Поэтому кажется очень логичным добавить в него возможность выключать все дочерние радиокнопки, что и было сделано.
А еще это очень удобно при использовании `ReduxForm`