### PR TITLE
feat(calendar-input): add max-min attribute for native calendar

### DIFF
--- a/README_MOBILE.md
+++ b/README_MOBILE.md
@@ -73,4 +73,4 @@ body { font-size: 16px };
 <a name="mobile-testing"></a>
 ## Автоматическое тестирование
 
-Временно: Запуск unit-тестов для тестирования в iOS Safari (необходим Xcode) `MOBILE=1 npm run karma`.
+Временно: Запуск unit-тестов для тестирования в iOS Safari (необходим Xcode) `MOBILE=1 npm run test`.

--- a/src/calendar-input/calendar-input-test.jsx
+++ b/src/calendar-input/calendar-input-test.jsx
@@ -217,6 +217,20 @@ describe('calendar-input', () => {
         expect(onInputChange).to.have.been.calledWith('01.08.2016');
     });
 
+    if (bowser.mobile) {
+        it('should set `max` attribute to `date`', () => {
+            let { inputNode } = renderCalendarInput({ max: '2017-12-25' });
+
+            expect(inputNode.max).to.equal('2017-12-25');
+        });
+
+        it('should set `min` attribute to `date`', () => {
+            let { inputNode } = renderCalendarInput({ min: '2017-12-25' });
+
+            expect(inputNode.min).to.equal('2017-12-25');
+        });
+    }
+
     if (!bowser.mobile) {
         it('should open calendar after input was focused', (done) => {
             let { calendarInput, popupNode } = renderCalendarInput();

--- a/src/calendar-input/calendar-input-test.jsx
+++ b/src/calendar-input/calendar-input-test.jsx
@@ -219,15 +219,23 @@ describe('calendar-input', () => {
 
     if (bowser.mobile) {
         it('should set `max` attribute to `date`', () => {
-            let { inputNode } = renderCalendarInput({ max: '2017-12-25' });
+            let calendar = {
+                laterLimit: 1514505600000
+            };
 
-            expect(inputNode.max).to.equal('2017-12-25');
+            let { inputNode } = renderCalendarInput({ calendar });
+
+            expect(inputNode.max).to.equal('2017-12-29');
         });
 
         it('should set `min` attribute to `date`', () => {
-            let { inputNode } = renderCalendarInput({ min: '2017-12-25' });
+            let calendar = {
+                earlierLimit: 1513900800000
+            };
 
-            expect(inputNode.min).to.equal('2017-12-25');
+            let { inputNode } = renderCalendarInput({ calendar });
+
+            expect(inputNode.min).to.equal('2017-12-22');
         });
     }
 

--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -4,6 +4,7 @@
 
 import { autobind } from 'core-decorators';
 import React from 'react';
+import formatDate from 'date-fns/format';
 import Type from 'prop-types';
 
 import Calendar from '../calendar/calendar';
@@ -76,10 +77,6 @@ class CalendarInput extends React.Component {
             'anchor', 'top-left', 'top-center', 'top-right', 'left-top', 'left-center', 'left-bottom', 'right-top',
             'right-center', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right'
         ])),
-        /** Значение максимально возможной даты при выборе в нативном календаре */
-        max: Type.string,
-        /** Значение минимально возможной даты при выборе в нативном календаре */
-        min: Type.string,
         /** Управление возможностью изменения значения компонента */
         disabled: Type.bool,
         /** Размер компонента */
@@ -220,8 +217,8 @@ class CalendarInput extends React.Component {
         };
 
         let nativeProps = {
-            max: this.props.max,
-            min: this.props.min
+            min: formatDate(this.props.calendar && this.props.calendar.earlierLimit, NATIVE_DATE_FORMAT),
+            max: formatDate(this.props.calendar && this.props.calendar.laterLimit, NATIVE_DATE_FORMAT)
         };
 
         let wrapperProps = this.isMobilePopup() && !this.props.disabled

--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -76,6 +76,10 @@ class CalendarInput extends React.Component {
             'anchor', 'top-left', 'top-center', 'top-right', 'left-top', 'left-center', 'left-bottom', 'right-top',
             'right-center', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right'
         ])),
+        /** Значение максимально возможной даты при выборе в нативном календаре */
+        max: Type.string,
+        /** Значение минимально возможной даты при выборе в нативном календаре */
+        min: Type.string,
         /** Управление возможностью изменения значения компонента */
         disabled: Type.bool,
         /** Размер компонента */
@@ -215,6 +219,11 @@ class CalendarInput extends React.Component {
             formNoValidate: true
         };
 
+        let nativeProps = {
+            max: this.props.max,
+            min: this.props.min
+        };
+
         let wrapperProps = this.isMobilePopup() && !this.props.disabled
             ? {
                 role: 'button',
@@ -240,6 +249,7 @@ class CalendarInput extends React.Component {
                                 this.nativeCalendarTarget = nativeCalendarTarget;
                             } }
                             { ...commonProps }
+                            { ...nativeProps }
                             className={ cn('native-control') }
                             type='date'
                             value={ changeDateFormat(value, CUSTOM_DATE_FORMAT, NATIVE_DATE_FORMAT) }


### PR DESCRIPTION
Добавить возможность задать аттрибуты max/min для нативного календаря.

## Мотивация и контекст
При использовании нативного календаря хотелось бы проставлять аттрибуты max/min.
