### PR TITLE
fix(masked-input): correct caret control condition

### DIFF
--- a/src/masked-input/masked-input.jsx
+++ b/src/masked-input/masked-input.jsx
@@ -232,7 +232,7 @@ class MaskedInput extends React.Component {
         // Если изменение поля ввода произошло не в конце ввода,
         // то необходимо починить стандартное поведение Реакта и
         // вернуть каретку к последнему изменению.
-        if (prevSelection < currentValue.length) {
+        if (prevSelection <= currentValue.length) {
             let newSelection = prevSelection;
 
             // Определяем тип операции, который был произведен над текстовым полем.


### PR DESCRIPTION
Исправление ошибки перескока каретки в крайнее правое положение при добавлении символа перед последним.

## Как воспроизводится ошибка:
1. `<Input mask={ 'AAAA' } />`;
2. `|____` -> поле пустое (| — каретка);
3. `A|___` -> вводим символ 'A': `prevSelection === 1`, `currentValue.length === 0`;
4. `AB|__` -> вводим символ 'B': `prevSelection === 2`,  `currentValue.length === 1`; 
5. `ABD|_` -> вводим символ 'D': `prevSelection === 3`,  `currentValue.length === 2`;  
6. `AB|D_` -> передвигаем каретку на место пропущенной 'C';
7. `ABCD|` -> вводим символ 'C': `prevSelection === 3`, `currentValue.length === 3`.

Каретка перепрыгивает в конец, хотя ожидаемым результатом является `ABC|D`;
