### PR TITLE
feat(*): add `hint` prop for radio-group

### DIFF
--- a/src/radio-group/README.md
+++ b/src/radio-group/README.md
@@ -38,6 +38,20 @@
 </RadioGroup>
 ```
 
+Горизонтальная группа радио кнопок с подсказкой
+```jsx
+<RadioGroup type='button' hint='Уточняющий текст'>
+    {['Один', 'Два', 'Три', 'Четыре'].map(text => (
+        <Radio
+            text={ text }
+            key={ text }
+            value={ text }
+            type='button'
+        />
+    ))}
+</RadioGroup>
+```
+
 Горизонтальная группа радио кнопок со 100% шириной
 ```jsx
 <RadioGroup width='available' type='button'>

--- a/src/radio-group/fantasy/radio-group.css
+++ b/src/radio-group/fantasy/radio-group.css
@@ -38,17 +38,16 @@
     color: var(--color-content-minor-alfa-on-white);
 }
 
+.radio-group__sub {
+    display: table-caption;
+    caption-side: bottom;
+    padding-top: 5px;
+    font-size: var(--font-size-s);
+}
+
 .radio-group_invalid {
     padding-left: 10px;
     border-left: 1px solid var(--color-error-translucent);
-
-    .radio-group__sub {
-        display: table-caption;
-        caption-side: bottom;
-        padding-top: 5px;
-        color: var(--color-error);
-        font-size: var(--font-size-s);
-    }
 
     &.radio-group_type_normal .radio-group__sub {
         padding-top: 0;

--- a/src/radio-group/fantasy/radio-group_theme_alfa-on-color.css
+++ b/src/radio-group/fantasy/radio-group_theme_alfa-on-color.css
@@ -5,7 +5,13 @@
 @import '../../vars-fantasy.css';
 
 .radio-group_theme_alfa-on-color {
-    .label {
+    .label, .radio-group__sub {
         color: var(--color-content-minor-alfa-on-color);
+    }
+
+    &.radio-group_invalid {
+        .radio-group__sub {
+            color: var(--color-error);
+        }
     }
 }

--- a/src/radio-group/fantasy/radio-group_theme_alfa-on-white.css
+++ b/src/radio-group/fantasy/radio-group_theme_alfa-on-white.css
@@ -5,7 +5,13 @@
 @import '../../vars-fantasy.css';
 
 .radio-group_theme_alfa-on-white {
-    .label {
+    .label, .radio-group__sub {
         color: var(--color-content-minor-alfa-on-white);
+    }
+
+    &.radio-group_invalid {
+        .radio-group__sub {
+            color: var(--color-error);
+        }
     }
 }

--- a/src/radio-group/radio-group-test.jsx
+++ b/src/radio-group/radio-group-test.jsx
@@ -64,6 +64,42 @@ describe('radio-group', () => {
         expect(radioNode).to.have.class('radio_invalid');
     });
 
+    it('should render with `error` from props', () => {
+        let radioGroup = render(
+            <RadioGroup error='errorText'>
+                <Radio key='1' />
+            </RadioGroup>
+        );
+        let subNode = radioGroup.node.querySelector('.radio-group__sub');
+
+        expect(subNode).to.exist;
+        expect(subNode).to.have.text('errorText');
+    });
+
+    it('should render with `hint` from props', () => {
+        let radioGroup = render(
+            <RadioGroup hint='hintText'>
+                <Radio key='1' />
+            </RadioGroup>
+        );
+        let subNode = radioGroup.node.querySelector('.radio-group__sub');
+
+        expect(subNode).to.exist;
+        expect(subNode).to.have.text('hintText');
+    });
+
+    it('should render with `error` and without `hint` when both of them passed via props', () => {
+        let radioGroup = render(
+            <RadioGroup error='errorText' hint='hintText'>
+                <Radio key='1' />
+            </RadioGroup>
+        );
+        let subNode = radioGroup.node.querySelector('.radio-group__sub');
+
+        expect(subNode).to.exist;
+        expect(subNode).to.have.text('errorText');
+    });
+
     it('should focus first child radio-button on public focus method', (done) => {
         let radioGroup = render(
             <RadioGroup>

--- a/src/radio-group/radio-group.jsx
+++ b/src/radio-group/radio-group.jsx
@@ -37,6 +37,8 @@ class RadioGroup extends React.Component {
         className: Type.oneOfType([Type.func, Type.string]),
         /** Лейбл для группы */
         label: Type.node,
+        /** Подсказка под полем */
+        hint: Type.node,
         /** Обработчик фокуса радиогруппы */
         onFocus: Type.func,
         /** Обработчик снятия фокуса с радиогруппы */
@@ -113,9 +115,9 @@ class RadioGroup extends React.Component {
                 }
                 { createFragment(radioGroupParts) }
                 {
-                    this.props.error &&
+                    (this.props.error || this.props.hint) &&
                     <span className={ cn('sub') }>
-                        { this.props.error }
+                        { this.props.error || this.props.hint }
                     </span>
                 }
             </span>


### PR DESCRIPTION
Добавил свойство `hint` для компонента `RadioGroup` по аналогии с таким же свойством в компоненте Input

## Мотивация и контекст
В проекте alfaform-dc-ui нужны радиогруппы с подсказками.


