### PR TITLE
fix(mq): move match media utils functions to lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "arui-feather",
   "version": "9.6.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.1",
@@ -16630,14 +16629,7 @@
     },
     "postcss-url": {
       "version": "git://github.com/teryaew/postcss-url.git#9d10249f1696d4953aa67b2dfc6f41bd8c4fb4e5",
-      "dev": true,
-      "requires": {
-        "mime": "1.3.6",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "postcss": "6.0.8",
-        "xxhashjs": "0.2.1"
-      }
+      "dev": true
     },
     "postcss-value-parser": {
       "version": "3.3.0",

--- a/src/lib/match-media-test.js
+++ b/src/lib/match-media-test.js
@@ -1,0 +1,34 @@
+import { getMatchMedia, releaseMatchMedia } from './match-media';
+import defaultMq from '../mq/mq.json';
+
+describe('match-media', () => {
+    describe('getMatchMedia', () => {
+        it('should return instance of match media with correct query', () => {
+            const query = 'screen and (max-width: 48em)';
+            const mql = getMatchMedia(query);
+
+            expect(mql).to.be.instanceOf(MediaQueryList);
+            expect(mql.media).to.be.eql('screen and (max-width: 48em)');
+
+            releaseMatchMedia(query);
+        });
+
+        it('should get query from `src/mq/mq.json`', () => {
+            const mql = getMatchMedia('--small-only');
+
+            expect(mql.media).to.be.eql(defaultMq['--small-only']);
+
+            releaseMatchMedia('--small-only');
+        });
+    });
+
+    describe('releaseMatchMedia', () => {
+        it('should work', () => {
+            getMatchMedia('--small-only');
+
+            expect(() => {
+                releaseMatchMedia('--small-only');
+            }).to.not.throw();
+        });
+    });
+});

--- a/src/lib/match-media-test.js
+++ b/src/lib/match-media-test.js
@@ -7,7 +7,6 @@ describe('match-media', () => {
             const query = 'screen and (max-width: 48em)';
             const mql = getMatchMedia(query);
 
-            expect(mql).to.be.instanceOf(MediaQueryList);
             expect(mql.media).to.be.eql('screen and (max-width: 48em)');
 
             releaseMatchMedia(query);

--- a/src/lib/match-media.js
+++ b/src/lib/match-media.js
@@ -1,0 +1,39 @@
+import MqList from '../mq/mq.json';
+
+let pool = {};
+let refCounters = {};
+
+/**
+ * Возвращает MediaQueryList для заданного media-выражения.
+ *
+ * @param {String} queryProp media выражение или кастомные запросы из `src/mq/mq.json`, например `--small`.
+ * @returns {MediaQueryList}
+ */
+export function getMatchMedia(queryProp) {
+    let query = MqList[queryProp] || queryProp;
+
+    if (!pool[query]) {
+        pool[query] = window.matchMedia(query);
+        refCounters[query] = 1;
+    } else {
+        refCounters[query] += 1;
+    }
+
+    return pool[query];
+}
+
+/**
+ * Удаляет MediaQueryList.
+ *
+ * @param {String} queryProp media выражение
+ */
+export function releaseMatchMedia(queryProp) {
+    let query = MqList[queryProp] || queryProp;
+
+    refCounters[query] -= 1;
+
+    if (pool[query] && refCounters[query] === 0) {
+        delete pool[query];
+        delete refCounters[query];
+    }
+}

--- a/src/mq/mq.jsx
+++ b/src/mq/mq.jsx
@@ -5,39 +5,11 @@
 import { autobind } from 'core-decorators';
 import React from 'react';
 import Type from 'prop-types';
-
 import Modernizr from '../modernizr';
-import MqList from './mq.json';
+import { getMatchMedia, releaseMatchMedia } from '../lib/match-media';
 
 const IS_BROWSER = typeof window !== 'undefined';
 const SUPPORTS_TOUCH = IS_BROWSER && (Modernizr.pointerevents || Modernizr.touchevents);
-
-let pool = {};
-let refCounters = {};
-
-function getMatchMedia(queryProp) {
-    let query = MqList[queryProp] || queryProp;
-
-    if (!pool[query]) {
-        pool[query] = window.matchMedia(query);
-        refCounters[query] = 1;
-    } else {
-        refCounters[query] += 1;
-    }
-
-    return pool[query];
-}
-
-function releaseMatchMedia(queryProp) {
-    let query = MqList[queryProp] || queryProp;
-
-    refCounters[query] -= 1;
-
-    if (pool[query] && refCounters[query] === 0) {
-        delete pool[query];
-        delete refCounters[query];
-    }
-}
 
 /**
  * Компонент, имплементирующий поддержку медиа запросов в шаблонах.
@@ -53,7 +25,7 @@ class Mq extends React.Component {
         /** Запрос на поддержку тач-событий */
         touch: Type.bool,
         /** Дочерние элементы `Mq` */
-        children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
+        children: Type.node,
         /** Обработчик изменений в совпадении запросов */
         onMatchChange: Type.func
     };


### PR DESCRIPTION
Вынес утильные функции mq в отдельный файл

## Мотивация и контекст
1. так можно их протестить
2. Так можно использовать их вне `Mq`
