### PR TITLE
feat(popup-container-provider): getNode method

### DIFF
--- a/src/popup-container-provider/popup-container-provider-test.jsx
+++ b/src/popup-container-provider/popup-container-provider-test.jsx
@@ -59,4 +59,17 @@ describe('popup-container-provider', () => {
 
         expect(popupNode).to.exist;
     });
+
+    it('should return root `HTMLElement` after `getNode` method call', () => {
+        let popupContainer = render(
+            <PopupContainerProvider>
+                <Popup target='position'>Render-test</Popup>
+            </PopupContainerProvider>
+        );
+
+        let node = popupContainer.instance.getNode();
+
+        expect(node).to.be.instanceOf(HTMLDivElement);
+        expect(node).to.be.equal(popupContainer.node);
+    });
 });

--- a/src/popup-container-provider/popup-container-provider.jsx
+++ b/src/popup-container-provider/popup-container-provider.jsx
@@ -103,6 +103,16 @@ class PopupContainerProvider extends React.Component {
             didRender: true // eslint-disable-line react/no-unused-state
         });
     }
+
+    /**
+     * Возвращает корневой `HTMLElement` компонента.
+     *
+     * @public
+     * @returns {HTMLElement}
+     */
+    getNode() {
+        return this.positioningContainer;
+    }
 }
 
 export default PopupContainerProvider;


### PR DESCRIPTION
Добавил метод getNode в popup-container-provider

## Мотивация и контекст
Необходим для сохранения обратной совместимости с React v15 в редких случаях с модалками