### PR TITLE
feat(cn): set alfa-on-white theme as default, remove alfa-on-colored theme

### DIFF
--- a/src/cn.js
+++ b/src/cn.js
@@ -4,4 +4,4 @@
 
 import cn from 'cn-decorator';
 
-export default cn.create(['alfa-on-color', 'alfa-on-white', 'alfa-on-colored']);
+export default cn.create(['alfa-on-white', 'alfa-on-color']);


### PR DESCRIPTION
Изменение списка тем при создании `cn` — избавляет от дополнительного использования `<ThemeProvider theme='alfa-on-white' />` на проектах с обновлённым дизайном. Странная тема `alfa-on-colored` больше не используется, цветные иконки можно использовать через флаг `colored`, как на тёмных, так и на светлых подложках.