### PR TITLE
feat(select): add header to fullscreen select

### DIFF
--- a/docs/popup/README.md
+++ b/docs/popup/README.md
@@ -27,6 +27,7 @@ import Popup from 'arui-feather/popup';
 | visible | Boolean | `false`  |  | Управление видимостью компонента |
 | autoclosable | Boolean | `false`  |  | Управление возможностью автозакрытия компонента |
 | padded | Boolean | `true`  |  | Управление выставлением модификатора для добавления внутренних отступов в стилях |
+| header | Node |  |  | Элемент закреплённого заголовка для компонента |
 | size | [SizeEnum](#SizeEnum) | `'s'`  |  | Размер компонента |
 | theme | [ThemeEnum](#ThemeEnum) |  |  | Тема компонента |
 | onMouseEnter | Function |  |  | Обработчик события наведения курсора на попап |

--- a/docs/select/README.md
+++ b/docs/select/README.md
@@ -30,7 +30,8 @@ import Select from 'arui-feather/select';
 | placeholder | String | `'Выберите:'`  |  | Подсказка в поле |
 | hint | Node |  |  | Подсказка под полем |
 | error | Node |  |  | Отображение ошибки |
-| mobileMenuMode | [MobileMenuModeEnum](#MobileMenuModeEnum) | `'native'`  |  | Управление нативным режимом на мобильных устройствах * |
+| mobileMenuMode | [MobileMenuModeEnum](#MobileMenuModeEnum) | `'native'`  |  | Управление нативным режимом на мобильных устройствах |
+| mobileTitle | Node |  |  | Подсказка над меню в мобильном режиме |
 | theme | [ThemeEnum](#ThemeEnum) |  |  | Тема компонента |
 | onFocus | Function |  |  | Обработчик фокуса на компоненте |
 | onBlur | Function |  |  | Обработчик потери фокуса компонентом |

--- a/src/popup/README.md
+++ b/src/popup/README.md
@@ -9,6 +9,7 @@ class PopupDemo extends React.Component {
             popup4: false,
             popup5: false,
             popup6: false,
+            popup7: false,
         };
 
         this.popup1;
@@ -17,6 +18,7 @@ class PopupDemo extends React.Component {
         this.popup4;
         this.popup5;
         this.popup6;
+        this.popup7;
 
         this.target1;
         this.target2;
@@ -24,6 +26,7 @@ class PopupDemo extends React.Component {
         this.target4;
         this.target5;
         this.target6;
+        this.target7;
     }
 
     componentDidMount() {
@@ -32,6 +35,7 @@ class PopupDemo extends React.Component {
         this.popup3.setTarget(this.target3.control);
         this.popup4.setTarget(this.target4.control);
         this.popup5.setTarget(this.target5.control);
+        this.popup7.setTarget(this.target7.control);
     }
 
     render() {
@@ -155,6 +159,26 @@ class PopupDemo extends React.Component {
                                 Close
                             </Button>
                         </p>
+                    </Popup>
+                </div>
+                <div className='row'>
+                    <Button
+                        ref={ (target) => { this.target7 = target; } }
+                        size='m'
+                        onClick={ () => { this.setState({ popup7: !this.state.popup7 }); } }
+                    >
+                        Click me
+                    </Button>
+                    <Popup
+                        ref={ (popup) => { this.popup7 = popup; } }
+                        autoclosable={ true }
+                        visible={ this.state.popup7 }
+                        header={
+                            <Heading size='xs'>Popup Header</Heading>
+                        }
+                        onClickOutside={ () => { this.setState({ popup7: false }); } }
+                    >
+                        { 'Popup with header' }
                     </Popup>
                 </div>
             </div>

--- a/src/popup/fantasy/popup.css
+++ b/src/popup/fantasy/popup.css
@@ -23,7 +23,7 @@
         box-sizing: border-box;
     }
 
-    &__inner {
+    &__container {
         position: relative;
         width: 100%;
         height: 100%;
@@ -136,7 +136,9 @@
         border-radius: 0;
         box-shadow: none;
 
-        .popup__inner {
+        .popup__container {
+            display: flex;
+            flex-direction: column;
             border-radius: 0;
         }
     }

--- a/src/popup/fantasy/popup_theme_alfa-on-color.css
+++ b/src/popup/fantasy/popup_theme_alfa-on-color.css
@@ -8,7 +8,7 @@
     color: var(--color-content-alfa-on-color);
     box-shadow: var(--shadow-light);
 
-    .popup__inner {
+    .popup__container {
         background-color: var(--color-background-alfa-on-color);
     }
 

--- a/src/popup/fantasy/popup_theme_alfa-on-white.css
+++ b/src/popup/fantasy/popup_theme_alfa-on-white.css
@@ -8,7 +8,7 @@
     color: var(--color-content-alfa-on-white);
     box-shadow: var(--shadow-light);
 
-    .popup__inner {
+    .popup__container {
         background-color: var(--color-background-alfa-on-white);
     }
 

--- a/src/popup/popup-test.jsx
+++ b/src/popup/popup-test.jsx
@@ -39,6 +39,11 @@ function renderPopup(popupProps, anchorProps) {
         );
     }
 
+    let popupHeaderNode;
+    if (popup) {
+        popupHeaderNode = popup.node.querySelector('.popup__header');
+    }
+
     let popupContentNode;
     if (popup) {
         popupContentNode = popup.node.querySelector('.popup__content');
@@ -48,7 +53,7 @@ function renderPopup(popupProps, anchorProps) {
         popup.instance.setTarget(anchor.node);
     }
 
-    return { popup, anchor, popupContentNode };
+    return { popup, anchor, popupHeaderNode, popupContentNode };
 }
 
 function getPopupDimensions(popupNode, popupContentNode) {
@@ -176,6 +181,18 @@ describe('popup', () => {
             expect(onClickOutside).to.not.have.been.called();
             done();
         }, 0);
+    });
+
+    it('should not render a header element by default', () => {
+        let { popupHeaderNode } = renderPopup({ visible: true }, {});
+
+        expect(popupHeaderNode).to.not.exist;
+    });
+
+    it('should render a header element when header parameter is present', () => {
+        let { popupHeaderNode } = renderPopup({ header: <div />, visible: true }, {});
+
+        expect(popupHeaderNode).to.exist;
     });
 
     describe('popup calculate drawing params', () => {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -131,6 +131,12 @@
         position: fixed;
         border-radius: 0;
         box-shadow: none;
+
+        .popup__container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
     }
 }
 

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -83,6 +83,8 @@ class Popup extends React.Component {
         autoclosable: Type.bool,
         /** Управление выставлением модификатора для добавления внутренних отступов в стилях */
         padded: Type.bool,
+        /** Элемент закреплённого заголовка для компонента */
+        header: Type.node,
         /** Размер компонента */
         size: Type.oneOf(['s', 'm', 'l', 'xl']),
         /** Тема компонента */
@@ -240,21 +242,30 @@ class Popup extends React.Component {
                     onMouseEnter={ this.handleMouseEnter }
                     onMouseLeave={ this.handleMouseLeave }
                 >
-                    <div
-                        ref={ (inner) => { this.inner = inner; } }
-                        className={ cn('inner') }
-                        onScroll={ this.handleInnerScroll }
-                    >
-                        <div className={ cn('content') } ref={ (content) => { this.content = content; } }>
-                            { this.props.children }
-                            <ResizeSensor onResize={ this.handleResize } />
+                    <div className={ cn('container') }>
+                        {
+                            this.props.header && (
+                                <div className={ cn('header') }>
+                                    { this.props.header }
+                                </div>
+                            )
+                        }
+                        <div
+                            ref={ (inner) => { this.inner = inner; } }
+                            className={ cn('inner') }
+                            onScroll={ this.handleInnerScroll }
+                        >
+                            <div className={ cn('content') } ref={ (content) => { this.content = content; } }>
+                                { this.props.children }
+                                <ResizeSensor onResize={ this.handleResize } />
+                            </div>
                         </div>
+                        {
+                            this.state.hasScrollbar && (
+                                <div className={ cn('gradient') } style={ this.state.gradientStyles } />
+                            )
+                        }
                     </div>
-                    {
-                        this.state.hasScrollbar && (
-                            <div className={ cn('gradient') } style={ this.state.gradientStyles } />
-                        )
-                    }
                 </div>
             </RenderInContainer>
         );

--- a/src/select/README.md
+++ b/src/select/README.md
@@ -178,7 +178,7 @@ const options = [
     { value: '49', text: 'Facebook' },
 ];
 <div>
-    {['s'].map(size => (
+    {['s', 'm', 'l', 'xl'].map(size => (
         <div className='row' >
             <div className='column'>
                 <Select
@@ -186,6 +186,7 @@ const options = [
                     mode='radio'
                     options={ options }
                     mobileMenuMode='popup'
+                    mobileTitle='Очень длинный заголовок на мобильном устройстве'
                 />
             </div>
             <div className='column'>

--- a/src/select/fantasy/select.css
+++ b/src/select/fantasy/select.css
@@ -169,6 +169,53 @@
         min-width: 0;
         height: 100%;
     }
+
+    &__mobile-title {
+        font-weight: var(--font-weight-medium);
+        line-height: var(--line-height-normal);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__mobile-closer {
+        position: absolute;
+        right: 6px;
+    }
+
+    &__mobile-header {
+        &_size_s {
+            padding: 6px 25px 6px 10px;
+
+            .select__mobile-closer {
+                top: 6px;
+            }
+        }
+
+        &_size_m {
+            padding: 9px 32px 9px 12px;
+
+            .select__mobile-closer {
+                top: 8px;
+            }
+        }
+
+        &_size_l {
+            padding: 12px 40px 13px 15px;
+
+            .select__mobile-closer {
+                top: 10px;
+            }
+        }
+
+        &_size_xl {
+            padding: 11px 42px 11px 15px;
+
+            .select__mobile-closer {
+                top: 8px;
+            }
+        }
+    }
 }
 
 .select_size_s {

--- a/src/select/select.css
+++ b/src/select/select.css
@@ -183,6 +183,53 @@
         height: 100%;
         border-radius: var(--border-radius-control);
     }
+
+    &__mobile-title {
+        font-weight: var(--font-weight-accent);
+        line-height: var(--line-height-normal);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__mobile-closer {
+        position: absolute;
+        right: 6px;
+    }
+
+    &__mobile-header {
+        &_size_s {
+            padding: 6px 25px 6px 10px;
+
+            .select__mobile-closer {
+                top: 6px;
+            }
+        }
+
+        &_size_m {
+            padding: 9px 32px 9px 12px;
+
+            .select__mobile-closer {
+                top: 8px;
+            }
+        }
+
+        &_size_l {
+            padding: 12px 40px 13px 15px;
+
+            .select__mobile-closer {
+                top: 10px;
+            }
+        }
+
+        &_size_xl {
+            padding: 11px 42px 11px 15px;
+
+            .select__mobile-closer {
+                top: 8px;
+            }
+        }
+    }
 }
 
 .select_invalid {

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -100,8 +100,10 @@ class Select extends React.Component {
         hint: Type.node,
         /** Отображение ошибки */
         error: Type.node,
-        /** Управление нативным режимом на мобильных устройствах **/
+        /** Управление нативным режимом на мобильных устройствах */
         mobileMenuMode: Type.oneOf(['native', 'popup']),
+        /** Подсказка над меню в мобильном режиме */
+        mobileTitle: Type.node,
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Обработчик фокуса на компоненте */
@@ -336,6 +338,7 @@ class Select extends React.Component {
                 padded={ false }
                 size={ this.props.size }
                 target={ this.state.isMobile ? 'screen' : 'anchor' }
+                header={ this.state.isMobile && this.renderMobileHeader(cn) }
                 visible={ opened }
                 onClickOutside={ this.handleClickOutside }
                 minWidth={ this.state.popupStyles.minWidth }
@@ -422,6 +425,21 @@ class Select extends React.Component {
 
         let checkedItemsText = checkedItems.map(item => item.checkedText || item.text).join(', ');
         return checkedItemsText || this.props.placeholder;
+    }
+
+    renderMobileHeader(cn) {
+        return (
+            <div className={ cn('mobile-header', { size: this.props.size }) }>
+                <Icon
+                    className={ cn('mobile-closer') }
+                    size={ this.props.size }
+                    icon='close'
+                />
+                <div className={ cn('mobile-title') }>
+                    { this.props.mobileTitle || this.props.placeholder }
+                </div>
+            </div>
+        );
     }
 
     @autobind


### PR DESCRIPTION
## Мотивация и контекст
В режиме mobileMenuMode='popup' стоит предусмотреть возможность отменить операцию выбора. Вдобавок можем показать пользователю поясняющий заголовок.

![default](https://user-images.githubusercontent.com/2873293/27907068-c155c99e-624e-11e7-8949-96e11353d1e8.png)
