### PR TITLE
fix(input): no need to set state if input value is controlled by input

### DIFF
--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -455,7 +455,9 @@ class Input extends React.Component {
      * @param {String} value Новое значение
      */
     changeValue(value) {
-        this.setState({ value });
+        if (this.props.value === undefined) {
+            this.setState({ value });
+        }
 
         if (this.props.onChange) {
             this.props.onChange(value);


### PR DESCRIPTION
Убрал выставление value в стейт для случая, если value передаётся с пропсами. Зачем надо? Об этом далее. (Воспроизводится в 16 реакте, при использовании редакс-форм)


В рендере если инпут привязан к валью в пропсах, то он игнорирует значение в стейте. 

При этом если мы делаем setState, в пропсы ещё не обновились, то у нас берётся предыдущее значение value из пропсов
        let value = this.props.value !== undefined
            ? this.props.value
            : this.state.value;

 и апдейтится value инпута на старое значение. 

Потом апдейтятся пропсы и компонент снова перерисовывается уже с новым значением, и каретка улетает в конец инпута.


Порочный воркфлоу такой:
Поехал changeValue -> setState -> (тут же рендер с предыдущим props.value) -> dispatch new props -> (снова рендер, но уже с новыми props.value)