### PR TITLE
feat(popup): full-screen popup mode for select on mobile

### DIFF
--- a/docs/popup/README.md
+++ b/docs/popup/README.md
@@ -19,7 +19,7 @@ import Popup from 'arui-feather/popup';
 | type | [TypeEnum](#TypeEnum) |  |  | Тип попапа |
 | height | [HeightEnum](#HeightEnum) |  |  | Подстраивание высоты попапа под край окна ('adaptive'), занятие попапом всей возможной высоты ('available'), 'default' |
 | directions | Array.<[DirectionsEnum](#DirectionsEnum)> |  |  | Только для target='anchor', расположение (в порядке приоритета) относительно точки открытия. Первым указывается главное направление, через дефис - второстепенное направление |
-| target | [TargetEnum](#TargetEnum) | `'anchor'`  |  | Привязка компонента к другому элементу на странице, или его расположение независимо от остальных: 'anchor', 'position' |
+| target | [TargetEnum](#TargetEnum) | `'anchor'`  |  | Привязка компонента к другому элементу на странице, или его расположение независимо от остальных: 'anchor', 'position', 'screen' |
 | mainOffset | Number |  |  | Только для target='anchor'. Смещение в пикселях всплывающего окна относительно основного направления |
 | secondaryOffset | Number | `0`  |  | Только для target='anchor'. Смещение в пикселях всплывающего окна относительно второстепенного направления |
 | fitContaiterOffset | Number | `0`  |  | Только для target='anchor'. Минимально допустимое смещение в пикселях всплывающего окна от края его контейнера |
@@ -92,6 +92,7 @@ import Popup from 'arui-feather/popup';
 
  * `'anchor'`
  * `'position'`
+ * `'screen'`
 
 
 ### <a id="SizeEnum"></a>SizeEnum

--- a/docs/select/README.md
+++ b/docs/select/README.md
@@ -30,6 +30,7 @@ import Select from 'arui-feather/select';
 | placeholder | String | `'Выберите:'`  |  | Подсказка в поле |
 | hint | Node |  |  | Подсказка под полем |
 | error | Node |  |  | Отображение ошибки |
+| mobileMenuMode | [MobileMenuModeEnum](#MobileMenuModeEnum) | `'native'`  |  | Управление нативным режимом на мобильных устройствах * |
 | theme | [ThemeEnum](#ThemeEnum) |  |  | Тема компонента |
 | onFocus | Function |  |  | Обработчик фокуса на компоненте |
 | onBlur | Function |  |  | Обработчик потери фокуса компонентом |
@@ -123,6 +124,12 @@ import Select from 'arui-feather/select';
  * `'m'`
  * `'l'`
  * `'xl'`
+
+
+### <a id="MobileMenuModeEnum"></a>MobileMenuModeEnum
+
+ * `'native'`
+ * `'popup'`
 
 
 ### <a id="ThemeEnum"></a>ThemeEnum

--- a/src/popup/README.md
+++ b/src/popup/README.md
@@ -7,7 +7,8 @@ class PopupDemo extends React.Component {
             popup2: false,
             popup3: false,
             popup4: false,
-            popup5: false
+            popup5: false,
+            popup6: false,
         };
 
         this.popup1;
@@ -15,12 +16,14 @@ class PopupDemo extends React.Component {
         this.popup3;
         this.popup4;
         this.popup5;
+        this.popup6;
 
         this.target1;
         this.target2;
         this.target3;
         this.target4;
         this.target5;
+        this.target6;
     }
 
     componentDidMount() {
@@ -128,6 +131,30 @@ class PopupDemo extends React.Component {
                         onClickOutside={ () => { this.setState({ popup5: false }); } }
                     >
                         { 'Popup with autoclosable="true"' }
+                    </Popup>
+                </div>
+                <div className='row'>
+                    <Button
+                        ref={ (target) => { this.target6 = target; } }
+                        size='m'
+                        onClick={ () => { this.setState({ popup6: !this.state.popup6 }); } }
+                    >
+                        Click me
+                    </Button>
+                    <Popup
+                        ref={ (popup) => { this.popup6 = popup; } }
+                        target='screen'
+                        visible={ this.state.popup6 }
+                    >
+                        <p>Popup with target="screen"</p>
+                        <p>
+                            <Button
+                                size='m'
+                                onClick={ () => { this.setState({ popup6: false }); } }
+                            >
+                                Close
+                            </Button>
+                        </p>
                     </Popup>
                 </div>
             </div>

--- a/src/popup/fantasy/popup.css
+++ b/src/popup/fantasy/popup.css
@@ -130,6 +130,16 @@
             padding: 17px 22px;
         }
     }
+
+    &_target_screen {
+        position: fixed;
+        border-radius: 0;
+        box-shadow: none;
+
+        .popup__inner {
+            border-radius: 0;
+        }
+    }
 }
 
 .popup_type_tooltip {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -126,6 +126,12 @@
     &_padded.popup_size_xl &__content {
         padding: 17px 22px;
     }
+
+    &_target_screen {
+        position: fixed;
+        border-radius: 0;
+        box-shadow: none;
+    }
 }
 
 .popup_type_tooltip {

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -265,7 +265,7 @@ class Popup extends React.Component {
         let { scrollTop, offsetHeight, scrollHeight } = event.target;
         let isBottomReached = Math.round(scrollTop) + offsetHeight === scrollHeight;
 
-        if (this.props.height === 'adaptive') {
+        if (this.props.height === 'adaptive' || this.props.target === 'screen') {
             let gradientStyles = {
                 right: this.state.gradientStyles.right
             };
@@ -433,7 +433,13 @@ class Popup extends React.Component {
                 break;
 
             case 'screen':
-                bestDrawingParams = { top: 0, left: 0, right: 0, bottom: 0 };
+                bestDrawingParams = {
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    overflow: this.inner.scrollHeight > this.inner.clientHeight
+                };
                 break;
 
             case 'anchor':

--- a/src/select/README.md
+++ b/src/select/README.md
@@ -122,3 +122,82 @@ const options = [
     ))}
 </div>
 ```
+
+Без фолбэка на нативный контрол на мобильном устройстве
+```
+const options = [
+    { value: '00', text: 'Vkontakte' },
+    { value: '01', text: 'Facebook' },
+    { value: '02', text: 'Twitter' },
+    { value: '03', text: 'Vkontakte' },
+    { value: '04', text: 'Facebook' },
+    { value: '05', text: 'Twitter' },
+    { value: '06', text: 'Vkontakte' },
+    { value: '07', text: 'Facebook' },
+    { value: '08', text: 'Twitter' },
+    { value: '09', text: 'Vkontakte' },
+    { value: '10', text: 'Facebook' },
+    { value: '11', text: 'Twitter' },
+    { value: '12', text: 'Vkontakte' },
+    { value: '13', text: 'Facebook' },
+    { value: '14', text: 'Twitter' },
+    { value: '15', text: 'Vkontakte' },
+    { value: '16', text: 'Facebook' },
+    { value: '17', text: 'Twitter' },
+    { value: '18', text: 'Vkontakte' },
+    { value: '19', text: 'Facebook' },
+    { value: '20', text: 'Twitter' },
+    { value: '21', text: 'Vkontakte' },
+    { value: '22', text: 'Facebook' },
+    { value: '23', text: 'Twitter' },
+    { value: '24', text: 'Vkontakte' },
+    { value: '25', text: 'Facebook' },
+    { value: '26', text: 'Twitter' },
+    { value: '27', text: 'Vkontakte' },
+    { value: '28', text: 'Facebook' },
+    { value: '29', text: 'Twitter' },
+    { value: '30', text: 'Vkontakte' },
+    { value: '31', text: 'Facebook' },
+    { value: '32', text: 'Twitter' },
+    { value: '33', text: 'Vkontakte' },
+    { value: '34', text: 'Facebook' },
+    { value: '35', text: 'Twitter' },
+    { value: '36', text: 'Vkontakte' },
+    { value: '37', text: 'Facebook' },
+    { value: '38', text: 'Twitter' },
+    { value: '39', text: 'Vkontakte' },
+    { value: '40', text: 'Facebook' },
+    { value: '41', text: 'Twitter' },
+    { value: '42', text: 'Vkontakte' },
+    { value: '43', text: 'Facebook' },
+    { value: '44', text: 'Twitter' },
+    { value: '45', text: 'Vkontakte' },
+    { value: '46', text: 'Facebook' },
+    { value: '47', text: 'Twitter' },
+    { value: '48', text: 'Vkontakte' },
+    { value: '49', text: 'Facebook' },
+];
+<div>
+    {['s'].map(size => (
+        <div className='row' >
+            <div className='column'>
+                <Select
+                    size={ size }
+                    mode='radio'
+                    options={ options }
+                    mobileMenuMode='popup'
+                />
+            </div>
+            <div className='column'>
+                <Select
+                    size={ size }
+                    mode='radio'
+                    options={ options }
+                    mobileMenuMode='popup'
+                    disabled={ true }
+                />
+            </div>
+        </div>
+    ))}
+</div>
+```

--- a/src/select/select-test.jsx
+++ b/src/select/select-test.jsx
@@ -328,6 +328,18 @@ describe('select', () => {
 
             expect(optGroup).to.have.attr('label', 'Select something');
         });
+
+        it('should render popup when mobileMenuMode = popup', () => {
+            let selectProps = {
+                options: OPTIONS,
+                mobileMenuMode: 'popup',
+                opened: true
+            };
+            let { nativeSelectNode, popupNode } = renderSelect(selectProps);
+
+            expect(nativeSelectNode).to.not.exist;
+            expect(popupNode).to.have.class('popup');
+        });
     } else {
         it('should set popup width equal to button width when equalPopupWidth = true', () => {
             let selectProps = {


### PR DESCRIPTION
## Мотивация и контекст
В приложениях возникает потребность использовать селекты со списками, плохо отображающимися на мобильных устройствах в нативном виде.

Опция mobileMenuMode позволяет отключить рендер нативного контрола, что даёт возможность показать список через popup.