### PR TITLE
fix(calendar): fix calendar blur on last month page

### DIFF
--- a/src/calendar/calendar.css
+++ b/src/calendar/calendar.css
@@ -145,6 +145,9 @@
     &__arrow_disabled {
         pointer-events: none;
         cursor: default;
-        opacity: 0;
+
+        &, &:hover {
+            opacity: 0;
+        }
     }
 }

--- a/src/calendar/calendar.css
+++ b/src/calendar/calendar.css
@@ -143,6 +143,8 @@
     }
 
     &__arrow_disabled {
-        visibility: hidden;
+        pointer-events: none;
+        cursor: default;
+        opacity: 0;
     }
 }


### PR DESCRIPTION
Изменил стили кнопки навигации календаря

## Мотивация и контекст
Сейчас при переходе на последнюю страницу календаря, кнопке ставится стиль `visibility: hidden`. По этому происходит блюр и в случае `CalendarInput` popup календарь скрывается.

Скрины проблемы:

<img width="620" alt="screen shot 2018-03-01 at 15 17 45" src="https://user-images.githubusercontent.com/10559998/36845540-3a157f26-1d68-11e8-84c3-f0997639ed90.png">
<img width="620" alt="bug" src="https://user-images.githubusercontent.com/10559998/36845744-edb5be1a-1d68-11e8-9f4f-7e1bb24cf8e8.gif">

