### PR TITLE
feat(*): add autoclosable component, use it in popup

### DIFF
--- a/src/autoclosable/autoclosable-test.jsx
+++ b/src/autoclosable/autoclosable-test.jsx
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render, cleanUp } from '../test-utils';
+
+import Autoclosable from './autoclosable';
+
+describe('autoclosable', () => {
+    afterEach(cleanUp);
+
+    it('should call `onClickOutside` callback after click outside div', (done) => {
+        let onClickOutside = sinon.spy();
+        render(
+            <Autoclosable onClickOutside={ onClickOutside }>
+                <div style={ { position: 'absolute', top: 0, left: 0, width: 100, height: 100 } } />
+            </Autoclosable>
+        );
+
+        let outsideElement = document.createElement('div');
+        outsideElement.setAttribute('style',
+            'position: absolute; top: 200; left: 200; width: 100px; height: 100px;'
+        );
+        document.body.appendChild(outsideElement);
+
+        setTimeout(() => {
+            outsideElement.click();
+            expect(onClickOutside).to.have.been.calledOnce;
+            done();
+        }, 0);
+    });
+
+    it('should not call `onClickOutside` callback after click inside div', (done) => {
+        let onClickOutside = sinon.spy();
+        render(
+            <Autoclosable onClickOutside={ onClickOutside }>
+                <div className='foo' style={ { width: 100, height: 100 } } />
+            </Autoclosable>
+        );
+
+        setTimeout(() => {
+            document.querySelector('.foo').click();
+            expect(onClickOutside).to.not.have.been.called;
+            done();
+        }, 0);
+    });
+});

--- a/src/autoclosable/autoclosable.jsx
+++ b/src/autoclosable/autoclosable.jsx
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { autobind } from 'core-decorators';
+import { Component } from 'react';
+import Type from 'prop-types';
+
+import keyboardCode from '../lib/keyboard-code';
+import { isNodeOutsideElement } from '../lib/window';
+import performance from '../performance';
+
+/**
+ * Компонент автозакрытия дочернего элемента.
+ */
+@performance()
+class Autoclosable extends Component {
+    static propTypes = {
+        /** Управление активностью компонента */
+        active: Type.bool,
+        /** Дочерние элементы `Autoclosable` */
+        children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
+        /** Обработчик клика вне компонента */
+        onClickOutside: Type.func,
+        /** Обработчик нажатия на клавишу Esc */
+        onEscapeKeyDown: Type.func
+    }
+
+    static defaultProps = {
+        active: true
+    }
+
+    root;
+
+    componentDidMount() {
+        this.ensureClickEvent();
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.onClickOutside !== this.props.onClickOutside) {
+            this.ensureClickEvent();
+        } else if (prevProps.active !== this.props.active) {
+            this.ensureClickEvent(!this.props.active);
+        }
+    }
+
+    componentWillUnmount() {
+        this.ensureClickEvent(true);
+    }
+
+    render() {
+        return (
+            <div
+                ref={ (root) => { this.root = root; } }
+                role='presentation'
+                tabIndex='-1'
+                onKeyDown={ this.handleKeyDown }
+            >
+                { this.props.children }
+            </div>
+        );
+    }
+
+    @autobind
+    handleKeyDown(event) {
+        if (event.which === keyboardCode.ESCAPE) {
+            if (document.activeElement) {
+                document.activeElement.blur();
+            }
+
+            if (this.props.onEscapeKeyDown) {
+                this.props.onEscapeKeyDown(event);
+            }
+        }
+    }
+
+    @autobind
+    handleWindowClick(event) {
+        if (!!this.root && isNodeOutsideElement(event.target, this.root)) {
+            if (this.props.onClickOutside) {
+                this.props.onClickOutside(event);
+            }
+        }
+    }
+
+    ensureClickEvent(isDestroy) {
+        let isNeedBindEvent = isDestroy !== undefined ? !isDestroy : this.props.active;
+
+        // We need timeouts to not to catch the event that causes
+        // popup opening (because it propagates to the `window`).
+        if (this.clickEventBindTimeout) {
+            clearTimeout(this.clickEventBindTimeout);
+            this.clickEventBindTimeout = null;
+        }
+
+        this.clickEventBindTimeout = setTimeout(() => {
+            if (!this.isWindowClickBinded && isNeedBindEvent) {
+                window.addEventListener('click', this.handleWindowClick);
+                window.addEventListener('touchend', this.handleWindowClick);
+                this.isWindowClickBinded = true;
+            } else if (this.isWindowClickBinded && !isNeedBindEvent) {
+                window.removeEventListener('click', this.handleWindowClick);
+                window.removeEventListener('touchend', this.handleWindowClick);
+                this.isWindowClickBinded = false;
+            }
+        }, 0);
+    }
+}
+
+export default Autoclosable;

