### PR TITLE
fix(intl-phone-input): optimizing intl-phone-input component

### DIFF
--- a/src/intl-phone-input/intl-phone-input-test.jsx
+++ b/src/intl-phone-input/intl-phone-input-test.jsx
@@ -126,11 +126,46 @@ describe('intl-phone-input', () => {
         expect(elem.node.querySelector('.flag-icon')).to.have.class('flag-icon_country_au');
     });
 
+    describe('handleSelectFocus method', () => {
+        const elem = render(<IntlPhoneInput />).instance;
+
+        beforeEach(() => {
+            elem.loadUtil = sinon.spy();
+            elem.resolveFocusedState = () => {};
+        });
+
+        it('should call `loadUtil` method if state.onceOpened is falsy', () => {
+            elem.setState({ onceOpened: false });
+            elem.handleSelectFocus();
+            expect(elem.loadUtil).to.have.callCount(1);
+        });
+
+        it('shouldn`t call `loadUtil` method if state.onceOpened is truly', () => {
+            elem.setState({ onceOpened: true });
+            elem.handleSelectFocus();
+            expect(elem.loadUtil).to.have.callCount(0);
+        });
+    });
+
+    describe('getOptions method', () => {
+        const elem = render(<IntlPhoneInput />).instance;
+
+        it('should return array with zero length if state.onceOpened is falsy', () => {
+            elem.setState({ onceOpened: false });
+            expect(elem.getOptions(() => {}).length).to.equal(0);
+        });
+
+        it('should return array with countries length if state.onceOpened is truly', () => {
+            elem.setState({ onceOpened: true });
+            expect(elem.getOptions(() => {}).length).to.equal(243);
+        });
+    });
+
     if (!bowser.mobile) {
         it('should call `onChange` callback after select was changed', () => {
             let onChange = sinon.spy();
 
-            render(<IntlPhoneInput onChange={ onChange } />);
+            render(<IntlPhoneInput onChange={ onChange } />).instance.setState({ onceOpened: true });
 
             let popupNode = document.querySelector('.popup');
             let firstOptionNode = popupNode.querySelector('.menu-item');
@@ -142,6 +177,7 @@ describe('intl-phone-input', () => {
 
         it('should focus on input after select was changed', (done) => {
             let elem = render(<IntlPhoneInput />);
+            elem.instance.setState({ onceOpened: true });
             let controlNode = elem.instance.getControl();
             let popupNode = document.querySelector('.popup');
             let firstOptionNode = popupNode.querySelector('.menu-item');

--- a/src/intl-phone-input/intl-phone-input.jsx
+++ b/src/intl-phone-input/intl-phone-input.jsx
@@ -48,7 +48,6 @@ class IntlPhoneInput extends React.Component {
     util;
 
     componentDidMount() {
-        this.loadUtil();
         this.setCountry();
     }
 
@@ -119,6 +118,7 @@ class IntlPhoneInput extends React.Component {
     @autobind
     handleSelectFocus(event) {
         if (!this.state.onceOpened) {
+            this.loadUtil();
             this.setState({
                 onceOpened: true
             });
@@ -178,7 +178,7 @@ class IntlPhoneInput extends React.Component {
     getOptions(cn) {
         this.countries = countries.getCountries();
 
-        return this.countries.map(country => ({
+        return this.state.onceOpened ? this.countries.map(country => ({
             value: country.iso2,
             text: (
                 <span>
@@ -192,7 +192,7 @@ class IntlPhoneInput extends React.Component {
                     { this.renderFlagIcon(country.iso2) }
                 </span>
             )
-        }));
+        })) : [];
     }
 
     getSelectPopupOffset() {


### PR DESCRIPTION
Оптимизация первой загрузки для компонента intl-phone-input

## Мотивация и контекст
На данный момент если intl-phone-input расположен на первой загружаемой странице, то все флаги стран и утилита грузится сразу. Это не есть хорошо, так как увеличивается время первоначальной загрузки страницы. Решением было перенести загрузку флагов и утилиты на момент фокуса на селекте с флагами.
