### PR TITLE
refactor(*): remove acorn low version in deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -326,12 +326,6 @@
         "through2": "2.0.3"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -412,9 +406,9 @@
       }
     },
     "acorn": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
+      "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -441,6 +435,14 @@
       "dev": true,
       "requires": {
         "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
       }
     },
     "acorn-node": {
@@ -451,14 +453,6 @@
       "requires": {
         "acorn": "5.5.0",
         "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        }
       }
     },
     "add-stream": {
@@ -2891,12 +2885,6 @@
         "vlq": "1.0.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        },
         "acorn-dynamic-import": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
@@ -5887,14 +5875,6 @@
       "requires": {
         "acorn": "5.5.0",
         "defined": "1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        }
       }
     },
     "di": {
@@ -6939,14 +6919,6 @@
       "requires": {
         "acorn": "5.5.0",
         "acorn-jsx": "3.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -14345,12 +14317,6 @@
         "vinyl": "2.1.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        },
         "clone": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
@@ -23876,12 +23842,6 @@
         "through2": "0.4.2"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        },
         "duplexer2": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
@@ -26690,12 +26650,6 @@
         "yargs": "8.0.2"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
-          "dev": true
-        },
         "ajv": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "react-dom": ">=15.6"
   },
   "devDependencies": {
-    "acorn": "3.3.0",
     "alfa-ui-primitives": "1.3.1",
     "arui-presets": "4.11.11",
     "bowser": "1.9.2",


### PR DESCRIPTION
Удаление явно указанной версии `acorn` для работоспособности одной из предыдущих версий `react-syleguidist`. С последними версиями всё хорошо.