### PR TITLE
fix(calendar-input): correctly set month when limits given

### DIFF
--- a/src/calendar-input/calendar-input-test.jsx
+++ b/src/calendar-input/calendar-input-test.jsx
@@ -8,6 +8,7 @@ import bowser from 'bowser';
 import { render, cleanUp, simulate } from '../test-utils';
 
 import CalendarInput from './calendar-input';
+import * as calendarUtils from './utils';
 import keyboardCode from '../lib/keyboard-code';
 import { SCROLL_TO_CORRECTION } from '../vars';
 
@@ -373,4 +374,56 @@ describe('calendar-input', () => {
             }, 0);
         });
     }
+
+    describe('calendar utils', () => {
+        it('should change format of a date', () => {
+            const result = calendarUtils.changeDateFormat('2012-11-10', 'YYYY-MM-DD', 'DD.MM.YYYY');
+            expect(result).to.be.eql('10.11.2012');
+        });
+
+        it('should return start of month', () => {
+            const result = new Date(calendarUtils.calculateMonth('2012-11-10', 'YYYY-MM-DD'));
+            expect(result.getMonth() + 1).to.be.eql(11); // getMonth is zero based
+            expect(result.getFullYear()).to.be.eql(2012);
+        });
+
+        it('should return current month if not valid value given', () => {
+            const result = new Date(calendarUtils.calculateMonth('foo', 'YYYY-MM-DD'));
+            const now = new Date();
+            expect(result.getMonth()).to.be.eql(now.getMonth());
+            expect(result.getFullYear()).to.be.eql(now.getFullYear());
+        });
+
+        it('should return earlierLimit month if it after given date', () => {
+            const result = new Date(calendarUtils.calculateMonth(
+                '2012-11-10',
+                'YYYY-MM-DD',
+                (new Date(2013, 8, 10).getTime())
+            ));
+            expect(result.getMonth()).to.be.eql(8);
+            expect(result.getFullYear()).to.be.eql(2013);
+        });
+
+        it('should return laterLimit month if it before given date', () => {
+            const result = new Date(calendarUtils.calculateMonth(
+                '2012-11-10',
+                'YYYY-MM-DD',
+                (new Date(2011, 8, 10).getTime()),
+                (new Date(2011, 9, 10).getTime())
+            ));
+            expect(result.getMonth()).to.be.eql(9);
+            expect(result.getFullYear()).to.be.eql(2011);
+        });
+
+        it('should return start of month if earlier and later limit given, but value is between them', () => {
+            const result = new Date(calendarUtils.calculateMonth(
+                '2012-11-10',
+                'YYYY-MM-DD',
+                (new Date(2011, 8, 10).getTime()),
+                (new Date(2014, 9, 10).getTime())
+            ));
+            expect(result.getMonth() + 1).to.be.eql(11); // getMonth is zero based
+            expect(result.getFullYear()).to.be.eql(2012);
+        });
+    });
 });

--- a/src/calendar-input/utils.js
+++ b/src/calendar-input/utils.js
@@ -1,0 +1,64 @@
+import startOfDay from 'date-fns/start_of_day';
+import formatDate from 'date-fns/format';
+import isDateValid from 'date-fns/is_valid';
+import { parse } from '../lib/date-utils';
+
+/**
+ * Разбирает введенную пользователем дату используя заданный формат.
+ *
+ * @param {String} value Дата
+ * @param {String} format Ожидаемый формат даты
+ * @returns {Number}
+ */
+export function parseDate(value, format) {
+    const valueTrimmed = value ? value.replace(/~+$/, '') : '';
+    let result = null;
+
+    // Проверяем, чтобы пользователь ввёл полную строку даты без пробелов.
+    if (valueTrimmed.length === format.length && !valueTrimmed.match(/\s/)) {
+        let valueDate = parse(valueTrimmed, format);
+        if (isDateValid(valueDate)) {
+            result = valueDate.valueOf();
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Изменяет формат даты с одного на другой.
+ *
+ * @param {String} value Оригинальная строка с датой
+ * @param {String} inFormat Входной формат даты
+ * @param {String} outFormat Формат возвращаемой даты
+ * @returns {String}
+ */
+export function changeDateFormat(value, inFormat, outFormat) {
+    let date = parseDate(value, inFormat);
+
+    if (date) {
+        return formatDate(date, outFormat);
+    }
+    return value;
+}
+
+/**
+ * Возвращает дату с корректным месяцем.
+ *
+ * @param {String} value Строка даты
+ * @param {String} format Формат строки с датой
+ * @param {Number} [earlierLimit] Левая граница дат
+ * @param {Number} [laterLimit] Правая граница дат
+ * @returns {Number}
+ */
+export function calculateMonth(value, format, earlierLimit, laterLimit) {
+    let newValue = (value && parseDate(value, format)) || Date.now();
+    if (earlierLimit && earlierLimit > newValue) {
+        return startOfDay(earlierLimit).valueOf();
+    }
+    if (laterLimit && laterLimit < newValue) {
+        return startOfDay(laterLimit).valueOf();
+    }
+
+    return startOfDay(newValue).valueOf();
+}


### PR DESCRIPTION
Корректная обработка earlierLimit и laterLimit когда value не попадает в них

## Мотивация и контекст
> Если earlierLimit установлен на более поздний месяц, то если calendar-input пустой, он показывает изначально текущий месяц, где нельзя ничего выбрать