### PR TITLE
fix(menu): fix item highlighting on componentWillReceiveProps

### DIFF
--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -117,7 +117,8 @@ class Menu extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (this.props.mode !== 'check' && nextProps.checkedItems[0] !== this.state.checkedItems[0]) {
+        if (this.props.mode !== 'check' && this.state.checkedItems[0] &&
+            nextProps.checkedItems[0] !== this.state.checkedItems[0]) {
             let highlightedItem = null;
 
             this.menuItemList.forEach((item, index, menuItemList) => {


### PR DESCRIPTION
Фикс подсветки активного пункта меня на componentWillReceiveProps — есть случай с незаполненными `state.checkedItems` и например вызовом этого метода из-за ре-рендера родительского компонента (Select -> Popup, при изменении Mq), а не изменения самих props в `<Menu />`. В таких случаях нет смысла кидать лишний раз `props.onHighlightItem()`.