### PR TITLE
fix(button): fix mouseover after disabled button

### DIFF
--- a/src/button/button.css
+++ b/src/button/button.css
@@ -70,6 +70,7 @@
 
     &_disabled {
         cursor: default;
+        pointer-events: none;
     }
 
     &_disabled &__icon {

--- a/src/button/fantasy/button.css
+++ b/src/button/fantasy/button.css
@@ -64,6 +64,7 @@
 
     &_disabled {
         cursor: default;
+        pointer-events: none;
     }
 
     &_disabled &__icon {


### PR DESCRIPTION
 Fix mouseover after disabled button

Исправлен баг при котором не срабатывало событие mouseover после того как переводишь курсор мыши с disabled кнопки на любую другую
https://trello.com/c/GZTgThg4/309-checkboxgroup-проблемы-с-mouseover
