### PR TITLE
fix(input): fix control height in ie11

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -63,6 +63,7 @@
         display: inline-block;
         position: relative;
         width: 100%;
+        height: 100%;
         margin: 0;
         padding: 0;
         outline: none;


### PR DESCRIPTION
Фикс бага с высотой контролов в IE11 на текущем дизайне.

FYI: Завёл задачу про тесты на ie в gemini на ближайшее время.