### PR TITLE
fix(calendar): keyboard navigation

### DIFF
--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -469,8 +469,14 @@ class CalendarInput extends React.Component {
 
                 this.setState({
                     opened: true,
-                    month: calculateMonth(value)
+                    month: calculateMonth(
+                        value,
+                        CUSTOM_DATE_FORMAT,
+                        this.props.calendar ? this.props.calendar.earlierLimit : undefined,
+                        this.props.calendar ? this.props.calendar.laterLimit : undefined
+                    )
                 });
+
                 this.calendar.focus();
 
                 break;

--- a/src/calendar/calendar-test.jsx
+++ b/src/calendar/calendar-test.jsx
@@ -134,6 +134,21 @@ describe('calendar', () => {
         expect(onMonthChange).to.have.been.calledWith((new Date(2015, 0, 1)).valueOf());
     });
 
+    it('should call `onMonthChange` callback when month was changed by arrow key press', () => {
+        const LAST_DAY_OF_MONTH = startOfDay(new Date('2016-01-31'));
+        let onMonthChange = sinon.spy();
+        let calendar = render(
+            <Calendar
+                value={ LAST_DAY_OF_MONTH.valueOf() }
+                onMonthChange={ onMonthChange }
+            />
+        );
+
+        simulate(calendar.node, 'keyDown', { which: keyboardCode.DOWN_ARROW });
+
+        expect(onMonthChange).to.have.been.calledWith((new Date(2016, 1, 7)).valueOf());
+    });
+
     it('should select date on next week after down arrow key was pressed', () => {
         let onValueChange = sinon.spy();
         let calendar = render(

--- a/src/calendar/calendar.jsx
+++ b/src/calendar/calendar.jsx
@@ -16,6 +16,7 @@ import addDays from 'date-fns/add_days';
 import addYears from 'date-fns/add_years';
 import subtractYears from 'date-fns/sub_years';
 import formatDate from 'date-fns/format';
+import isSameMonth from 'date-fns/is_same_month';
 import sortedIndexOf from 'lodash.sortedindexof';
 
 import cn from '../cn';
@@ -488,7 +489,12 @@ class Calendar extends React.Component {
         if (!this.value) {
             this.performChange(this.state.month, true);
         } else {
-            this.performChange(addDays(value, dayShift).valueOf(), isTriggeredByKeyboard);
+            let shiftedValue = addDays(value, dayShift);
+            this.performChange(shiftedValue.valueOf(), isTriggeredByKeyboard);
+
+            if (this.props.onMonthChange && !isSameMonth(shiftedValue, value)) {
+                this.props.onMonthChange(shiftedValue.valueOf());
+            }
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1803,10 +1803,6 @@ chai-dom@*, chai-dom@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/chai-dom/-/chai-dom-1.5.0.tgz#bc1ca85f8b3f6ac024515e4a9c4c40f6888e2f17"
 
-chai-spies@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/chai-spies/-/chai-spies-0.7.1.tgz#343d99f51244212e8b17e64b93996ff7b2c2a9b1"
-
 chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
@@ -3068,7 +3064,7 @@ di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
 
-diff@3.2.0, diff@^3.2.0:
+diff@3.2.0, diff@^3.1.0, diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -4166,6 +4162,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -5982,6 +5984,12 @@ karma-sauce-launcher@^1.1.0:
     saucelabs "^1.3.0"
     wd "^1.0.0"
 
+karma-sinon-chai@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/karma-sinon-chai/-/karma-sinon-chai-1.3.1.tgz#4633419494d9e2d848787dd76053031859f5b7f5"
+  dependencies:
+    lolex "^1.6.0"
+
 karma-sourcemap-loader@^0.3.7:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz#91322c77f8f13d46fed062b042e1009d4c4505d8"
@@ -6114,9 +6122,9 @@ lexical-scope@^1.2.0:
   dependencies:
     astw "^2.0.0"
 
-library-utils@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/library-utils/-/library-utils-1.4.2.tgz#95e9e147ac8809a1be9850db6bf55018d844d0dc"
+library-utils@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/library-utils/-/library-utils-1.5.0.tgz#a6860aba6c4337188d228eac7f747da89a288931"
   dependencies:
     del "^2.2.2"
     ejs "^2.5.6"
@@ -6572,6 +6580,10 @@ logalot@^2.0.0:
     figures "^1.3.5"
     squeak "^1.0.0"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
 longest-streak@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.1.tgz#42d291b5411e40365c00e63193497e2247316e35"
@@ -6965,6 +6977,10 @@ mute-stream@0.0.5:
 nan@^2.0.0, nan@^2.0.4, nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natives@^1.1.0:
   version "1.1.0"
@@ -7570,6 +7586,12 @@ path-root@^0.1.1:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -9174,6 +9196,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
 sane@^1.3.3:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.7.0.tgz#b3579bccb45c94cf20355cc81124990dfd346e30"
@@ -9356,6 +9382,23 @@ sigmund@^1.0.1, sigmund@~1.0.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon-chai@^2.11.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.12.0.tgz#da71e9642ef7b893ba3cf2af806396a00aa45927"
+
+sinon@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.8.tgz#31de06fed8fba3a671e576dd96d0a5863796f25c"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 sizzle@^2.2.0:
   version "2.3.3"
@@ -10065,6 +10108,10 @@ test-value@^2.1.0:
     array-back "^1.0.3"
     typical "^2.6.0"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-extensions@^1.0.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.5.0.tgz#d1cb2d14b5d0bc45bfdca8a08a473f68c7eb0cbc"
@@ -10323,7 +10370,7 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-type-detect@^4.0.3:
+type-detect@^4.0.0, type-detect@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 


### PR DESCRIPTION
Починил навигацию в календаре с клавиатуры

## Мотивация и контекст
Были следующие проблемы:
1. Не работала стрелочка вниз на календарь-инпуте
2. Не стрелял колбек onMonthChange, если месяц менялся клавиатурными стрелочками
