### PR TITLE
feat(label): add 2xl, 3xl, 4xl sizes to label

### DIFF
--- a/src/label/label.css
+++ b/src/label/label.css
@@ -39,6 +39,18 @@
     &_size_xl {
         font-size: var(--font-size-xl);
     }
+
+    &_size_2xl {
+        font-size: var(--font-size-2xl);
+    }
+
+    &_size_3xl {
+        font-size: var(--font-size-3xl);
+    }
+
+    &_size_4xl {
+        font-size: var(--font-size-4xl);
+    }
 }
 
 .label_theme_alfa-on-color {

--- a/src/label/label.jsx
+++ b/src/label/label.jsx
@@ -16,7 +16,7 @@ import performance from '../performance';
 class Label extends React.Component {
     static propTypes = {
         /** Размер компонента */
-        size: Type.oneOf(['s', 'm', 'l', 'xl']),
+        size: Type.oneOf(['s', 'm', 'l', 'xl', '2xl', '3xl', '4xl']),
         /** Дочерние элементы `Label` */
         children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
         /** Тема компонента */


### PR DESCRIPTION
Добавление недостающих размеров для компонента Label

## Мотивация и контекст
Для того, чтобы не каскадить стили компонентов из feather и покрывать требования макетов, предлагаю добавить недостающие размеры для компонента Label.
