### PR TITLE
feat(*): custom text onChange when item selected

### DIFF
--- a/docs/input-autocomplete/README.md
+++ b/docs/input-autocomplete/README.md
@@ -20,6 +20,7 @@ import InputAutocomplete from 'arui-feather/input-autocomplete';
 | size | [SizeEnum](#SizeEnum) | `'m'`  |  | Размер компонента |
 | width | [WidthEnum](#WidthEnum) | `'default'`  |  | Управление возможностью компонента занимать всю ширину родителя |
 | equalPopupWidth | Boolean | `false`  |  | Ширинa выпадающего списка равна ширине инпута |
+| updateValueOnItemSelect | Boolean | `true`  |  | Определяет нужно или нет обновлять значение текстового поля при выборе варианта |
 | directions | Array.<[DirectionsEnum](#DirectionsEnum)> | `['bottom-left', 'bottom-right', 'top-left', 'top-right']`  |  | Направления, в которые может открываться попап компонента |
 | onItemSelect | Function |  |  | Обработчик выбора пункта в выпадающем меню |
 
@@ -50,6 +51,7 @@ import InputAutocomplete from 'arui-feather/input-autocomplete';
 | type | [TypeEnum](#TypeEnum) | Тип списка вариантов |
 | value | String | Уникальное значение, которое будет отправлено на сервер, если вариант выбран |
 | description | Node | Отображение варианта |
+| text | String | Текст, который должен быть записан в текстовое поле при выборе варианта |
 | content | Array | Список вариантов, только для type='group' |
 
 

--- a/src/input-autocomplete/input-autocomplete-test.jsx
+++ b/src/input-autocomplete/input-autocomplete-test.jsx
@@ -181,6 +181,31 @@ describe('input-autocomplete', () => {
         expect(onChange).to.have.been.calledWith('Vkontakte');
     });
 
+    it('should call `onChange` callback after option was clicked and pass `text` when `option.text` is exist', () => {
+        let onChange = sinon.spy();
+        const OPTIONS = [
+            { value: 'Vkontakte', text: 'Вконтакте' },
+            { value: 'Facebook', text: 'Фейсбук' },
+            { value: 'Twitter', text: 'Твиттер' }
+        ];
+        let { popupNode } = renderInputAutocomplete({ onChange, options: OPTIONS });
+        let firstOptionNode = popupNode.querySelector('.menu-item');
+
+        firstOptionNode.click();
+
+        expect(onChange).to.have.been.calledWith('Вконтакте');
+    });
+
+    it('should not call `onChange` callback after option was clicked when updateValueOnItemSelect = false', () => {
+        let onChange = sinon.spy();
+        let { popupNode } = renderInputAutocomplete({ onChange, updateValueOnItemSelect: false, options: OPTIONS });
+        let firstOptionNode = popupNode.querySelector('.menu-item');
+
+        firstOptionNode.click();
+
+        expect(onChange).to.not.have.been.called;
+    });
+
     it('should call `onKeyDown` callback after key down in input', () => {
         let onKeyDown = sinon.spy();
         let { controlNode } = renderInputAutocomplete({ onKeyDown });

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -37,6 +37,8 @@ class InputAutocomplete extends React.Component {
             value: Type.string,
             /** Отображение варианта */
             description: Type.node,
+            /** Текст, который должен быть записан в текстовое поле при выборе варианта */
+            text: Type.string,
             /** Список вариантов, только для type='group' */
             content: Type.array
         })),
@@ -50,6 +52,8 @@ class InputAutocomplete extends React.Component {
         width: Type.oneOf(['default', 'available']),
         /** Ширинa выпадающего списка равна ширине инпута */
         equalPopupWidth: Type.bool,
+        /** Определяет нужно или нет обновлять значение текстового поля при выборе варианта */
+        updateValueOnItemSelect: Type.bool,
         /** Направления, в которые может открываться попап компонента */
         directions: Type.arrayOf(Type.oneOf([
             'top-left', 'top-center', 'top-right', 'left-top', 'left-center', 'left-bottom', 'right-top',
@@ -64,6 +68,7 @@ class InputAutocomplete extends React.Component {
         size: 'm',
         width: 'default',
         options: [],
+        updateValueOnItemSelect: true,
         directions: ['bottom-left', 'bottom-right', 'top-left', 'top-right'],
         equalPopupWidth: false
     };
@@ -211,16 +216,20 @@ class InputAutocomplete extends React.Component {
         let checkedItemValue = checkedItemsValues.length ? checkedItemsValues[0] : this.state.checkedItemValue;
         let checkedItem = this.getCheckedOption(this.props.options, checkedItemValue);
 
-        let newValue = checkedItem ? checkedItem.value : this.state.value;
-
-        this.setState({ value: newValue });
+        let newValue = checkedItem
+            ? (checkedItem.text || checkedItem.value)
+            : this.state.value;
 
         if (this.props.onItemSelect) {
             this.props.onItemSelect(checkedItem);
         }
 
-        if (this.props.onChange) {
-            this.props.onChange(newValue);
+        if (this.props.updateValueOnItemSelect) {
+            this.setState({ value: newValue });
+
+            if (this.props.onChange) {
+                this.props.onChange(newValue);
+            }
         }
 
         if (this.inputFocusTimeout) {


### PR DESCRIPTION
Параметр, для регулирования вызывать ли обновление значения текстового поля при выборе варианта

Текст для подстановки в текстовое поле при выборе варианта

## Мотивация и контекст

проблему иллюстрирует пример:
начинаем вводить `vko` видим вариант в выпадающем списке, кликаем на него и в инпут подставляется `2`
несколько неожиданно

https://alfa-laboratory.github.io/arui-feather/styleguide/#playground/code=const%20socialNetworks%20=%20%5B%0A%20%20%20%20%7B%20value:%201,%20description:%20'%D0%B2%D0%B0%D1%80%D0%B8%D0%B0%D0%BD%D1%82%20facebook',%20text:%20'facebook'%20%20%7D,%0A%20%20%20%20%7B%20value:%202,%20description:%20'%D0%B2%D0%B0%D1%80%D0%B8%D0%B0%D0%BD%D1%82%20vkontact',%20text:%20'vkontact'%20%20%7D,%0A%20%5D;%0Afunction%20getFilteredOptions(list,%20typedValue)%20%7B%0A%20%20%20%20if%20(!typedValue)%20%7B%0A%20%20%20%20%20%20%20%20return%20list;%0A%20%20%20%20%7D%0A%20%20%20%20return%20list.filter((%7B%20text%20%7D)%20=%3E%20text%20!==%20typedValue%20&&%20text.indexOf(typedValue)%20!==%20-1);%0A%7D%0Afunction%20handleItemSelect(item)%20%7B%0A%20%20%20%20setState(%7B%20value:%20item.text%20%7D)%0A%7D%0Afunction%20handleChange(value)%20%7B%0A%20%20%20%20setState(%7B%20value%20%7D);%0A%7D%0A%3Cdiv%20style=%7B%20%7B%20width:%20'300px'%20%7D%20%7D%3E%0A%20%20%20%20%3CInputAutocomplete%0A%20%20%20%20%20%20%20%20size='m'%0A%20%20%20%20%20%20%20%20width='available'%0A%20%20%20%20%20%20%20%20value=%7B%20state.value%20%7D%0A%20%20%20%20%20%20%20%20onChange=%7B%20handleChange%20%7D%0A%20%20%20%20%20%20%20%20onItemSelect=%7B%20handleItemSelect%20%7D%0A%20%20%20%20%20%20%20%20placeholder='%D0%92%D0%B2%D0%B5%D0%B4%D0%B8%D1%82%D0%B5%20%D0%BD%D0%B0%D0%B7%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5%20%D1%81%D0%BE%D1%86%D0%B8%D0%B0%D0%BB%D1%8C%D0%BD%D0%BE%D0%B9%20%D1%81%D0%B5%D1%82%D0%B8'%0A%20%20%20%20%20%20%20%20options=%7B%20getFilteredOptions(socialNetworks,%20state.value)%20%7D%0A%20%20%20%20/%3E%0A%3C/div%3E
