### PR TITLE
fix(autocomplete-key) transfer keys in input-autocomplete and menu

### DIFF
--- a/src/input-autocomplete/input-autocomplete-test.jsx
+++ b/src/input-autocomplete/input-autocomplete-test.jsx
@@ -14,6 +14,16 @@ const OPTIONS = [
     { value: 'Twitter' }
 ];
 
+const OPTIONS2 = [
+    {
+        value: 'Vkontakte'
+    },
+    {
+        value: 'Vkontakte',
+        key: 'vk2'
+    }
+];
+
 function renderInputAutocomplete(props = {}) {
     let inputAutocomplete = render(<InputAutocomplete { ...props } />);
 
@@ -40,6 +50,13 @@ describe('input-autocomplete', () => {
         let { inputAutocomplete } = renderInputAutocomplete();
 
         expect(inputAutocomplete.node).to.exist;
+    });
+
+    it('should render without problem when give item with duplicate value', () => {
+        let { popupNode } = renderInputAutocomplete({ options: OPTIONS2 });
+        let optionsNode = popupNode.querySelectorAll('.menu-item');
+
+        expect(optionsNode.length).is.equal(OPTIONS2.length);
     });
 
     it('should render input and popup with options', () => {

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -426,6 +426,7 @@ class InputAutocomplete extends React.Component {
                 }
 
                 return ({
+                    key: option.key || option.value,
                     value: option.value,
                     content: option.description || option.value
                 });

--- a/src/menu/menu-test.jsx
+++ b/src/menu/menu-test.jsx
@@ -24,6 +24,13 @@ const MENU_ITEM2 = {
     }
 };
 
+const MENU_ITEM2_CLONE = {
+    type: 'item',
+    content: 'MenuItem 2',
+    value: 'value2',
+    key: 'value3'
+};
+
 const MENU_GROUP = {
     type: 'group',
     title: 'Group Title',
@@ -108,6 +115,14 @@ describe('menu', () => {
         let menuItemsNum = getNumberOfItemsWithClass(menuChildsNode, 'menu-item_disabled');
 
         expect(menuItemsNum).to.equal(menuChildsNode.length);
+    });
+
+    it('should render without problem when give item with duplicate value', () => {
+        let content = [MENU_ITEM1, MENU_ITEM2, MENU_ITEM2_CLONE];
+        let menu = render(<Menu content={ content } />);
+        let menuChildNodes = menu.node.querySelectorAll('.menu-item');
+
+        expect(menuChildNodes.length).to.equal(content.length);
     });
 
     it('should call `onItemCheck` callback after menu-item was clicked and if `mode` is identified', () => {

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -199,7 +199,7 @@ class Menu extends React.Component {
             <MenuItem
                 { ...menuItemProps }
                 ref={ (instance) => { menuItem.instance = instance; } }
-                key={ item.value }
+                key={ item.key || item.value }
                 checked={ this.getIndexInCheckedItemsList(item.value) !== -1 }
                 type={ this.props.mode !== 'basic' ? 'block' : itemProps.type }
                 onMouseEnter={ () => this.handleMenuItemMouseEnter(menuItem) }


### PR DESCRIPTION
При передаче одинаковых value в InputAutocomplete ломалось отображение в компоненте Menu: 

> Warning: flattenChildren(...): Encountered two children with the same key, `test`. Child keys must be unique; when two children share a key, only the first child will be used.

Подправил компоненты InputAutocomplete и Menu чтобы могли принимать ещё параметр `key`