### PR TITLE
fix(*): fix labeled inputs on ios11

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -46,7 +46,7 @@
         font-size: var(--font-size-m);
         text-overflow: ellipsis;
         white-space: nowrap;
-        transform: scale(1) translate3d(0, 0, 0);
+        transform: scale(1) translateY(0);
         transform-origin: 0 100%;
         transition-duration: 200ms;
         transition-property: color, transform;
@@ -254,7 +254,7 @@
     &.input_focused,
     &.input_has-value {
         .input__top {
-            transform: scale(var(--top-scale-s)) translate3d(0, -22px, 0);
+            transform: scale(var(--top-scale-s)) translateY(-22px);
         }
     }
 
@@ -299,7 +299,7 @@
     &.input_focused,
     &.input_has-value {
         .input__top {
-            transform: scale(var(--top-scale-m)) translate3d(0, -30px, 0);
+            transform: scale(var(--top-scale-m)) translateY(-30px);
         }
     }
 
@@ -344,7 +344,7 @@
     &.input_focused,
     &.input_has-value {
         .input__top {
-            transform: scale(var(--top-scale-l)) translate3d(0, -40px, 0);
+            transform: scale(var(--top-scale-l)) translateY(-40px);
         }
     }
 
@@ -389,7 +389,7 @@
     &.input_focused,
     &.input_has-value {
         .input__top {
-            transform: scale(var(--top-scale-xl)) translate3d(0, -50px, 0);
+            transform: scale(var(--top-scale-xl)) translateY(-50px);
         }
     }
 

--- a/src/select/select.css
+++ b/src/select/select.css
@@ -41,7 +41,7 @@
         font-size: var(--font-size-m);
         text-overflow: ellipsis;
         white-space: nowrap;
-        transform: scale(1) translate3d(0, 0, 0);
+        transform: scale(1) translateY(0);
         transform-origin: 0 100%;
         transition-duration: 200ms;
         transition-property: color, transform;
@@ -182,7 +182,7 @@
     &.select_opened,
     &.select_has-value {
         .select__top {
-            transform: scale(var(--top-scale-s)) translate3d(0, -22px, 0);
+            transform: scale(var(--top-scale-s)) translateY(-22px);
         }
     }
 }
@@ -200,7 +200,7 @@
     &.select_opened,
     &.select_has-value {
         .select__top {
-            transform: scale(var(--top-scale-m)) translate3d(0, -30px, 0);
+            transform: scale(var(--top-scale-m)) translateY(-30px);
         }
     }
 }
@@ -218,7 +218,7 @@
     &.select_opened,
     &.select_has-value {
         .select__top {
-            transform: scale(var(--top-scale-l)) translate3d(0, -40px, 0);
+            transform: scale(var(--top-scale-l)) translateY(-40px);
         }
     }
 }
@@ -236,7 +236,7 @@
     &.select_opened,
     &.select_has-value {
         .select__top {
-            transform: scale(var(--top-scale-xl)) translate3d(0, -50px, 0);
+            transform: scale(var(--top-scale-xl)) translateY(-50px);
         }
     }
 }

--- a/src/textarea/textarea.css
+++ b/src/textarea/textarea.css
@@ -35,7 +35,7 @@
         font-size: var(--font-size-m);
         white-space: nowrap;
         text-overflow: ellipsis;
-        transform: scale(1) translate3d(0, 0, 0);
+        transform: scale(1) translateY(0);
         transform-origin: 0 100%;
         transition-duration: 200ms;
         transition-property: color, transform;
@@ -157,7 +157,7 @@
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {
-                transform: scale(var(--top-scale-s)) translate3d(0, -22px, 0);
+                transform: scale(var(--top-scale-s)) translateY(-22px);
             }
         }
     }
@@ -188,7 +188,7 @@
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {
-                transform: scale(var(--top-scale-m)) translate3d(0, -30px, 0);
+                transform: scale(var(--top-scale-m)) translateY(-30px);
             }
         }
     }
@@ -219,7 +219,7 @@
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {
-                transform: scale(var(--top-scale-l)) translate3d(0, -40px, 0);
+                transform: scale(var(--top-scale-l)) translateY(-40px);
             }
         }
     }
@@ -250,7 +250,7 @@
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {
-                transform: scale(var(--top-scale-xl)) translate3d(0, -50px, 0);
+                transform: scale(var(--top-scale-xl)) translateY(-50px);
             }
         }
     }


### PR DESCRIPTION
Фикс исчезания лейблов инпутов при скроллинге на ios 11

Увы, на issue у меня ссылки нет, т. к. меня еще не добавили в трелло, где эта карточка висит
Есть только кусок переписки
```
artptr [4:19 PM]
@here в ios 11 инпуты с топ-лейблом при прокрутке исчезают из-за того, что на них стоит translate3d

[4:19]
если заменить на translateY, то работает нормально

[4:22]
будет ли регрессия в ios 10, если так сделать?
```