### PR TITLE
fix(calendar): Fixed period selection in calendar

### DIFF
--- a/src/calendar/calendar.jsx
+++ b/src/calendar/calendar.jsx
@@ -643,7 +643,7 @@ class Calendar extends React.Component {
         }
 
         if (isInitializing || this.props.selectedTo !== nextProps.selectedTo) {
-            this.selectedFrom = nextProps.selectedTo ? normalizeDate(nextProps.selectedTo) : null;
+            this.selectedTo = nextProps.selectedTo ? normalizeDate(nextProps.selectedTo) : null;
         }
 
         if (isInitializing || this.props.selectedFrom !== nextProps.selectedFrom) {


### PR DESCRIPTION
Исправлен баг календаря при отображении диапазона дат

Значение записывалось в selectedFrom вместо selectedTo, поэтому даты внутри диапазона не окрашивались.