### PR TITLE
feat(*): remove deprecated props in form-field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "arui-feather",
   "version": "9.10.4",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.1",
@@ -16680,7 +16681,14 @@
     },
     "postcss-url": {
       "version": "git://github.com/teryaew/postcss-url.git#9d10249f1696d4953aa67b2dfc6f41bd8c4fb4e5",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime": "1.3.6",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "postcss": "6.0.8",
+        "xxhashjs": "0.2.1"
+      }
     },
     "postcss-value-parser": {
       "version": "3.3.0",

--- a/src/form-field/fantasy/form-field.css
+++ b/src/form-field/fantasy/form-field.css
@@ -5,144 +5,16 @@
 @import '../../vars-fantasy.css';
 
 .form-field {
-    position: relative;
-
-    &__label {
-        font-family: var(--font);
-    }
-
     &_size_s {
         padding-bottom: 20px;
-    }
-
-    &_size_s &__label {
-        padding-bottom: 12px;
     }
 
     &_size_m {
         padding-bottom: 30px;
     }
 
-    &_size_m &__label {
-        padding-bottom: 10px;
-    }
-
     &_size_l,
     &_size_xl {
         padding-bottom: 35px;
-    }
-
-    &_size_l &__label,
-    &_size_xl &__label {
-        padding-bottom: 15px;
-    }
-}
-
-@media (--large) {
-    .form-field_view_line {
-        .form-field__label {
-            position: absolute;
-            top: 0;
-            left: -172px;
-            width: 152px;
-            text-align: right;
-            padding-bottom: 0;
-        }
-
-        &.form-field_size_s {
-            .form-field__label {
-                padding-top: 6px;
-            }
-
-            .form-field__control {
-                & > .radio
-                & > .checkbox {
-                    padding-top: 7px;
-                }
-
-                & > .radio-group_type_normal,
-                & > .checkbox-group_type_normal {
-                    padding-top: 7px;
-                }
-
-                & > .radio-group_type_button,
-                & > .checkbox-group_type_button {
-                    padding-top: 0;
-                }
-            }
-        }
-
-        &.form-field_size_m {
-            .form-field__label {
-                padding-top: 9px;
-            }
-
-            .form-field__control {
-                & > .radio,
-                & > .radio-group_type_normal,
-                & > .radio-group_type_line {
-                    padding-top: 9px;
-                }
-
-                & > .checkbox,
-                & > .checkbox-group_type_normal,
-                & > .checkbox-group_type_line {
-                    padding-top: 11px;
-                }
-
-                & > .radio-group_type_button,
-                & > .checkbox-group_type_button {
-                    padding-top: 0;
-                }
-            }
-        }
-
-        &.form-field_size_l {
-            .form-field__label {
-                padding-top: 12px;
-            }
-
-            .form-field__control {
-                & > .radio,
-                & > .radio-group_type_normal,
-                & > .radio-group_type_line {
-                    padding-top: 10px;
-                }
-
-                & > .checkbox,
-                & > .checkbox-group_type_normal,
-                & > .checkbox-group_type_line {
-                    padding-top: 12px;
-                }
-
-                & > .radio-group_type_button,
-                & > .checkbox-group_type_button {
-                    padding-top: 0;
-                }
-            }
-        }
-
-        &.form-field_size_xl {
-            .form-field__label {
-                padding-top: 13px;
-            }
-
-            .form-field__control {
-                & > .radio
-                & > .checkbox {
-                    padding-top: 8px;
-                }
-
-                & > .radio-group_type_normal,
-                & > .checkbox-group_type_normal {
-                    padding-top: 8px;
-                }
-
-                & > .radio-group_type_button,
-                & > .checkbox-group_type_button {
-                    padding-top: 0;
-                }
-            }
-        }
     }
 }

--- a/src/form-field/form-field-test.jsx
+++ b/src/form-field/form-field-test.jsx
@@ -15,18 +15,4 @@ describe('form-field', () => {
         expect(formField.node).to.exist;
         expect(formField.node).to.have.text('FormField-test');
     });
-
-    it('should render view line without problems', () => {
-        let formField = render(<FormField view='line'>FormField-test</FormField>);
-
-        expect(formField.node).to.have.class('form-field_view_line');
-    });
-
-    it('should render Label with text from property `label`', () => {
-        let formField = render(<FormField label='FormField Label'>FormField-test</FormField>);
-        let formFieldLabelNode = formField.node.firstChild;
-
-        expect(formFieldLabelNode).to.have.class('form-field__label');
-        expect(formFieldLabelNode).to.have.text('FormField Label');
-    });
 });

