### PR TITLE
fix(select): fix popup breaking on window resize

### DIFF
--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -145,7 +145,7 @@ class Popup extends React.Component {
     inner;
     content;
 
-    handleResizeWindow = debounce(() => {
+    handleWindowResize = debounce(() => {
         if (this.isPropsToPositionCorrect()) {
             this.redraw();
         }
@@ -170,7 +170,7 @@ class Popup extends React.Component {
             this.setGradientStyles();
         }
 
-        window.addEventListener('resize', this.handleResizeWindow);
+        window.addEventListener('resize', this.handleWindowResize);
     }
 
     componentWillReceiveProps(nextProps, nextContext) {
@@ -208,7 +208,9 @@ class Popup extends React.Component {
             this.ensureClickEvent(true);
         }
 
-        window.removeEventListener('resize', this.handleResizeWindow);
+        // Cancel debouncing to avoid `this.setState()` invocation in unmounted component state
+        this.handleWindowResize.cancel();
+        window.removeEventListener('resize', this.handleWindowResize);
     }
 
     render(cn) {

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -661,6 +661,11 @@ class Select extends React.Component {
     handleMqMatchChange(isMatched) {
         this.setState({
             isMobile: isMatched
+        }, () => {
+            if (this.popup) {
+                this.setPopupTarget();
+                this.updatePopupStyles();
+            }
         });
     }
 


### PR DESCRIPTION
Фикс поломки Popup в Select при переходе/ресайзе из мобайла в десктоп.

```
warning.js:35 Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Popup component.
```

```
Uncaught Error: Cannot show popup without target or position
at Popup.redraw
at Popup.componentWillReceiveProps
```