### PR TITLE
fix(link): fix security bug wich work via target='_blank'

### DIFF
--- a/src/link/link-test.jsx
+++ b/src/link/link-test.jsx
@@ -123,4 +123,14 @@ describe('link', () => {
         expect(node).to.be.instanceOf(HTMLElement);
         expect(node).to.be.equal(link.node);
     });
+
+    it('should render with rel="noreferrer noopener" when using target="_blank"', () => {
+        let link = render(<Link target='_blank' rel='noreferrer noopener' />);
+
+        let node = link.instance.getNode();
+
+        expect(node).to.be.have.attr('target');
+        expect(node).to.be.have.attr('rel');
+        expect(node.getAttribute('rel')).to.be.equal('noreferrer noopener');
+    });
 });

--- a/src/link/link.jsx
+++ b/src/link/link.jsx
@@ -95,6 +95,10 @@ class Link extends React.Component {
             onMouseLeave: this.handleMouseLeave
         };
 
+        if (this.props.target === '_blank') {
+            linkProps.rel = 'noreferrer noopener';
+        }
+
         if (!this.props.checked && !this.props.disabled) {
             linkProps.href = this.props.url;
             linkProps.target = this.props.target;


### PR DESCRIPTION
Исправил уязвимость связанную с target='_blank';

https://mathiasbynens.github.io/rel-noopener/

Вообще по хорошему передавать кастомные пропсы пользователей дальше в компонент. Вдруг кому - то нужно будет атрибут aria или другие атрибуты, но как - то с первого раза у меня не получилось это сделать, чуть позже предложу второй PR