--- a/src/form-field/form-field.css
+++ b/src/form-field/form-field.css
@@ -5,144 +5,16 @@
 @import '../vars.css';
 
 .form-field {
-    position: relative;
-
-    &__label {
-        font-family: var(--font);
-    }
-
     &_size_s {
         padding-bottom: 20px;
-    }
-
-    &_size_s &__label {
-        padding-bottom: 12px;
     }
 
     &_size_m {
         padding-bottom: 30px;
     }
 
-    &_size_m &__label {
-        padding-bottom: 10px;
-    }
-
     &_size_l,
     &_size_xl {
         padding-bottom: 35px;
-    }
-
-    &_size_l &__label,
-    &_size_xl &__label {
-        padding-bottom: 15px;
-    }
-}
-
-@media (--large) {
-    .form-field_view_line {
-        .form-field__label {
-            position: absolute;
-            top: 0;
-            left: -172px;
-            width: 152px;
-            text-align: right;
-            padding-bottom: 0;
-        }
-
-        &.form-field_size_s {
-            .form-field__label {
-                padding-top: 6px;
-            }
-
-            .form-field__control {
-                & > .radio
-                & > .checkbox {
-                    padding-top: 7px;
-                }
-
-                & > .radio-group_type_normal,
-                & > .checkbox-group_type_normal {
-                    padding-top: 7px;
-                }
-
-                & > .radio-group_type_button,
-                & > .checkbox-group_type_button {
-                    padding-top: 0;
-                }
-            }
-        }
-
-        &.form-field_size_m {
-            .form-field__label {
-                padding-top: 9px;
-            }
-
-            .form-field__control {
-                & > .radio,
-                & > .radio-group_type_normal,
-                & > .radio-group_type_line {
-                    padding-top: 9px;
-                }
-
-                & > .checkbox,
-                & > .checkbox-group_type_normal,
-                & > .checkbox-group_type_line {
-                    padding-top: 11px;
-                }
-
-                & > .radio-group_type_button,
-                & > .checkbox-group_type_button {
-                    padding-top: 0;
-                }
-            }
-        }
-
-        &.form-field_size_l {
-            .form-field__label {
-                padding-top: 12px;
-            }
-
-            .form-field__control {
-                & > .radio,
-                & > .radio-group_type_normal,
-                & > .radio-group_type_line {
-                    padding-top: 10px;
-                }
-
-                & > .checkbox,
-                & > .checkbox-group_type_normal,
-                & > .checkbox-group_type_line {
-                    padding-top: 12px;
-                }
-
-                & > .radio-group_type_button,
-                & > .checkbox-group_type_button {
-                    padding-top: 0;
-                }
-            }
-        }
-
-        &.form-field_size_xl {
-            .form-field__label {
-                padding-top: 13px;
-            }
-
-            .form-field__control {
-                & > .radio
-                & > .checkbox {
-                    padding-top: 8px;
-                }
-
-                & > .radio-group_type_normal,
-                & > .checkbox-group_type_normal {
-                    padding-top: 8px;
-                }
-
-                & > .radio-group_type_button,
-                & > .checkbox-group_type_button {
-                    padding-top: 0;
-                }
-            }
-        }
     }
 }

--- a/src/form-field/form-field.jsx
+++ b/src/form-field/form-field.jsx
@@ -7,7 +7,6 @@ import Type from 'prop-types';
 
 import cn from '../cn';
 import performance from '../performance';
-import { deprecated } from '../lib/prop-types';
 
 /**
  * Компонент поля формы.
@@ -19,18 +18,14 @@ class FormField extends React.Component {
     static propTypes = {
         /** Дочерние элементы `FormField` */
         children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
-        /** @deprecated Заголовок для контрола */
-        label: deprecated(Type.node, 'Use \'label\' property directly on controls.'),
-        /** Размер компонента */
-        size: Type.oneOf(['s', 'm', 'l', 'xl']),
-        /** Расположение элемента label: 'line' */
-        view: Type.string,
-        /** Тема компонента */
-        theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
         className: Type.oneOfType([Type.func, Type.string]),
         /** Идентификатор компонента в DOM */
-        id: Type.string
+        id: Type.string,
+        /** Размер компонента */
+        size: Type.oneOf(['s', 'm', 'l', 'xl']),
+        /** Тема компонента */
+        theme: Type.oneOf(['alfa-on-color', 'alfa-on-white'])
     };
 
     static defaultProps = {
@@ -40,20 +35,10 @@ class FormField extends React.Component {
     render(cn) {
         return (
             <div
-                className={ cn({
-                    size: this.props.size,
-                    view: this.props.view
-                }) }
+                className={ cn({ size: this.props.size }) }
                 id={ this.props.id }
             >
-                { this.props.label &&
-                    <div className={ cn('label') }>
-                        { this.props.label }
-                    </div>
-                }
-                <div className={ cn('control') }>
-                    { this.props.children }
-                </div>
+                { this.props.children }
             </div>
         );
     }


### PR DESCRIPTION
Удаление устаревших props в `<FormField />`: `label` и связанного с ним `view`.

Предполагается взамен использование встроенных в контролы форм лейблов:
```
<Input label='foo' />
<Select label='foo' />
<Textarea label='foo' />
...
```