### PR TITLE
fix(input): label styles for disabled input

### DIFF
--- a/src/input/fantasy/input.css
+++ b/src/input/fantasy/input.css
@@ -228,7 +228,7 @@
         display: none;
     }
 
-    .input__control {
+    .input_has-value {
         &::placeholder {
             opacity: var(--opacity-minor);
         }


### PR DESCRIPTION
Починил стили для дизейбленного инпута без текста, но с лейблом и плейсхолдером.

## Мотивация и контекст
Было:
<img width="399" alt="screen shot 2017-08-17 at 13 59 36" src="https://user-images.githubusercontent.com/2974415/29409332-5db09924-8354-11e7-85be-cec90a463f25.png">

