### PR TITLE
fix(*): support weakMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "cn-decorator": "^1.0.4",
     "core-decorators": "^0.18.0",
     "date-fns": "^1.28.2",
+    "es6-map": "^0.1.5",
     "es6-object-assign": "^1.1.0",
     "es6-promise": "^4.1.0",
     "es6-weak-map": "^2.0.2",

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -10,6 +10,7 @@ const ArrayFrom = require('array-from');
 const ObjectIs = require('object-is');
 require('es6-object-assign').polyfill();
 require('es6-promise').polyfill();
+require('es6-map/implement');
 require('es6-weak-map/implement'); // for autobind from core-decorators
 require('array.prototype.fill');
 require('ima-babel6-polyfill'); // fix super constructor call for ie <= 10, see https://phabricator.babeljs.io/T3041


### PR DESCRIPTION
Support Map
Map collection as specified in ECMAScript6

## Мотивация и контекст
Map wasn't implemented in library.
Make sure environment implements Map globally. 
