### PR TITLE
fix(css): there is no space for showing addons on the right side of c…

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -73,6 +73,7 @@
         border: 0;
         -webkit-appearance: none;
         -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+        min-width: 1px;
 
         &::-webkit-search-decoration {
             -webkit-appearance: none;


### PR DESCRIPTION
проблема в FF с input, не хватает места для input, если ширина контейнера для всего блока инпута с аддонами такая что. Для инпута в FF надо указывать минимальный width для горизонтального инпута, если аддоны внизу, то min-height.

