### PR TITLE
fix(calendar-input): fix clickable disabled calendar-input in mobile popup mode

### DIFF
--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -212,7 +212,7 @@ class CalendarInput extends React.Component {
             noValidate: true
         };
 
-        let wrapperProps = this.isMobilePopup()
+        let wrapperProps = this.isMobilePopup() && !this.props.disabled
             ? {
                 role: 'button',
                 tabIndex: 0,


### PR DESCRIPTION
Исправлен баг, позволявший тапнуть дизейбленный контрол.
