### PR TITLE
fix(*): fix disabled control color in calendar-input & textarea

### DIFF
--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -227,6 +227,27 @@ class CalendarInput extends React.Component {
                 className={ cn({ width: this.props.width }) }
                 { ...wrapperProps }
             >
+                <Mq
+                    query='--small-only'
+                    touch={ true }
+                    onMatchChange={ this.handleMqMatchChange }
+                >
+                    {
+                        this.canBeNative() &&
+                        <input
+                            ref={ (nativeCalendarTarget) => {
+                                this.nativeCalendarTarget = nativeCalendarTarget;
+                            } }
+                            { ...commonProps }
+                            className={ cn('native-control') }
+                            type='date'
+                            value={ changeDateFormat(value, CUSTOM_DATE_FORMAT, NATIVE_DATE_FORMAT) }
+                            onBlur={ this.handleNativeInputBlur }
+                            onChange={ this.handleNativeInputChange }
+                            onFocus={ this.handleNativeInputFocus }
+                        />
+                    }
+                </Mq>
                 <Input
                     ref={ (customCalendarTarget) => {
                         this.customCalendarTarget = customCalendarTarget;
@@ -259,27 +280,6 @@ class CalendarInput extends React.Component {
                         />
                     }
                 />
-                <Mq
-                    query='--small-only'
-                    touch={ true }
-                    onMatchChange={ this.handleMqMatchChange }
-                >
-                    {
-                        this.canBeNative() &&
-                        <input
-                            ref={ (nativeCalendarTarget) => {
-                                this.nativeCalendarTarget = nativeCalendarTarget;
-                            } }
-                            { ...commonProps }
-                            className={ cn('native-control') }
-                            type='date'
-                            value={ changeDateFormat(value, CUSTOM_DATE_FORMAT, NATIVE_DATE_FORMAT) }
-                            onBlur={ this.handleNativeInputBlur }
-                            onChange={ this.handleNativeInputChange }
-                            onFocus={ this.handleNativeInputFocus }
-                        />
-                    }
-                </Mq>
                 { this.renderPopup(cn, value, Popup) }
             </span>
         );

--- a/src/calendar-input/fantasy/calendar-input.css
+++ b/src/calendar-input/fantasy/calendar-input.css
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@import '../../vars-fantasy.css';
+
 .calendar-input {
     display: inline-block;
     position: relative;
@@ -41,5 +43,21 @@
         display: block;
         width: 265px;
         margin: 0 auto;
+    }
+}
+
+.calendar-input_theme_alfa-on-color {
+    .calendar-input__native-control + .calendar-input__custom-control {
+        .input__control:disabled {
+            -webkit-text-fill-color: var(--color-content-alfa-on-color) !important;
+        }
+    }
+}
+
+.calendar-input_theme_alfa-on-white {
+    .calendar-input__native-control + .calendar-input__custom-control {
+        .input__control:disabled {
+            -webkit-text-fill-color: var(--color-content-alfa-on-white) !important;
+        }
     }
 }

--- a/src/textarea/fantasy/textarea_theme_alfa-on-color.css
+++ b/src/textarea/fantasy/textarea_theme_alfa-on-color.css
@@ -43,6 +43,10 @@
             &::placeholder {
                 color: var(--color-content-disabled-alfa-on-color);
             }
+
+            &:disabled {
+                -webkit-text-fill-color: var(--color-content-disabled-alfa-on-color) !important;
+            }
         }
     }
 

--- a/src/textarea/fantasy/textarea_theme_alfa-on-white.css
+++ b/src/textarea/fantasy/textarea_theme_alfa-on-white.css
@@ -43,6 +43,10 @@
             &::placeholder {
                 color: var(--color-content-disabled-alfa-on-white);
             }
+
+            &:disabled {
+                -webkit-text-fill-color: var(--color-content-disabled-alfa-on-white) !important;
+            }
         }
     }
 


### PR DESCRIPTION
![screen shot 2017-09-28 at 15 41 41](https://user-images.githubusercontent.com/4638427/30967026-912dfdb6-a463-11e7-940e-c3e7e31d5ea5.png)

Фикс цвета полей ввода при `:disabled` атрибуте на контроле. Пример на iOS Safari с нативным `CalendarInput`.