### PR TITLE
fix(input): remove default browser box-shadow from invalid input

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -79,6 +79,10 @@
         -webkit-appearance: none;
         -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 
+        &:invalid {
+            box-shadow: none;
+        }
+
         &::-webkit-search-decoration {
             -webkit-appearance: none;
         }


### PR DESCRIPTION
Фикс для инвалидных полей. Встречается в FF:

<img width="367" alt="screen shot 2017-10-09 at 16 55 56" src="https://user-images.githubusercontent.com/4638427/31341648-d2b9af0c-ad12-11e7-93da-42b4054bfc3b.png">