### PR TITLE
fix(label): fix label colors

### DIFF
--- a/src/checkbox-group/checkbox-group_theme-alfa-on-white.css
+++ b/src/checkbox-group/checkbox-group_theme-alfa-on-white.css
@@ -5,7 +5,7 @@
 @import '../vars.css';
 
 .checkbox-group_theme_alfa-on-white {
-    .checkbox-group__label {
+    .label {
         color: var(--color-content-alfa-on-white);
     }
 }

--- a/src/checkbox-group/checkbox-group_theme_alfa-on-color.css
+++ b/src/checkbox-group/checkbox-group_theme_alfa-on-color.css
@@ -5,7 +5,7 @@
 @import '../vars.css';
 
 .checkbox-group_theme_alfa-on-color {
-    .checkbox-group__label {
+    .label {
         color: var(--color-content-alfa-on-color);
     }
 }

--- a/src/checkbox-group/fantasy/checkbox-group_theme-alfa-on-white.css
+++ b/src/checkbox-group/fantasy/checkbox-group_theme-alfa-on-white.css
@@ -5,7 +5,7 @@
 @import '../../vars-fantasy.css';
 
 .checkbox-group_theme_alfa-on-white {
-    .checkbox-group__label {
+    .label {
         color: var(--color-content-minor-alfa-on-white);
     }
 }

--- a/src/checkbox-group/fantasy/checkbox-group_theme_alfa-on-color.css
+++ b/src/checkbox-group/fantasy/checkbox-group_theme_alfa-on-color.css
@@ -5,7 +5,7 @@
 @import '../../vars-fantasy.css';
 
 .checkbox-group_theme_alfa-on-color {
-    .checkbox-group__label {
+    .label {
         color: var(--color-content-minor-alfa-on-color);
     }
 }

--- a/src/label/fantasy/label.css
+++ b/src/label/fantasy/label.css
@@ -42,7 +42,7 @@
 }
 
 .label_theme_alfa-on-color {
-    color: var(--color-content-minor-alfa-on-color);
+    color: var(--color-content-alfa-on-color);
 
     &.label_disabled {
         color: var(--color-content-minor-alfa-on-color);
@@ -50,7 +50,7 @@
 }
 
 .label_theme_alfa-on-white {
-    color: var(--color-content-minor-alfa-on-white);
+    color: var(--color-content-alfa-on-white);
 
     &.label_disabled {
         color: var(--color-content-minor-alfa-on-white);

--- a/src/radio-group/fantasy/radio-group_theme_alfa-on-color.css
+++ b/src/radio-group/fantasy/radio-group_theme_alfa-on-color.css
@@ -5,7 +5,7 @@
 @import '../../vars-fantasy.css';
 
 .radio-group_theme_alfa-on-color {
-    .radio-group__label {
+    .label {
         color: var(--color-content-minor-alfa-on-color);
     }
 }

--- a/src/radio-group/fantasy/radio-group_theme_alfa-on-white.css
+++ b/src/radio-group/fantasy/radio-group_theme_alfa-on-white.css
@@ -5,7 +5,7 @@
 @import '../../vars-fantasy.css';
 
 .radio-group_theme_alfa-on-white {
-    .radio-group__label {
+    .label {
         color: var(--color-content-minor-alfa-on-white);
     }
 }

--- a/src/radio-group/radio-group_theme_alfa-on-color.css
+++ b/src/radio-group/radio-group_theme_alfa-on-color.css
@@ -5,7 +5,7 @@
 @import '../vars.css';
 
 .radio-group_theme_alfa-on-color {
-    .radio-group__label {
+    .label {
         color: var(--color-content-alfa-on-color);
     }
 }

--- a/src/radio-group/radio-group_theme_alfa-on-white.css
+++ b/src/radio-group/radio-group_theme_alfa-on-white.css
@@ -5,7 +5,7 @@
 @import '../vars.css';
 
 .radio-group_theme_alfa-on-white {
-    .radio-group__label {
+    .label {
         color: var(--color-content-alfa-on-white);
     }
 }


### PR DESCRIPTION
<!--- Название для изменений -->
Возвращен цвет лейблов

## Мотивация и контекст
При переводе CheckboxGroup и RadioGroup в fantasy style был ошибочно переопределен цвет Label на минорный. Необходимо в Label вернуть правильный цвет, а для заголовков CheckboxGroup и RadioGroup установить минорный цвет непосредственно в этих компонентах.