### PR TITLE
fix(sidebar): fix hidden scrollbar

### DIFF
--- a/src/sidebar/sidebar.jsx
+++ b/src/sidebar/sidebar.jsx
@@ -105,6 +105,8 @@ class Sidebar extends React.Component {
         const { hasCloser, children, visible, headerContent, hasOverlay } = this.props;
         let offset = visible ? getScrollbarWidth() : 0;
 
+        document.body.style.marginRight = !this.state.isMobile && hasOverlay ? `${offset}px` : 0;
+
         let style = {
             width: this.state.isMobile ? '100%' : `${sidebarWidth + offset}px`
         };


### PR DESCRIPTION
fix(sidebar): fix hidden scrollbar

При открытии сайдбара на body вешается overflow: hidden, из за этого исчезает скроллбар и body смещается вправо на ширину скроллбара, этот ПР испраляет данный баг
