### PR TITLE
fix(input): avoid component pruning with right addons in small width …

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -63,6 +63,7 @@
         display: inline-block;
         position: relative;
         width: 100%;
+        min-width: 0; /* Avoid component pruning with right addons in small width containers (Firefox 55.0.3) */
         height: 100%;
         margin: 0;
         padding: 0;


### PR DESCRIPTION
Фикс проблемы обрезания компонента с аддонами в контейнерах с небольшой шириной.

FF 55.0.3

Ссылка на демо (простите, только так):
```
https://alfa-laboratory.github.io/arui-feather/styleguide-fantasy/#playground/code=initialState = {%0A money: ''%0A};%0Afunction handleMoneyChange(money) {%0A setState({ money });%0A}%0Afunction renderAddons() {%0A return (%0A <RadioGroup type={ 'button' }>%0A {['₽', '$', '€'].map(item => (%0A <Radio%0A key={ item }%0A size='s'%0A type='button'%0A text={ item }%0A onChange={ handleMoneyChange }%0A />%0A ))}%0A </RadioGroup>%0A );%0A}%0A<div style={{ width: 296 }}>%0A <Input%0A size='m'%0A placeholder='Введите сумму'%0A rightAddons={ renderAddons() }%0A type='number'%0A width='available'%0A />%0A</div>
```

![screen shot 2017-09-15 at 12 39 09](https://user-images.githubusercontent.com/4638427/30476755-a59923b6-9a13-11e7-8b20-bf43fa08513b.png)
