### PR TITLE
chore(*): updated git commit format link

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -242,7 +242,7 @@ function setTarget(target) {
 
 ## Commit messages
 
-Для commit messages используйте [формат Angular](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit).
+Для commit messages используйте [формат Angular](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).
 В теме сообщения указывайте глагол в настоящем времени, который информирует об изменениях.
 Для валидации commit messages на соответствующем git hook используется `validate-commit-message`.
 


### PR DESCRIPTION
Обновил ссылку на формат коммитов.

Сегодня в проекте ангуляра этот кусок доки переехал в другой файл.