### PR TITLE
fix(*): fix missing key prop in PopupHeader

### DIFF
--- a/src/popup-header/README.md
+++ b/src/popup-header/README.md
@@ -21,6 +21,7 @@ class PopupHeaderDemo extends React.Component {
                     <div style={ { width: '100%' } }>
                         {['s', 'm', 'l', 'xl'].map(size => (
                             <PopupHeader
+                                key={ size }
                                 size={ size }
                                 title='Заголовок'
                             />


### PR DESCRIPTION
Добавил 'key' при генерации PopupHeader

## Мотивация и контекст
При запуске демо на локальной машине, заметил, что в консоль вываливаются предупреждения реакта об отсутствии 'key' в компоненте.
Реакт требует добавления 'key' при создании элементов с помощью итерации.
Решил исправить этот баг.
@teryaew @GREENpoint 