### PR TITLE
feat(*): add `checked` className for radio Select

### DIFF
--- a/src/select/select-test.jsx
+++ b/src/select/select-test.jsx
@@ -304,6 +304,29 @@ describe('select', () => {
         }, 0);
     });
 
+    it('should set `checked` class when item is selected', () => {
+        let checkedOption = OPTIONS[0];
+        let selectProps = {
+            options: OPTIONS,
+            value: [checkedOption.value]
+        };
+        let { select } = renderSelect(selectProps);
+
+        expect(select.node).to.have.class('select_checked');
+    });
+
+    it('should set `checked` class when item is selected and select type is `radio`', () => {
+        let checkedOption = OPTIONS[0];
+        let selectProps = {
+            mode: 'radio',
+            options: OPTIONS,
+            value: [checkedOption.value]
+        };
+        let { select } = renderSelect(selectProps);
+
+        expect(select.node).to.have.class('select_checked');
+    });
+
     if (bowser.mobile) {
         it('should render default placeholder text', () => {
             let selectProps = { options: OPTIONS };

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -211,7 +211,7 @@ class Select extends React.Component {
                     size: this.props.size,
                     width: this.props.width,
                     disabled: this.props.disabled,
-                    checked: this.props.mode !== 'radio' && value.length > 0,
+                    checked: value.length > 0,
                     focused: this.getFocused(),
                     'has-label': !!this.props.label,
                     'has-value': !!value,


### PR DESCRIPTION
Сейчас в компоненте Select с типом `radio` не добавляется класс `checked` в случае выбора