### PR TITLE
fix(sidebar-closer): fix css rules for sidebar__closer

### DIFF
--- a/src/sidebar/sidebar.css
+++ b/src/sidebar/sidebar.css
@@ -36,8 +36,8 @@
         position: absolute;
         top: 0;
         right: 0;
-        margin-top: calc(var(--sidebar-padding) - 6);
-        margin-right: calc(var(--sidebar-shift) + var(--sidebar-padding) - 6);
+        margin-top: calc(var(--sidebar-padding) - 6px);
+        margin-right: calc(var(--sidebar-shift) + var(--sidebar-padding) - 6px);
         margin-bottom: 0;
         margin-left: 0;
         padding: 0;


### PR DESCRIPTION
Указание величин без единиц измерения не работает в новой версии Postcss