### PR TITLE
fix(link): set hover/focus styles with css instead of js

### DIFF
--- a/src/link/fantasy/link.css
+++ b/src/link/fantasy/link.css
@@ -76,8 +76,8 @@
         border-color: rgba(255, 255, 255, .4);
     }
 
-    &.link_hovered,
-    &.link_focused {
+    &:hover,
+    &:focus {
         color: var(--color-content-accent-alfa-on-color);
 
         .link__text {
@@ -97,8 +97,8 @@
         border-color: rgba(0, 0, 0, .4);
     }
 
-    &.link_hovered,
-    &.link_focused {
+    &:hover,
+    &:focus {
         color: var(--color-content-accent-alfa-on-white);
 
         .link__text {

--- a/src/link/link.css
+++ b/src/link/link.css
@@ -77,8 +77,8 @@
         border-color: rgba(255, 255, 255, .4);
     }
 
-    &.link_hovered,
-    &.link_focused {
+    &:hover:not(.link_disabled),
+    &:focus:not(.link_disabled) {
         color: var(--color-content-accent-alfa-on-color);
 
         .link__text {
@@ -103,8 +103,8 @@
         border-color: rgba(0, 0, 0, .4);
     }
 
-    &.link_hovered,
-    &.link_focused {
+    &:hover:not(.link_disabled),
+    &:focus:not(.link_disabled) {
         color: var(--color-content-heavy-accent-alfa-on-white);
 
         .link__text {

--- a/src/tab-item/fantasy/tab-item.css
+++ b/src/tab-item/fantasy/tab-item.css
@@ -65,8 +65,8 @@
 .tab-item_theme_alfa-on-color {
     color: var(--color-content-minor-alfa-on-color);
 
-    &.tab-item_hovered,
-    &.tab-item_focused {
+    &:hover:not(.tab-item_disabled),
+    &:focus:not(.tab-item_disabled) {
         color: var(--color-content-alfa-on-color);
     }
 
@@ -87,8 +87,8 @@
 .tab-item_theme_alfa-on-white {
     color: var(--color-content-minor-alfa-on-white);
 
-    &.tab-item_hovered,
-    &.tab-item_focused {
+    &:hover:not(.tab-item_disabled),
+    &:focus:not(.tab-item_disabled) {
         color: var(--color-content-alfa-on-white);
     }
 

--- a/src/tab-item/fantasy/tab-item.jsx
+++ b/src/tab-item/fantasy/tab-item.jsx
@@ -15,6 +15,7 @@ export default class TabItem extends Link {
         size: 'l',
         disabled: false,
         checked: false,
-        pseudo: false
+        pseudo: false,
+        tabIndex: 0
     };
 }


### PR DESCRIPTION
Навешиваем стили на link для hover/focus состояние через js.

## Мотивация и контекст
Состояние focused не всегда пропадает с элемента, даже когда он его вроде как теряет. С css такой проблемы нет. Навешивание классов пока оставил, на случай если кто-то завязался на него в своих проектах