### PR TITLE
fix(input): fix invalid input label styles

### DIFF
--- a/src/input/fantasy/input.css
+++ b/src/input/fantasy/input.css
@@ -253,7 +253,6 @@
         line-height: 30px;
     }
 
-    &.input_invalid,
     &.input_focused,
     &.input_has-value {
         .input__top {
@@ -300,7 +299,6 @@
         line-height: 40px;
     }
 
-    &.input_invalid,
     &.input_focused,
     &.input_has-value {
         .input__top {
@@ -358,7 +356,6 @@
         line-height: 50px;
     }
 
-    &.input_invalid,
     &.input_focused,
     &.input_has-value {
         .input__top {
@@ -405,7 +402,6 @@
         line-height: 60px;
     }
 
-    &.input_invalid,
     &.input_focused,
     &.input_has-value {
         .input__top {

--- a/src/input/fantasy/input_theme_alfa-on-color.css
+++ b/src/input/fantasy/input_theme_alfa-on-color.css
@@ -72,7 +72,6 @@
     }
 
     &.input_invalid {
-        .input__top,
         .input__sub {
             color: var(--color-error);
         }
@@ -82,6 +81,10 @@
         }
 
         &.input_focused {
+            .input__top {
+                color: var(--color-error);
+            }
+
             .input__box {
                 border-bottom-color: var(--color-error-translucent);
                 box-shadow: inset 0 -1px 0 var(--color-error-translucent);

--- a/src/input/fantasy/input_theme_alfa-on-white.css
+++ b/src/input/fantasy/input_theme_alfa-on-white.css
@@ -72,7 +72,6 @@
     }
 
     &.input_invalid {
-        .input__top,
         .input__sub {
             color: var(--color-error);
         }
@@ -82,6 +81,10 @@
         }
 
         &.input_focused {
+            .input__top {
+                color: var(--color-error);
+            }
+
             .input__box {
                 border-bottom-color: var(--color-error-translucent);
                 box-shadow: inset 0 -1px 0 var(--color-error-translucent);

--- a/src/textarea/fantasy/textarea.css
+++ b/src/textarea/fantasy/textarea.css
@@ -154,7 +154,6 @@
             font-size: var(--font-size-xs);
         }
 
-        &.textarea_invalid,
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {
@@ -186,7 +185,6 @@
             font-size: var(--font-size-s);
         }
 
-        &.textarea_invalid,
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {
@@ -218,7 +216,6 @@
             font-size: var(--font-size-m);
         }
 
-        &.textarea_invalid,
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {
@@ -250,7 +247,6 @@
             font-size: var(--font-size-l);
         }
 
-        &.textarea_invalid,
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {

--- a/src/textarea/fantasy/textarea_theme_alfa-on-color.css
+++ b/src/textarea/fantasy/textarea_theme_alfa-on-color.css
@@ -43,7 +43,6 @@
     }
 
     &.textarea_invalid {
-        .textarea__top,
         .textarea__sub {
             color: var(--color-error);
         }
@@ -53,6 +52,10 @@
         }
 
         &.textarea_focused {
+            .textarea__top {
+                color: var(--color-error);
+            }
+
             .textarea__control {
                 border-bottom-color: var(--color-error-translucent);
                 box-shadow: inset 0 -1px 0 var(--color-error-translucent);

--- a/src/textarea/fantasy/textarea_theme_alfa-on-white.css
+++ b/src/textarea/fantasy/textarea_theme_alfa-on-white.css
@@ -43,7 +43,6 @@
     }
 
     &.textarea_invalid {
-        .textarea__top,
         .textarea__sub {
             color: var(--color-error);
         }
@@ -53,6 +52,10 @@
         }
 
         &.textarea_focused {
+            .textarea__top {
+                color: var(--color-error);
+            }
+
             .textarea__control {
                 border-bottom-color: var(--color-error-translucent);
                 box-shadow: inset 0 -1px 0 var(--color-error-translucent);


### PR DESCRIPTION
Поправил стили для лейблов внутри невалидных инпутов

## Мотивация и контекст
Инпуты с ошибкой бессмысленно выкидывали наверх свои лейблы. Это и поправил.

Было:
<img width="493" alt="screen shot 2017-08-08 at 17 23 57" src="https://user-images.githubusercontent.com/2974415/29076545-8317db52-7c5e-11e7-888c-fdead72a328e.png">

Стало:
<img width="500" alt="screen shot 2017-08-08 at 17 24 31" src="https://user-images.githubusercontent.com/2974415/29076566-8d52843c-7c5e-11e7-999d-fd9386e806e3.png">


