### PR TITLE
feat(*): override default browser border-radius on controls

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -76,6 +76,7 @@
         line-height: inherit;
         background: none;
         border: none;
+        border-radius: 0;
         -webkit-appearance: none;
         -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 

--- a/src/textarea/textarea.css
+++ b/src/textarea/textarea.css
@@ -63,6 +63,7 @@
         font: inherit;
         background: none;
         border: none;
+        border-radius: 0;
         transition-duration: 250ms;
         transition-property: border-bottom-color, box-shadow, width;
         transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);


### PR DESCRIPTION
Оверрайд для предотвращения подобного:

![img_0148](https://user-images.githubusercontent.com/4638427/34990893-c2561330-fad8-11e7-8ad0-2eaf2fa570a9.PNG)
