### PR TITLE
fix(input): avoid overflow cutting of addons in ie11

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -203,6 +203,7 @@
 
     &__addons {
         display: flex;
+        flex-shrink: 0; /* Avoid overflow cutting of addons in IE11 */
         align-items: center;
     }
 


### PR DESCRIPTION
Исправление обрезания аддонов в IE11.

<img width="338" alt="screen shot 2017-11-06 at 18 06 16" src="https://user-images.githubusercontent.com/4638427/32447546-7ba99382-c31d-11e7-809a-7659b62e54ef.png">