--- a/src/autoclosable/index.js
+++ b/src/autoclosable/index.js
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export default from './autoclosable';

--- a/src/popup/popup-test.jsx
+++ b/src/popup/popup-test.jsx
@@ -144,35 +144,6 @@ describe('popup', () => {
         expect(onMouseLeave).to.have.been.calledOnce;
     });
 
-    it('should call `onClickOutside` callback after click outside popup', (done) => {
-        let onClickOutside = sinon.spy();
-        renderPopup({ onClickOutside, autoclosable: true, visible: true }, {});
-
-        let outsideElement = document.createElement('div');
-        outsideElement.setAttribute('style',
-            'width: 100px; height: 100px; position: absolute; left: 500px; top: 500px;'
-        );
-        outsideElement.setAttribute('id', 'outside');
-        document.body.appendChild(outsideElement);
-
-        setTimeout(() => {
-            outsideElement.click();
-            expect(onClickOutside).to.have.been.calledOnce;
-            done();
-        }, 0);
-    });
-
-    it('should not call `onClickOutside` callback after click inside popup', (done) => {
-        let onClickOutside = sinon.spy();
-        let { popupContentNode } = renderPopup({ onClickOutside, autoclosable: true, visible: true }, {});
-
-        setTimeout(() => {
-            popupContentNode.click();
-            expect(onClickOutside).to.not.have.been.called;
-            done();
-        }, 0);
-    });
-
     it('should not render a header element by default', () => {
         let { popupHeaderNode } = renderPopup({ visible: true }, {});
 

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -7,6 +7,7 @@ import debounce from 'lodash.debounce';
 import React from 'react';
 import Type from 'prop-types';
 
+import Autoclosable from '../autoclosable/autoclosable';
 import RenderInContainer from '../render-in-container/render-in-container';
 import ResizeSensor from '../resize-sensor/resize-sensor';
 
@@ -14,7 +15,6 @@ import { calcBestDrawingParams, calcTargetDimensions, calcFitContainerDimensions
 import cn from '../cn';
 import getScrollbarWidth from '../lib/scrollbar-width';
 import { HtmlElement } from '../lib/prop-types';
-import { isNodeOutsideElement } from '../lib/window';
 import performance from '../performance';
 
 /**
@@ -161,10 +161,6 @@ class Popup extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.autoclosable) {
-            this.ensureClickEvent();
-        }
-
         if (this.props.height === 'adaptive' || this.props.target === 'screen') {
             this.setGradientStyles();
         }
@@ -192,21 +188,7 @@ class Popup extends React.Component {
         }
     }
 
-    componentDidUpdate(prevProps) {
-        if (this.props.autoclosable) {
-            if (prevProps.onClickOutside !== this.props.onClickOutside) {
-                this.ensureClickEvent();
-            } else if (prevProps.visible !== this.props.visible) {
-                this.ensureClickEvent(!this.props.visible);
-            }
-        }
-    }
-
     componentWillUnmount() {
-        if (this.props.autoclosable) {
-            this.ensureClickEvent(true);
-        }
-
         // Cancel debouncing to avoid `this.setState()` invocation in unmounted component state
         this.handleWindowResize.cancel();
         window.removeEventListener('resize', this.handleWindowResize);
@@ -219,55 +201,67 @@ class Popup extends React.Component {
 
         return (
             <RenderInContainer container={ this.getRenderContainer() }>
-                <div
-                    ref={ (popup) => { this.popup = popup; } }
-                    data-for={ this.props.for }
-                    className={ cn({
-                        direction: this.state.direction,
-                        type: (this.props.target === 'anchor') && (this.props.type === 'tooltip') && this.props.type,
-                        target: this.props.target,
-                        size: this.props.size,
-                        visible: this.props.visible,
-                        height: this.props.height,
-                        autoclosable: this.props.autoclosable,
-                        padded: this.props.padded
-                    }) }
-                    id={ this.props.id }
-                    style={ {
-                        ...this.state.styles,
-                        minWidth: this.getMinWidth(),
-                        maxWidth: this.getMaxWidth()
-                    } }
-                    onMouseEnter={ this.handleMouseEnter }
-                    onMouseLeave={ this.handleMouseLeave }
+                <Autoclosable
+                    active={ this.props.visible }
+                    onClickOutside={ this.handleClickOutside }
                 >
-                    <div className={ cn('container') }>
-                        {
-                            this.props.header && (
-                                <div className={ cn('header') }>
-                                    { this.props.header }
+                    <div
+                        ref={ (popup) => { this.popup = popup; } }
+                        data-for={ this.props.for }
+                        className={ cn({
+                            direction: this.state.direction,
+                            type: (this.props.target === 'anchor') && (this.props.type === 'tooltip') &&
+                                this.props.type,
+                            target: this.props.target,
+                            size: this.props.size,
+                            visible: this.props.visible,
+                            height: this.props.height,
+                            padded: this.props.padded
+                        }) }
+                        id={ this.props.id }
+                        style={ {
+                            ...this.state.styles,
+                            minWidth: this.getMinWidth(),
+                            maxWidth: this.getMaxWidth()
+                        } }
+                        onMouseEnter={ this.handleMouseEnter }
+                        onMouseLeave={ this.handleMouseLeave }
+                    >
+                        <div className={ cn('container') }>
+                            {
+                                this.props.header && (
+                                    <div className={ cn('header') }>
+                                        { this.props.header }
+                                    </div>
+                                )
+                            }
+                            <div
+                                ref={ (inner) => { this.inner = inner; } }
+                                className={ cn('inner') }
+                                onScroll={ this.handleInnerScroll }
+                            >
+                                <div className={ cn('content') } ref={ (content) => { this.content = content; } }>
+                                    { this.props.children }
+                                    <ResizeSensor onResize={ this.handleResize } />
                                 </div>
-                            )
-                        }
-                        <div
-                            ref={ (inner) => { this.inner = inner; } }
-                            className={ cn('inner') }
-                            onScroll={ this.handleInnerScroll }
-                        >
-                            <div className={ cn('content') } ref={ (content) => { this.content = content; } }>
-                                { this.props.children }
-                                <ResizeSensor onResize={ this.handleResize } />
                             </div>
+                            {
+                                this.state.hasScrollbar && (
+                                    <div className={ cn('gradient') } style={ this.state.gradientStyles } />
+                                )
+                            }
                         </div>
-                        {
-                            this.state.hasScrollbar && (
-                                <div className={ cn('gradient') } style={ this.state.gradientStyles } />
-                            )
-                        }
                     </div>
-                </div>
+                </Autoclosable>
             </RenderInContainer>
         );
+    }
+
+    @autobind
+    handleClickOutside(event) {
+        if (this.props.autoclosable && this.props.onClickOutside) {
+            this.props.onClickOutside(event);
+        }
     }
 
     @autobind
@@ -301,15 +295,6 @@ class Popup extends React.Component {
     handleMouseLeave() {
         if (this.props.onMouseLeave) {
             this.props.onMouseLeave();
-        }
-    }
-
-    @autobind
-    handleWindowClick(event) {
-        if (this.props.autoclosable && !!this.domElemPopup && isNodeOutsideElement(event.target, this.domElemPopup)) {
-            if (this.props.onClickOutside) {
-                this.props.onClickOutside(event);
-            }
         }
     }
 
@@ -462,29 +447,6 @@ class Popup extends React.Component {
             hasScrollbar: bestDrawingParams.overflow,
             styles: this.getDrawingCss(bestDrawingParams)
         });
-    }
-
-    ensureClickEvent(isDestroy) {
-        let isNeedBindEvent = isDestroy !== undefined ? !isDestroy : this.props.visible;
-
-        // We need timeouts to not to catch the event that causes
-        // popup opening (because it propagates to the `window`).
-        if (this.clickEventBindTimeout) {
-            clearTimeout(this.clickEventBindTimeout);
-            this.clickEventBindTimeout = null;
-        }
-
-        this.clickEventBindTimeout = setTimeout(() => {
-            if (!this.isWindowClickBinded && isNeedBindEvent) {
-                window.addEventListener('click', this.handleWindowClick);
-                window.addEventListener('touchend', this.handleWindowClick);
-                this.isWindowClickBinded = true;
-            } else if (this.isWindowClickBinded && !isNeedBindEvent) {
-                window.removeEventListener('click', this.handleWindowClick);
-                window.removeEventListener('touchend', this.handleWindowClick);
-                this.isWindowClickBinded = false;
-            }
-        }, 0);
     }
 
     getDrawingCss(drawingParams) {


### PR DESCRIPTION
Добавление компонента `<Autoclosable />`, отвечающего за закрытие дочернего элемента кликом вне его или нажатием на Esc. По сути, данная механика была зашита до этого в компоненте `<Popup />` и есть возможность разгрузить его и использовать в других местах (например, `<Sidebar />` и новые компоненты в прототипах).