### PR TITLE
fix(calendar): fix Number.isFinite troubles in ie11

### DIFF
--- a/src/calendar/calendar.jsx
+++ b/src/calendar/calendar.jsx
@@ -432,9 +432,11 @@ class Calendar extends React.Component {
             return false;
         }
 
-        if (!(value instanceof Date) || !Number.isFinite(value.valueOf())) {
+        /* eslint-disable no-restricted-globals */
+        if (!(value instanceof Date) || !isFinite(value.valueOf())) {
             return false;
         }
+        /* eslint-enable no-restricted-globals */
 
         return !(
             (this.earlierLimit && this.earlierLimit > value) ||


### PR DESCRIPTION
Откатка изменений после https://github.com/alfa-laboratory/arui-feather/pull/425
`Number.isFinite` нет в IE11.
Если есть идеи как быстро сделать лучше — велкам.