### PR TITLE
fix(*): fix click on checkbox and radio fires twice

### DIFF
--- a/src/checkbox/checkbox.jsx
+++ b/src/checkbox/checkbox.jsx
@@ -110,6 +110,7 @@ class CheckBox extends React.Component {
                         value={ this.props.value }
                         checked={ checked }
                         disabled={ this.props.disabled }
+                        onClick={ this.handleInputControlClick }
                         onChange={ this.handleChange }
                     />
                 </span>
@@ -159,6 +160,11 @@ class CheckBox extends React.Component {
                 />
             </div>
         );
+    }
+
+    @autobind
+    handleInputControlClick(event) { // eslint-disable-line class-methods-use-this-regexp/class-methods-use-this
+        event.stopPropagation();
     }
 
     @autobind

--- a/src/radio/radio.jsx
+++ b/src/radio/radio.jsx
@@ -120,6 +120,7 @@ class Radio extends React.Component {
                         type='radio'
                         className={ cn('control') }
                         ref={ (control) => { this.control = control; } }
+                        onClick={ this.handleInputControlClick }
                         onChange={ this.handleChange }
                     />
                 </span>
@@ -171,6 +172,11 @@ class Radio extends React.Component {
                 />
             </div>
         );
+    }
+
+    @autobind
+    handleInputControlClick(event) { // eslint-disable-line class-methods-use-this-regexp/class-methods-use-this
+        event.stopPropagation();
     }
 
     @autobind


### PR DESCRIPTION
Запрещаем input[type="checkbox"] и input[type="radio"] распространять события

## Мотивация и контекст
Проблема:

```
<div>
    <div className='column' onClick={(e) => alert('вызываюсь дважды')}>
        <CheckBox text='Обычный чекбокс' />
    </div>
</div>
```

onClick вызывается 2 раза, потому-что клик по label триггирит клик по input[type="checkbox"].
Получаются 2 события, которые начинают всплывать, и их ловит родитель, собственно, поэтому onClick отрабатывает 2 раза.

как решение запретить input[type="checkbox"] распространять события, он у нас всё равно спрятан за `z-index: -1; opacity: 0;` и кликнуть на него намеренно нельзя