### PR TITLE
chore(styleguide): remove scalability for mobile

### DIFF
--- a/arui-demo/template.html
+++ b/arui-demo/template.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title><%=htmlWebpackPlugin.options.title%></title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	</head>
+	<body>
+		<div id="app"></div>
+	</body>
+</html>

--- a/styleguide-fantasy.config.js
+++ b/styleguide-fantasy.config.js
@@ -39,6 +39,7 @@ module.exports = {
     },
     ignore: ['**/*-test.jsx'],
     styleguideDir: path.resolve(__dirname, './arui-demo/styleguide-fantasy/'),
+    template: path.resolve(__dirname, './arui-demo/template.html'),
     webpackConfig: merge.smart(ARUI_TEMPLATE, {
         resolve: {
             alias: {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -71,6 +71,7 @@ module.exports = {
     },
     ignore: ['**/*-test.jsx'],
     styleguideDir: path.resolve(__dirname, './arui-demo/styleguide/'),
+    template: path.resolve(__dirname, './arui-demo/template.html'),
     webpackConfig: merge.smart(ARUI_TEMPLATE, {
         resolve: {
             alias: {


### PR DESCRIPTION
Кастомный шаблон для стайлгайда с user-scalable=no, чтобы избежать некоторых багов на мобильных устройствах.