### PR TITLE
fix(*): fix repeated click on the same radio after value in radio group was reseted

### DIFF
--- a/src/radio-group/radio-group-test.jsx
+++ b/src/radio-group/radio-group-test.jsx
@@ -175,7 +175,7 @@ describe('radio-group', () => {
         expect(radioGroupNode).to.have.valueOf('2');
     });
 
-    it('shouldn\'t call `onChange` twice when press to the same radio twice', function () {
+    it('shouldn\'t call `onChange` when radio group value and radio value are same', function () {
         const onChange = sinon.spy();
         const radioGroupNode = render(
             <RadioGroup value='1' onChange={ onChange }>
@@ -184,12 +184,11 @@ describe('radio-group', () => {
             </RadioGroup>
         ).node;
         const radios = radioGroupNode.querySelectorAll('input[type="radio"]');
-        const secondRadioControlNode = radios[1];
+        const secondRadioControlNode = radios[0];
 
         simulate(secondRadioControlNode, 'change');
-        simulate(secondRadioControlNode, 'change');
 
-        expect(onChange).to.have.been.calledOnce;
+        expect(onChange).not.to.have.been.called;
     });
 
     it('should disable all child radios when disabled=true', () => {

--- a/src/radio-group/radio-group.jsx
+++ b/src/radio-group/radio-group.jsx
@@ -126,10 +126,10 @@ class RadioGroup extends React.Component {
     handleRadioChange(value) {
         if (this.state.value !== value) {
             this.setState({ value });
+        }
 
-            if (this.props.onChange) {
-                this.props.onChange(value);
-            }
+        if (this.props.value !== value && this.props.onChange) {
+            this.props.onChange(value);
         }
     }
 


### PR DESCRIPTION
Фикс вызова хендлера onChange когда value у RadioGroup меняется извне через props

## Мотивация и контекст
Проблема:
Выберем один из радио в радио группе, сбросим value в радио группе, повторно выбрать предыдущий радио - нельзя, только какой-нибудь другой

[пример](https://alfa-laboratory.github.io/arui-feather/styleguide/#playground/code=const%20radios%20=%20%5B%7B%0A%20%20text:%20'one',%0A%20%20value:%201%0A%7D,%20%7B%0A%20%20text:%20'two',%0A%20%20value:%202%0A%7D,%20%7B%0A%20%20text:%20'three',%0A%20%20value:%203%0A%7D,%20%7B%0A%20%20text:%20'four',%0A%20%20value:%204%0A%7D%5D;%0A%0AinitialState%20=%20%7B%0A%20%20%20%20radioGroupValue:%20null%0A%7D;%0A%0A%3Cdiv%3E%0A%20%20%3CRadioGroup%0A%20%20%20%20type='button'%0A%20%20%20%20value=%7B%20state.radioGroupValue%20%7D%0A%20%20%20%20onChange=%7B%20(value)%20=%3E%20%7B%20setState(%7B%20...state,%20radioGroupValue:%20value%20%20%7D)%20%7D%20%20%7D%0A%20%20%3E%0A%20%20%20%20%20%20%7Bradios.map(radio%20=%3E%20(%0A%20%20%20%20%20%20%20%20%20%20%3CRadio%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20text=%7B%20radio.text%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20key=%7B%20radio.value%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20value=%7B%20radio.value%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20type='button'%0A%20%20%20%20%20%20%20%20%20%20/%3E%0A%20%20%20%20%20%20))%7D%0A%20%20%3C/RadioGroup%3E%0A%20%20%3Cdiv%20style=%7B%20%7B%20marginTop:%2010%20%7D%20%7D%3E%0A%20%20%09%09%09%20%20%20%3CButton%20onClick=%7B%20()%20=%3E%20%7B%20setState(%7B%20...state,%20radioGroupValue:%20null%20%7D)%20%7D%20%20%7D%3ERESET%20RADIO%20GROUP%3C/Button%3E%0A%20%20%3C/div%3E%0A%3C/div%3E)