### PR TITLE
fix(input-autocomplete): turn off autocomplete

### DIFF
--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -143,6 +143,7 @@ class InputAutocomplete extends React.Component {
                 focused: this.state.inputFocused || this.state.menuFocused,
                 'has-autocomplete': true
             }),
+            autocomplete: false,
             value,
             onChange: this.handleChange,
             onFocus: this.handleInputFocus,


### PR DESCRIPTION
Запрет браузерного автокомплита для `InputAutocomplete`.