### PR TITLE
fix(intl-phone-input): remove restriction of phone number length

### DIFF
--- a/src/intl-phone-input/intl-phone-input-test.jsx
+++ b/src/intl-phone-input/intl-phone-input-test.jsx
@@ -114,17 +114,6 @@ describe('intl-phone-input', () => {
         expect(onChange).to.have.been.calledWith('+74957888878');
     });
 
-    it('shouldn`t change input value if new value length more then asYouType template length', () => {
-        const elem = render(<IntlPhoneInput />).instance;
-        elem.setState = sinon.spy();
-        elem.asYouType = { template: 'xx xxx xxx xx xx' };
-        elem.state.inputValue = '+7 495 788 88 87';
-
-        simulate(elem.getControl(), 'change', { target: { value: '+7 495 788 88 879' } });
-
-        expect(elem.setState).to.have.been.calledWith({ inputValue: '+7 495 788 88 87' });
-    });
-
     it('should have default country flag icon', () => {
         let elem = render(<IntlPhoneInput />);
 

--- a/src/intl-phone-input/intl-phone-input.jsx
+++ b/src/intl-phone-input/intl-phone-input.jsx
@@ -168,17 +168,9 @@ class IntlPhoneInput extends React.Component {
 
     @autobind
     handleInputChange(value) {
-        let resultValue = value.length === 1 && value !== '+' ? `+${value}` : value;
-
-        if (
-            this.asYouType && this.asYouType.template &&
-            this.asYouType.template.length < resultValue.length &&
-            this.asYouType.template.length > MAX_DIAL_CODE_LENGTH
-        ) {
-            resultValue = this.state.inputValue;
-        }
-
-        this.setState({ inputValue: resultValue }, this.setCountry);
+        this.setState({
+            inputValue: value.length === 1 && value !== '+' ? `+${value}` : value
+        }, this.setCountry);
     }
 
     @autobind


### PR DESCRIPTION
Делаем проверку на длину введенного номера только для российских номеров.
Так как с иностранными номерами могут быть нюансы, то ограничивать их на ввод по длине не будем.