### PR TITLE
test(*): fix troubles between promise-based scroll-to tests & mq events

### DIFF
--- a/src/lib/scroll-to-test.js
+++ b/src/lib/scroll-to-test.js
@@ -22,7 +22,7 @@ describe('scroll-to', () => {
     beforeEach(() => {
         let domContainerNode = document.createElement('div');
         domContainerNode.setAttribute('id', 'container');
-        domContainerNode.setAttribute('style', 'min-width: 9999px; min-height: 9999px; margin: 0; padding: 0;');
+        domContainerNode.setAttribute('style', 'min-height: 9999px; margin: 0; padding: 0;');
         domContainerNode.innerHTML = `
             <div id='scroll-container' style='overflow: auto; width: 500px; height: 1000px;'>
                 <div style='width: 100%; height: 300px;'></div>


### PR DESCRIPTION
Исправление проблем с тестами на iOS Safari 10+.
Незадействованное увеличение ширины экрана вкупе с промисом в каждом тесте на `scroll-to` выстреливало пачку ивентов на изменение матчинга в `<Mq />`:
https://github.com/alfa-laboratory/arui-feather/blob/master/src/mq/mq.jsx#L41

Пачка ивентов триггерила массу `setState` дальше по дереву, в итоге можно было словить например здесь проблемы с множественными изменениями state и демонтирования компонента:
https://github.com/alfa-laboratory/arui-feather/blob/master/src/select/select.jsx#L263

Что вело к разного рода ошибкам, например:
```
  link
    ✖ should call `onClick` callback after link was clicked
      Mobile Safari 11.0.0 (iOS 11.1.0)
    NotFoundError (DOM Exception 8): The object can not be found here. (src/intl-phone-input/intl-phone-input-test.jsx:27382)
    click@[native code]
    src/link/link-test.jsx:25250:24
```

Стало заметно когда добавили `<IntlPhoneInput />`, в котором есть `<Select />`, в котором, в свою очередь, есть `<Mq />`. `<Mq />` теперь создавал инстанс `MediaQueryList` с listener до тестов `/lib/scroll-to`.

Проблема началась с warning:
```
  link
    ✖ should call `onClick` callback after link was clicked
      Mobile Safari 10.0.0 (iOS 10.3.0)
    Error: Warning: There is an internal error in the React performance measurement code. We did not expect componentWillUnmount timer to stop while no timer is still in progress for another instance. Please report this as a bug in React. (tools/karma-warnings.js:14)
    click@[native code]
    src/link/link-test.jsx:25222:24
```
https://travis-ci.org/alfa-laboratory/arui-feather/jobs/305787347

NB: Если подобные warning скрывать в сорцах `ReactDOM/lib/ReactDebugTool`, то дебаг становится сильно легче.
NB2: Инфа по теме: https://github.com/facebook/react/issues/6949#issuecomment-233318424