### PR TITLE
feat(*): use classname prop type string-only

### DIFF
--- a/src/amount/amount.jsx
+++ b/src/amount/amount.jsx
@@ -94,7 +94,7 @@ class Amount extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string
     };

--- a/src/attach/attach.jsx
+++ b/src/attach/attach.jsx
@@ -103,7 +103,7 @@ class Attach extends React.Component {
             togglable: Type.oneOf(['check', 'radio']),
             checked: Type.bool,
             theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
-            className: Type.oneOfType([Type.func, Type.string]),
+            className: Type.string,
             onClick: Type.func,
             onFocus: Type.func,
             onBlur: Type.func,
@@ -125,7 +125,7 @@ class Attach extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Обработчик клика по компоненту кнопки */
         onClick: Type.func,
         /** Обработчик изменения значения 'value' */

--- a/src/button/button.jsx
+++ b/src/button/button.jsx
@@ -60,7 +60,7 @@ class Button extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Обработчик клика по кнопке */
         onClick: Type.func,
         /** Обработчик фокуса кнопки */

--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -61,7 +61,7 @@ class CalendarInput extends React.Component {
             isKeyboard: Type.bool,
             error: Type.node,
             theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
-            className: Type.oneOfType([Type.func, Type.string]),
+            className: Type.string,
             onKeyDown: Type.func,
             onKeyUp: Type.func,
             onFocus: Type.func,
@@ -101,7 +101,7 @@ class CalendarInput extends React.Component {
         /** Имя компонента в DOM */
         name: Type.string,
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Обработчик установки фокуса на компонент */

--- a/src/calendar/calendar.jsx
+++ b/src/calendar/calendar.jsx
@@ -68,7 +68,7 @@ class Calendar extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Обработчик события нажатия на клавишу клавиатуры в момент, когда фокус находится на компоненте */

--- a/src/checkbox-group/checkbox-group.jsx
+++ b/src/checkbox-group/checkbox-group.jsx
@@ -32,7 +32,7 @@ class CheckBoxGroup extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Лейбл для группы */

--- a/src/checkbox/checkbox.jsx
+++ b/src/checkbox/checkbox.jsx
@@ -46,7 +46,7 @@ class CheckBox extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Обработчик изменения значения 'checked' компонента, принимает на вход isChecked и value компонента */
         onChange: Type.func,
         /** Обработчик фокуса комнонента */

--- a/src/collapse/collapse.jsx
+++ b/src/collapse/collapse.jsx
@@ -31,7 +31,7 @@ class Collapse extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Обработчик смены состояний `expanded/collapsed` */

--- a/src/dropdown/dropdown.jsx
+++ b/src/dropdown/dropdown.jsx
@@ -29,7 +29,7 @@ class Dropdown extends React.Component {
         popupContent: Type.node,
         /** Свойства для компонента [Popup](../popup/) */
         popupProps: Type.shape({
-            className: Type.oneOfType([Type.func, Type.string]),
+            className: Type.string,
             type: Type.oneOf(['default', 'tooltip']),
             height: Type.oneOf(['default', 'available', 'adaptive']),
             directions: Type.arrayOf(Type.oneOf([
@@ -67,7 +67,7 @@ class Dropdown extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Обработчик клика по кнопке компонента */

--- a/src/form-field/form-field.jsx
+++ b/src/form-field/form-field.jsx
@@ -19,7 +19,7 @@ class FormField extends React.Component {
         /** Дочерние элементы `FormField` */
         children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Размер компонента */

--- a/src/form/form.jsx
+++ b/src/form/form.jsx
@@ -37,7 +37,7 @@ class Form extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Имя компонента в DOM */

--- a/src/heading/heading.jsx
+++ b/src/heading/heading.jsx
@@ -29,7 +29,7 @@ class Heading extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string
     };

--- a/src/icon/icon.jsx
+++ b/src/icon/icon.jsx
@@ -16,7 +16,7 @@ import performance from '../performance';
 class Icon extends React.Component {
     static propTypes = {
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Управление цветностью иконки */
         colored: Type.bool,
         /** Идентификатор компонента в DOM */

--- a/src/input-group/input-group.jsx
+++ b/src/input-group/input-group.jsx
@@ -23,7 +23,7 @@ class InputGroup extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string
     };

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -84,7 +84,7 @@ class Input extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Тултип, который появляется при наведении  */
         title: Type.string,
         /** Обработчик изменения значения 'value' */

--- a/src/label/label.jsx
+++ b/src/label/label.jsx
@@ -22,7 +22,7 @@ class Label extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Управление возможностью рендерить компонент в одну сроку */

--- a/src/link/link.jsx
+++ b/src/link/link.jsx
@@ -41,7 +41,7 @@ class Link extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Обработчик клика но ссылке */

--- a/src/list/list.jsx
+++ b/src/list/list.jsx
@@ -27,7 +27,7 @@ class List extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string
     };

--- a/src/menu-item/menu-item.jsx
+++ b/src/menu-item/menu-item.jsx
@@ -49,7 +49,7 @@ class MenuItem extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Только для type='link', обработчик клика по компоненту */
         onClick: Type.func,
         /** Обработчик фокуса компонента */

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -66,7 +66,7 @@ class Menu extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Обработчик клика по варианту меню */

--- a/src/notification/notification.jsx
+++ b/src/notification/notification.jsx
@@ -38,7 +38,7 @@ class Notification extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Заголовок сообщения */

--- a/src/paragraph/paragraph.jsx
+++ b/src/paragraph/paragraph.jsx
@@ -24,7 +24,7 @@ class Paragraph extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string
     };

--- a/src/plate/plate.jsx
+++ b/src/plate/plate.jsx
@@ -30,7 +30,7 @@ class Plate extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Обработчик клика по плашке */

--- a/src/popup-container-provider/popup-container-provider.jsx
+++ b/src/popup-container-provider/popup-container-provider.jsx
@@ -48,7 +48,7 @@ class PopupContainerProvider extends React.Component {
         /** Дочерние элементы контейнера */
         children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Объект со стилями */

--- a/src/popup-header/popup-header.jsx
+++ b/src/popup-header/popup-header.jsx
@@ -26,7 +26,7 @@ class PopupHeader extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Обработчик клика по кнопке закрытия */

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -55,7 +55,7 @@ import performance from '../performance';
 class Popup extends React.Component {
     static propTypes = {
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Дочерние элементы `Popup` */

--- a/src/progress-bar/progress-bar.jsx
+++ b/src/progress-bar/progress-bar.jsx
@@ -16,7 +16,7 @@ class ProgressBar extends Component {
         /** Размер компонента */
         size: Type.oneOf(['m']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string])
+        className: Type.string
     };
 
     static defaultProps = {

--- a/src/radio-group/radio-group.jsx
+++ b/src/radio-group/radio-group.jsx
@@ -34,7 +34,7 @@ class RadioGroup extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Лейбл для группы */
         label: Type.node,
         /** Подсказка под полем */

--- a/src/radio/radio.jsx
+++ b/src/radio/radio.jsx
@@ -45,7 +45,7 @@ class Radio extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Обработчик изменения значения 'checked' компонента, принимает на вход isChecked и value компонента */
         onChange: Type.func,
         /** Обработчик фокуса комнонента */

--- a/src/render-in-container/render-in-container.jsx
+++ b/src/render-in-container/render-in-container.jsx
@@ -17,7 +17,7 @@ class RenderInContainer extends React.Component {
         /** Дочерние элементы контейнера */
         children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Контейнер, в котором будет визуализирован компонент */
         container: HtmlElement,
         /** Callback на рендер компонента */

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -45,7 +45,7 @@ class SelectButton extends Button {}
 class Select extends React.Component {
     static propTypes = {
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Тип выпадающего списка */
         mode: Type.oneOf(['check', 'radio', 'radio-check']),
         /** Размещение заголовка групп: обычное или в одну строку с первым элементом группы */

--- a/src/sidebar/sidebar.jsx
+++ b/src/sidebar/sidebar.jsx
@@ -53,7 +53,7 @@ class Sidebar extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Дочерние компоненты */

--- a/src/slide-down/slide-down.jsx
+++ b/src/slide-down/slide-down.jsx
@@ -25,7 +25,7 @@ class SlideDown extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.string, Type.func]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string
     };

--- a/src/spin/spin.jsx
+++ b/src/spin/spin.jsx
@@ -22,7 +22,7 @@ class Spin extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string
     };

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -23,7 +23,7 @@ export default class Tabs extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Идентификатор компонента в DOM */
         id: Type.string
     };

--- a/src/textarea/textarea.jsx
+++ b/src/textarea/textarea.jsx
@@ -20,7 +20,7 @@ import { SCROLL_TO_CORRECTION } from '../vars';
 class Textarea extends React.Component {
     static propTypes = {
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Управление возможностью компонента занимать всю ширину родителя */
         width: Type.oneOf(['default', 'available']),
         /** Управление автозаполнением компонента */

--- a/src/theme-provider/theme-provider.jsx
+++ b/src/theme-provider/theme-provider.jsx
@@ -32,7 +32,7 @@ class ThemeProvider extends React.Component {
         /** Дочерний элемент `ThemeProvider` */
         children: Type.node,
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string]),
+        className: Type.string,
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white'])
     };


### PR DESCRIPTION
> Non-event attributes with function values:
> `<div className={function() {}} />`
> React 15: Converts functions to strings and passes them through.
> React 16: Warns and ignores them.

https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html#changes-in-detail