### PR TITLE
feat(select): pass name to button attribute

### DIFF
--- a/src/select/select-test.jsx
+++ b/src/select/select-test.jsx
@@ -137,6 +137,15 @@ describe('select', () => {
         expect(buttonNode).to.have.text(checkedOption.checkedText);
     });
 
+    it('should set name attribute on button when name prop is passed', () => {
+        let selectProps = {
+            name: 'select-name'
+        };
+
+        let { buttonNode } = renderSelect(selectProps);
+        expect(buttonNode).to.have.attribute('name', 'select-name');
+    });
+
     it('should set class on public focus method', (done) => {
         let { select } = renderSelect({ options: OPTIONS });
 

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -236,6 +236,7 @@ class Select extends React.Component {
                 ref={ (button) => { this.button = button; } }
                 size={ this.props.size }
                 disabled={ this.props.disabled }
+                name={ this.props.name }
                 text={ this.renderButtonContent() }
                 rightAddons={ [
                     <Icon


### PR DESCRIPTION
Передача пропса `name` в атрибут `name` у кнопки компонента `Select`.

## Мотивация и контекст
В основном нужно для интеграционных тестов, чтобы вытаскивать текущее значение селекта из `Button`.
Думал, что можно также рендерить hidden инпут с правильным `name`, но это надо обсуждать отдельно.
