### PR TITLE
Fix/fantasy components naming

### DIFF
--- a/src/checkbox/fantasy/checkbox.js
+++ b/src/checkbox/fantasy/checkbox.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Checkbox from '../checkbox';
+import OriginalCheckBox from '../checkbox';
 import TagButton from '../../tag-button/fantasy/tag-button';
 
 import cn from '../../cn';
@@ -10,9 +10,9 @@ import cn from '../../cn';
 /**
  * Компонент чекбокса в обновлённом дизайне.
  *
- * @extends Radio
+ * @extends CheckBox
  */
 @cn('checkbox', TagButton)
-class FantasyCheckbox extends Checkbox {}
+class CheckBox extends OriginalCheckBox {}
 
-export default FantasyCheckbox;
+export default CheckBox;

--- a/src/radio/fantasy/radio.jsx
+++ b/src/radio/fantasy/radio.jsx
@@ -10,7 +10,7 @@ import cn from '../../cn';
 /**
  * Компонент радио-кнопки в обновлённом дизайне.
  *
- * @extends OriginalRadio
+ * @extends Radio
  */
 @cn('radio', TagButton)
 class Radio extends OriginalRadio {}

--- a/src/radio/fantasy/radio.jsx
+++ b/src/radio/fantasy/radio.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Radio from '../radio';
+import OriginalRadio from '../radio';
 import TagButton from '../../tag-button/fantasy/tag-button';
 
 import cn from '../../cn';
@@ -10,9 +10,9 @@ import cn from '../../cn';
 /**
  * Компонент радио-кнопки в обновлённом дизайне.
  *
- * @extends Radio
+ * @extends OriginalRadio
  */
 @cn('radio', TagButton)
-class FantasyRadio extends Radio {}
+class Radio extends OriginalRadio {}
 
-export default FantasyRadio;
+export default Radio;


### PR DESCRIPTION
Переименовал фентези версии компонентов

## Мотивация и контекст
Из-за других имен фентези версий компонентов разваливалось фентези демо, так как там имя компонентов определяется по имени класса.
