### PR TITLE
Feat/rewrite resize sensor with resize observer api

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ npm install arui-feather --save
 
 Запуск unit-тестов `npm run test`.
 
-Запуск unit-тестов для определенных компонентов `TESTS=amount,calendar npm run test`.
+Запуск unit-тестов для определенных компонентов `SUITES=amount,calendar npm run test`.
 
 Запуск unit-тестов используя Chrome `npm run test -- --browsers=Chrome`
 

--- a/karma.benchmark.config.js
+++ b/karma.benchmark.config.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* eslint global-require: 0 */
+/* eslint import/no-extraneous-dependencies: [2, {"devDependencies": true}] */
+
+const buildConfig = require('./karma.config-builder');
+
+const { SUITES } = process.env;
+
+function getTestFiles(tests, postfix) {
+    return tests.split(',').map(testName => `./src/${testName}/*-${postfix}.{js,jsx}`);
+}
+
+module.exports = (baseConfig) => {
+    const config = buildConfig({
+        frameworks: ['mocha', 'chai'],
+        reporters: ['mocha'],
+        plugins: [
+            require('karma-mocha'),
+            require('karma-chai'),
+            require('karma-mocha-reporter')
+        ],
+        files: SUITES ? getTestFiles(SUITES, 'benchmark') : ['./src/**/*-benchmark.js?(x)'],
+        proxies: {
+            '/stats': 'http://localhost:8186/write'
+        }
+    });
+
+    baseConfig.set(config);
+};

--- a/karma.common.config.js
+++ b/karma.common.config.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* eslint global-require: 0 */
+/* eslint import/no-extraneous-dependencies: [2, {"devDependencies": true}] */
+
+const buildConfig = require('./karma.config-builder');
+
+const { SUITES } = process.env;
+
+function getTestFiles(tests, postfix) {
+    return tests.split(',').map(testName => `./src/${testName}/*-${postfix}.{js,jsx}`);
+}
+
+module.exports = (baseConfig) => {
+    const config = buildConfig({
+        frameworks: ['mocha', 'chai', 'chai-dom', 'sinon-chai'],
+        reporters: ['mocha', 'coverage-istanbul'],
+        coverageIstanbulReporter: {
+            reports: ['lcov', 'text'],
+            fixWebpackSourcePaths: true
+        },
+        coverageReporter: {
+            check: {
+                global: {
+                    statements: 86,
+                    branches: 80,
+                    functions: 95,
+                    lines: 40
+                }
+            }
+        },
+        plugins: [
+            require('karma-mocha'),
+            require('karma-chai'),
+            require('karma-chai-dom'),
+            require('karma-sinon-chai'),
+            require('karma-coverage'),
+            require('karma-coverage-istanbul-reporter'),
+            require('karma-mocha-reporter')
+        ],
+        files: SUITES ? getTestFiles(SUITES, 'test') : ['./src/**/*-test.js?(x)'],
+        webpack: {
+            module: {
+                rules: [
+                    {
+                        test: /\.jsx?$/,
+                        use: {
+                            loader: 'istanbul-instrumenter-loader',
+                            options: { esModules: true }
+                        },
+                        enforce: 'post',
+                        exclude: [
+                            /node_modules/,
+                            /-test\.jsx?$/,
+                            /(cn|modernizr|polyfills|-utils|vars)\.js$/,
+                            /(countries|currency-codes|easings|keyboard-code)\.js$/
+                        ]
+                    }
+                ]
+            }
+        }
+    });
+
+    baseConfig.set(config);
+};

--- a/karma.config-builder.js
+++ b/karma.config-builder.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* eslint global-require: 0 */
 /* eslint import/no-extraneous-dependencies: [2, {"devDependencies": true}] */
 /* eslint strict: [0, "global"] */
@@ -10,21 +14,22 @@ const WEBPACK_DEV_TEMPLATE = require('arui-presets/webpack.development');
 
 const IS_MOBILE = !!process.env.MOBILE;
 
-function getTestsGlobs(tests, postfix) {
-    return tests.split(',').map(testName => `./src/${testName}/*-${postfix}.{js,jsx}`);
-}
-
 let babelLoaderConfig = WEBPACK_BASE_TEMPLATE.module.rules.find(l => /babel-loader/.test(l.loader));
 delete babelLoaderConfig.exclude;
 
-module.exports = (config) => {
+module.exports = (options) => {
     let cfg = {
+        preprocessors: {
+            './src/**/*': ['webpack', 'sourcemap']
+        },
+        captureConsole: true,
+        logLevel: 'WARN',
         singleRun: true,
         plugins: [
             require('karma-webpack'),
-            require('karma-sourcemap-loader'),
-            require('karma-coverage-istanbul-reporter')
+            require('karma-sourcemap-loader')
         ],
+        files: ['./src/polyfills.js', './tools/karma-warnings.js'],
         webpack: merge.smart(WEBPACK_BASE_TEMPLATE, WEBPACK_DEV_TEMPLATE, {
             devtool: 'inline-source-map'
         }),
@@ -33,62 +38,6 @@ module.exports = (config) => {
             quiet: true
         }
     };
-
-    cfg.webpack.module.rules.push({
-        test: /\.jsx?$/,
-        use: {
-            loader: 'istanbul-instrumenter-loader',
-            options: { esModules: true }
-        },
-        enforce: 'post',
-        exclude: [
-            /node_modules/,
-            /-test\.jsx?$/,
-            /(cn|modernizr|polyfills|test-utils|vars)\.js$/,
-            /(countries|currency-codes|easings|keyboard-code)\.js$/
-        ]
-    });
-
-    let testsFiles = !process.env.TESTS
-        ? ['./src/**/*-test.js?(x)']
-        : getTestsGlobs(process.env.TESTS, 'test');
-
-    testsFiles.unshift('./src/polyfills.js');
-    testsFiles.unshift('./tools/karma-warnings.js');
-
-    Object.assign(cfg, {
-        frameworks: ['mocha', 'chai-dom', 'chai', 'sinon-chai'],
-        reporters: ['mocha', 'coverage-istanbul'],
-        preprocessors: {
-            './src/**/*': ['webpack', 'sourcemap']
-        },
-        files: testsFiles,
-        coverageIstanbulReporter: {
-            reports: ['lcov', 'text'],
-            fixWebpackSourcePaths: true
-        },
-        captureConsole: true,
-        coverageReporter: {
-            check: {
-                global: {
-                    statements: 86,
-                    branches: 80,
-                    functions: 95,
-                    lines: 40
-                }
-            }
-        },
-        logLevel: cfg.LOG_DEBUG
-    });
-
-    cfg.plugins.push(
-        require('karma-mocha'),
-        require('karma-chai'),
-        require('karma-chai-dom'),
-        require('karma-mocha-reporter'),
-        require('karma-coverage'),
-        require('karma-sinon-chai')
-    );
 
     if (IS_MOBILE) {
         cfg.customLaunchers = {
@@ -136,5 +85,5 @@ module.exports = (config) => {
 
     cfg.browsers = Object.keys(cfg.customLaunchers);
 
-    config.set(cfg);
+    return merge.smart(cfg, options);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,6 +3492,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -4695,7 +4696,7 @@
         "is-directory": "0.3.1",
         "js-yaml": "3.11.0",
         "parse-json": "4.0.0",
-        "require-from-string": "2.0.1"
+        "require-from-string": "2.0.2"
       },
       "dependencies": {
         "parse-json": {
@@ -8678,6 +8679,1024 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        }
+      }
+    },
     "ftp": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
@@ -11367,7 +12386,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
       "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
       "requires": {
-        "safer-buffer": "2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "icss-replace-symbols": {
@@ -21042,6 +22061,12 @@
       "integrity": "sha512-l0iUmKZxKmMAtr9x/6lcHgAMmUZIVufRd0YdTKIe6Y/4Fv4z+0nvaInPituRep/hpeG5WUoEVaZoIV7qEltfDg==",
       "dev": true
     },
+    "react-component-benchmark": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/react-component-benchmark/-/react-component-benchmark-0.0.4.tgz",
+      "integrity": "sha1-7uNYXiIDZF7ZaKQAIPYH2JvIL2Q=",
+      "dev": true
+    },
     "react-component-info": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/react-component-info/-/react-component-info-1.1.2.tgz",
@@ -21297,9 +22322,9 @@
       "dev": true
     },
     "react-group": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/react-group/-/react-group-1.0.5.tgz",
-      "integrity": "sha1-ygfWjLuubZklCCnhwy94JYdpPAc=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-group/-/react-group-1.0.6.tgz",
+      "integrity": "sha1-jdfADDs10FzhZAIUWLsH1YDjABo=",
       "dev": true,
       "requires": {
         "prop-types": "15.6.1"
@@ -21414,7 +22439,7 @@
         "react-docgen": "3.0.0-beta9",
         "react-docgen-annotation-resolver": "1.0.0",
         "react-docgen-displayname-handler": "1.0.1",
-        "react-group": "1.0.5",
+        "react-group": "1.0.6",
         "react-icons": "2.2.7",
         "remark": "8.0.0",
         "semver-utils": "1.1.2",
@@ -22314,9 +23339,9 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-from-string": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
-      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {
@@ -22535,9 +23560,9 @@
       }
     },
     "safer-buffer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.0.tgz",
-      "integrity": "sha512-HQhCIIl7TrF1aa7d352EXG+xumPERvoIWxOqq2CagDId0FVGtlG/fuQ7kZT+wZ7ytyGiP3pnYUVni5otBzOVmA=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "samsam": {
       "version": "1.3.0",
@@ -26041,6 +27066,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.2",
+            "fsevents": "1.1.3",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -26950,6 +27976,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.2",
+            "fsevents": "1.1.3",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15932,6 +15932,12 @@
         }
       }
     },
+    "lodash.defaultsdeep": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz",
+      "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=",
+      "dev": true
+    },
     "lodash.escape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15932,12 +15932,6 @@
         }
       }
     },
-    "lodash.defaultsdeep": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz",
-      "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=",
-      "dev": true
-    },
     "lodash.escape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "git+https://github.com/alfa-laboratory/arui-feather.git"
   },
   "scripts": {
-    "test": "karma start ./karma.config.js",
+    "test": "karma start ./karma.common.config.js",
+    "benchmark": "karma start ./karma.benchmark.config.js",
     "lint": "npm run lint-css && npm run lint-js",
     "lint-js": "eslint ./*.js ./src/ ./gemini/ --ext .js,.jsx",
     "lint-md": "eslint -c .eslintrc.styleguide.js ./src/ --ext .md",
@@ -117,7 +118,6 @@
     "conventional-github-releaser": "2.0.0",
     "coveralls": "3.0.0",
     "del": "3.0.0",
-    "es6-promise": "4.2.4",
     "eslint-plugin-markdown": "1.0.0-beta.6",
     "gemini": "5.5.0",
     "gemini-babel": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "mkdirp": "0.5.1",
     "mocha": "5.0.1",
     "react": "16.2.0",
+    "react-component-benchmark": "0.0.4",
     "react-dom": "16.2.0",
     "react-frame-component": "2.0.2",
     "react-hot-loader": "3.1.3",

--- a/src/amount/amount-benchmark.jsx
+++ b/src/amount/amount-benchmark.jsx
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Amount from './amount';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Amount, {
+    amount: {
+        value: 123314145,
+        currency: {
+            code: 'RUR',
+            minority: 100
+        }
+    }
+});

--- a/src/attach/attach-benchmark.jsx
+++ b/src/attach/attach-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Attach from './attach';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Attach);

--- a/src/benchmark-utils.jsx
+++ b/src/benchmark-utils.jsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* eslint import/no-extraneous-dependencies: [2, {"devDependencies": true}] */
+/* eslint import/prefer-default-export: 0 */
 
 import bowser from 'bowser';
 import React from 'react';
@@ -31,7 +32,7 @@ const REACT_VERSION = React.version;
  * @param {Object} componentProps Свойства для измеряемого компонента.
  * @param {Number} threshold Пороговое значение для тестирования.
  */
-export default function runBenchmark(component, componentProps, threshold = 20) {
+export function runBenchmark(component, componentProps, threshold = 20) {
     let { name } = component;
 
     describe(name, () => {

--- a/src/benchmark-utils.jsx
+++ b/src/benchmark-utils.jsx
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* eslint import/no-extraneous-dependencies: [2, {"devDependencies": true}] */
+
+import bowser from 'bowser';
+import React from 'react';
+import Benchmark from 'react-component-benchmark';
+import { render, cleanUp } from './test-utils';
+
+/**
+ * Набор типов событий для тестирования производительности компонентов.
+ */
+const BENCHMARK_TYPES = [
+    'mount', 'update', 'unmount'
+];
+
+/**
+ * Количество прогонов в бенчмарке.
+ */
+const SAMPLES_QTY = 100;
+
+const BROWSER = bowser.name;
+const REACT_VERSION = React.version;
+
+/**
+ * Запускает бенчмарк.
+ *
+ * @param {Object} component Компонент для измерения.
+ * @param {Object} componentProps Свойства для измеряемого компонента.
+ * @param {Number} threshold Пороговое значение для тестирования.
+ */
+export default function runBenchmark(component, componentProps, threshold = 20) {
+    let { name } = component;
+
+    describe(name, () => {
+        let result = 0;
+        let props = {
+            component,
+            componentProps,
+            samples: SAMPLES_QTY
+        };
+
+        afterEach(cleanUp);
+
+        beforeEach(() => { result = 0; });
+
+        BENCHMARK_TYPES.forEach((type) => {
+            it(`should ${type} in expected time`, () => {
+                props.onComplete = (results) => {
+                    result = results.p99;
+                    // Post results to stats collector
+                    fetch('/stats', {
+                        method: 'POST',
+                        body: `${name},type=${type},browser=${BROWSER},react=${REACT_VERSION} value=${result}`
+                    });
+                };
+
+                let component = render(<Benchmark { ...props } type={ type } />);
+
+                component.instance.start();
+
+                expect(result).to.be.below(threshold);
+            });
+        });
+    });
+}

--- a/src/button/button-benchmark.jsx
+++ b/src/button/button-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Button from './button';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Button, {
+    children: 'Button'
+});

--- a/src/calendar-input/calendar-input-benchmark.jsx
+++ b/src/calendar-input/calendar-input-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import CalendarInput from './calendar-input';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(CalendarInput, {}, 50);

--- a/src/calendar/calendar-benchmark.jsx
+++ b/src/calendar/calendar-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Calendar from './calendar';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Calendar);

--- a/src/card-input/card-input-benchmark.jsx
+++ b/src/card-input/card-input-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import CardInput from './card-input';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(CardInput);

--- a/src/checkbox-group/checkbox-group-benchmark.jsx
+++ b/src/checkbox-group/checkbox-group-benchmark.jsx
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import CheckboxGroup from './checkbox-group';
+import Checkbox from '../checkbox';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(CheckboxGroup, {
+    children: <Checkbox key='1' />
+});

--- a/src/checkbox/checkbox-benchmark.jsx
+++ b/src/checkbox/checkbox-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Checkbox from './checkbox';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Checkbox);

--- a/src/collapse/collapse-benchmark.jsx
+++ b/src/collapse/collapse-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Collapse from './collapse';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Collapse, {
+    children: 'Collapse'
+}, 50);

--- a/src/collapse/collapse-test.jsx
+++ b/src/collapse/collapse-test.jsx
@@ -2,128 +2,187 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Benchmark from 'react-component-benchmark';
 import { render, cleanUp } from '../test-utils';
 
 import Collapse from './collapse';
 
+const TEXT = 'Collapsing text';
+
 describe('collapse', () => {
     afterEach(cleanUp);
 
-    it('should render without problem', () => {
-        let collapse = render(<Collapse>Collapsing text</Collapse>);
+    describe('common', () => {
+        it('should render without problem', () => {
+            let collapse = render(<Collapse>{ TEXT }</Collapse>);
 
-        expect(collapse.node).to.exist;
-        expect(collapse.node).to.have.class('collapse');
-    });
+            expect(collapse.node).to.exist;
+            expect(collapse.node).to.have.class('collapse');
+        });
 
-    it('should call `onExpandedChange` callback after expand/collapse', () => {
-        let onExpandedChange = sinon.spy();
-        let collapse = render(
-            <Collapse
-                collapsedLabel='Expand'
-                expandedLabel='Collapse'
-                onExpandedChange={ onExpandedChange }
-            >
-                Collapsing text
-            </Collapse>
-        );
-        let linkNode = collapse.node.querySelector('.link');
-
-        linkNode.click();
-
-        expect(onExpandedChange).to.have.been.calledOnce;
-    });
-
-    it('should update component height', (done) => {
-        const HEIGHT_DELTA = 100;
-        let collapse = render(
-            <Collapse
-                collapsedLabel='Expand'
-                expandedLabel='Collapse'
-            >
-                <div
-                    id='pusher'
-                    style={ { width: '100%', height: '10px' } }
-                />
-            </Collapse>
-        );
-        let collapseContent = collapse.node.querySelector('.collapse__content');
-        let linkNode = collapse.node.querySelector('.link');
-
-        setTimeout(() => {
-            document.getElementById('pusher').style.height = `${HEIGHT_DELTA}px`;
+        it('should call `onExpandedChange` callback after expand/collapse', () => {
+            let onExpandedChange = sinon.spy();
+            let collapse = render(
+                <Collapse
+                    collapsedLabel='Expand'
+                    expandedLabel='Collapse'
+                    onExpandedChange={ onExpandedChange }
+                >
+                    { TEXT }
+                </Collapse>
+            );
+            let linkNode = collapse.node.querySelector('.link');
 
             linkNode.click();
 
+            expect(onExpandedChange).to.have.been.calledOnce;
+        });
+
+        it('should update component height', (done) => {
+            const HEIGHT_DELTA = 100;
+            let collapse = render(
+                <Collapse
+                    collapsedLabel='Expand'
+                    expandedLabel='Collapse'
+                >
+                    <div
+                        id='pusher'
+                        style={ { width: '100%', height: '10px' } }
+                    />
+                </Collapse>
+            );
+            let collapseContent = collapse.node.querySelector('.collapse__content');
+            let linkNode = collapse.node.querySelector('.link');
+
             setTimeout(() => {
-                expect(collapseContent.style.height).to.equal(`${HEIGHT_DELTA}px`);
-                done();
+                document.getElementById('pusher').style.height = `${HEIGHT_DELTA}px`;
+
+                linkNode.click();
+
+                setTimeout(() => {
+                    expect(collapseContent.style.height).to.equal(`${HEIGHT_DELTA}px`);
+                    done();
+                }, 0);
             }, 0);
-        }, 0);
+        });
+
+        it('should not update component height when it is collapsed', (done) => {
+            const HEIGHT_DELTA = 100;
+            let collapse = render(
+                <Collapse
+                    collapsedLabel='Expand'
+                    expandedLabel='Collapse'
+                >
+                    <div
+                        id='pusher'
+                        style={ { width: '100%', height: '0px' } }
+                    />
+                </Collapse>
+            );
+            let initialComponentHeight = collapse.node.offsetHeight;
+
+            document.getElementById('pusher').style.height = `${HEIGHT_DELTA}px`;
+
+            setTimeout(() => {
+                expect(collapse.node.offsetHeight).to.equal(initialComponentHeight);
+                done();
+            }, 1000);
+        });
+
+        it('should apply custom expanded label', () => {
+            let collapse = render(
+                <Collapse
+                    collapsedLabel='Раскрыть'
+                    isExpanded={ false }
+                >
+                    { TEXT }
+                </Collapse>
+            );
+            let linkNode = collapse.node.querySelector('.link');
+
+            expect(linkNode).to.have.text('Раскрыть');
+        });
+
+        it('should apply custom collapsed label', () => {
+            let collapse = render(
+                <Collapse
+                    expandedLabel='Закрыть'
+                    isExpanded={ true }
+                >
+                    { TEXT }
+                </Collapse>
+            );
+            let linkNode = collapse.node.querySelector('.link');
+
+            expect(linkNode).to.have.text('Закрыть');
+        });
+
+        it('should have default expanded label', () => {
+            let collapse = render(<Collapse isExpanded={ false }>{ TEXT }</Collapse>);
+            let linkNode = collapse.node.querySelector('.link');
+
+            expect(linkNode).to.have.text('Expand');
+        });
+
+        it('should have default collapsed label', () => {
+            let collapse = render(<Collapse isExpanded={ true }>{ TEXT }</Collapse>);
+            let linkNode = collapse.node.querySelector('.link');
+
+            expect(linkNode).to.have.text('Collapse');
+        });
     });
 
-    it('should not update component height when it is collapsed', (done) => {
-        const HEIGHT_DELTA = 100;
-        let collapse = render(
-            <Collapse
-                collapsedLabel='Expand'
-                expandedLabel='Collapse'
-            >
-                <div
-                    id='pusher'
-                    style={ { width: '100%', height: '0px' } }
-                />
-            </Collapse>
-        );
-        let initialComponentHeight = collapse.node.offsetHeight;
+    describe('benchmark', () => {
+        let meanTime;
+        let props;
 
-        document.getElementById('pusher').style.height = `${HEIGHT_DELTA}px`;
+        beforeEach(() => {
+            meanTime = 0;
+            props = {
+                component: Collapse,
+                componentProps: {
+                    children: TEXT
+                },
+                onComplete: (results) => {
+                    console.log(results);
+                    meanTime = results.mean;
+                },
+                samples: 100
+            };
+        });
 
-        setTimeout(() => {
-            expect(collapse.node.offsetHeight).to.equal(initialComponentHeight);
-            done();
-        }, 1000);
-    });
+        it('should mount in a reasonable amount of time', () => {
+            var hz;
+            var period;
+            var startTime = new Date;
+            var runs = 0;
+            var totalTime = 0;
+            do {
+            	// Code snippet goes here.
+                let component = render(<Benchmark { ...props } type='mount' />);
+                component.instance.start();
+                console.log(meanTime);
+                console.log('$$$');
 
-    it('should apply custom expanded label', () => {
-        let collapse = render(
-            <Collapse
-                collapsedLabel='Раскрыть'
-                isExpanded={ false }
-            >
-                Collapsing text
-            </Collapse>
-        );
-        let linkNode = collapse.node.querySelector('.link');
+            	runs++;
+            	totalTime = new Date - startTime;
+            } while (totalTime < 1000);
 
-        expect(linkNode).to.have.text('Раскрыть');
-    });
+            // Convert milliseconds to seconds.
+            totalTime /= 1000;
 
-    it('should apply custom collapsed label', () => {
-        let collapse = render(
-            <Collapse
-                expandedLabel='Закрыть'
-                isExpanded={ true }
-            >
-                Collapsing text
-            </Collapse>
-        );
-        let linkNode = collapse.node.querySelector('.link');
+            // period → how long each operation takes
+            period = totalTime / runs;
 
-        expect(linkNode).to.have.text('Закрыть');
-    });
+            // hz → the number of operations per second.
+            hz = 1 / period;
 
-    it('should have default expanded label', () => {
-        let collapse = render(<Collapse isExpanded={ false }>Collapsing text</Collapse>);
-        let linkNode = collapse.node.querySelector('.link');
+            console.log(period);
+            console.log(hz);
+            console.log('#!@#!@#!@');
+            console.log('########');
 
-        expect(linkNode).to.have.text('Expand');
-    });
-
-    it('should have default collapsed label', () => {
-        let collapse = render(<Collapse isExpanded={ true }>Collapsing text</Collapse>);
-        let linkNode = collapse.node.querySelector('.link');
-
-        expect(linkNode).to.have.text('Collapse');
+            // expect(meanTime).to.be.less.than(10);
+        });
     });
 });

--- a/src/collapse/collapse-test.jsx
+++ b/src/collapse/collapse-test.jsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Benchmark from 'react-component-benchmark';
 import { render, cleanUp } from '../test-utils';
 
 import Collapse from './collapse';
@@ -12,177 +11,121 @@ const TEXT = 'Collapsing text';
 describe('collapse', () => {
     afterEach(cleanUp);
 
-    describe('common', () => {
-        it('should render without problem', () => {
-            let collapse = render(<Collapse>{ TEXT }</Collapse>);
+    it('should render without problem', () => {
+        let collapse = render(<Collapse>{ TEXT }</Collapse>);
 
-            expect(collapse.node).to.exist;
-            expect(collapse.node).to.have.class('collapse');
-        });
+        expect(collapse.node).to.exist;
+        expect(collapse.node).to.have.class('collapse');
+    });
 
-        it('should call `onExpandedChange` callback after expand/collapse', () => {
-            let onExpandedChange = sinon.spy();
-            let collapse = render(
-                <Collapse
-                    collapsedLabel='Expand'
-                    expandedLabel='Collapse'
-                    onExpandedChange={ onExpandedChange }
-                >
-                    { TEXT }
-                </Collapse>
-            );
-            let linkNode = collapse.node.querySelector('.link');
+    it('should call `onExpandedChange` callback after expand/collapse', () => {
+        let onExpandedChange = sinon.spy();
+        let collapse = render(
+            <Collapse
+                collapsedLabel='Expand'
+                expandedLabel='Collapse'
+                onExpandedChange={ onExpandedChange }
+            >
+                { TEXT }
+            </Collapse>
+        );
+        let linkNode = collapse.node.querySelector('.link');
+
+        linkNode.click();
+
+        expect(onExpandedChange).to.have.been.calledOnce;
+    });
+
+    it('should update component height', (done) => {
+        const HEIGHT_DELTA = 100;
+        let collapse = render(
+            <Collapse
+                collapsedLabel='Expand'
+                expandedLabel='Collapse'
+            >
+                <div
+                    id='pusher'
+                    style={ { width: '100%', height: '10px' } }
+                />
+            </Collapse>
+        );
+        let collapseContent = collapse.node.querySelector('.collapse__content');
+        let linkNode = collapse.node.querySelector('.link');
+
+        setTimeout(() => {
+            document.getElementById('pusher').style.height = `${HEIGHT_DELTA}px`;
 
             linkNode.click();
 
-            expect(onExpandedChange).to.have.been.calledOnce;
-        });
-
-        it('should update component height', (done) => {
-            const HEIGHT_DELTA = 100;
-            let collapse = render(
-                <Collapse
-                    collapsedLabel='Expand'
-                    expandedLabel='Collapse'
-                >
-                    <div
-                        id='pusher'
-                        style={ { width: '100%', height: '10px' } }
-                    />
-                </Collapse>
-            );
-            let collapseContent = collapse.node.querySelector('.collapse__content');
-            let linkNode = collapse.node.querySelector('.link');
-
             setTimeout(() => {
-                document.getElementById('pusher').style.height = `${HEIGHT_DELTA}px`;
-
-                linkNode.click();
-
-                setTimeout(() => {
-                    expect(collapseContent.style.height).to.equal(`${HEIGHT_DELTA}px`);
-                    done();
-                }, 0);
-            }, 0);
-        });
-
-        it('should not update component height when it is collapsed', (done) => {
-            const HEIGHT_DELTA = 100;
-            let collapse = render(
-                <Collapse
-                    collapsedLabel='Expand'
-                    expandedLabel='Collapse'
-                >
-                    <div
-                        id='pusher'
-                        style={ { width: '100%', height: '0px' } }
-                    />
-                </Collapse>
-            );
-            let initialComponentHeight = collapse.node.offsetHeight;
-
-            document.getElementById('pusher').style.height = `${HEIGHT_DELTA}px`;
-
-            setTimeout(() => {
-                expect(collapse.node.offsetHeight).to.equal(initialComponentHeight);
+                expect(collapseContent.style.height).to.equal(`${HEIGHT_DELTA}px`);
                 done();
-            }, 1000);
-        });
-
-        it('should apply custom expanded label', () => {
-            let collapse = render(
-                <Collapse
-                    collapsedLabel='Раскрыть'
-                    isExpanded={ false }
-                >
-                    { TEXT }
-                </Collapse>
-            );
-            let linkNode = collapse.node.querySelector('.link');
-
-            expect(linkNode).to.have.text('Раскрыть');
-        });
-
-        it('should apply custom collapsed label', () => {
-            let collapse = render(
-                <Collapse
-                    expandedLabel='Закрыть'
-                    isExpanded={ true }
-                >
-                    { TEXT }
-                </Collapse>
-            );
-            let linkNode = collapse.node.querySelector('.link');
-
-            expect(linkNode).to.have.text('Закрыть');
-        });
-
-        it('should have default expanded label', () => {
-            let collapse = render(<Collapse isExpanded={ false }>{ TEXT }</Collapse>);
-            let linkNode = collapse.node.querySelector('.link');
-
-            expect(linkNode).to.have.text('Expand');
-        });
-
-        it('should have default collapsed label', () => {
-            let collapse = render(<Collapse isExpanded={ true }>{ TEXT }</Collapse>);
-            let linkNode = collapse.node.querySelector('.link');
-
-            expect(linkNode).to.have.text('Collapse');
-        });
+            }, 0);
+        }, 0);
     });
 
-    describe('benchmark', () => {
-        let meanTime;
-        let props;
+    it('should not update component height when it is collapsed', (done) => {
+        const HEIGHT_DELTA = 100;
+        let collapse = render(
+            <Collapse
+                collapsedLabel='Expand'
+                expandedLabel='Collapse'
+            >
+                <div
+                    id='pusher'
+                    style={ { width: '100%', height: '0px' } }
+                />
+            </Collapse>
+        );
+        let initialComponentHeight = collapse.node.offsetHeight;
 
-        beforeEach(() => {
-            meanTime = 0;
-            props = {
-                component: Collapse,
-                componentProps: {
-                    children: TEXT
-                },
-                onComplete: (results) => {
-                    console.log(results);
-                    meanTime = results.mean;
-                },
-                samples: 100
-            };
-        });
+        document.getElementById('pusher').style.height = `${HEIGHT_DELTA}px`;
 
-        it('should mount in a reasonable amount of time', () => {
-            var hz;
-            var period;
-            var startTime = new Date;
-            var runs = 0;
-            var totalTime = 0;
-            do {
-            	// Code snippet goes here.
-                let component = render(<Benchmark { ...props } type='mount' />);
-                component.instance.start();
-                console.log(meanTime);
-                console.log('$$$');
+        setTimeout(() => {
+            expect(collapse.node.offsetHeight).to.equal(initialComponentHeight);
+            done();
+        }, 1000);
+    });
 
-            	runs++;
-            	totalTime = new Date - startTime;
-            } while (totalTime < 1000);
+    it('should apply custom expanded label', () => {
+        let collapse = render(
+            <Collapse
+                collapsedLabel='Раскрыть'
+                isExpanded={ false }
+            >
+                { TEXT }
+            </Collapse>
+        );
+        let linkNode = collapse.node.querySelector('.link');
 
-            // Convert milliseconds to seconds.
-            totalTime /= 1000;
+        expect(linkNode).to.have.text('Раскрыть');
+    });
 
-            // period → how long each operation takes
-            period = totalTime / runs;
+    it('should apply custom collapsed label', () => {
+        let collapse = render(
+            <Collapse
+                expandedLabel='Закрыть'
+                isExpanded={ true }
+            >
+                { TEXT }
+            </Collapse>
+        );
+        let linkNode = collapse.node.querySelector('.link');
 
-            // hz → the number of operations per second.
-            hz = 1 / period;
+        expect(linkNode).to.have.text('Закрыть');
+    });
 
-            console.log(period);
-            console.log(hz);
-            console.log('#!@#!@#!@');
-            console.log('########');
+    it('should have default expanded label', () => {
+        let collapse = render(<Collapse isExpanded={ false }>{ TEXT }</Collapse>);
+        let linkNode = collapse.node.querySelector('.link');
 
-            // expect(meanTime).to.be.less.than(10);
-        });
+        expect(linkNode).to.have.text('Expand');
+    });
+
+    it('should have default collapsed label', () => {
+        let collapse = render(<Collapse isExpanded={ true }>{ TEXT }</Collapse>);
+        let linkNode = collapse.node.querySelector('.link');
+
+        expect(linkNode).to.have.text('Collapse');
     });
 });

--- a/src/dropdown/dropdown-benchmark.jsx
+++ b/src/dropdown/dropdown-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Dropdown from './dropdown';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Dropdown, {
+    children: 'Dropdown'
+});

--- a/src/email-input/email-input-benchmark.jsx
+++ b/src/email-input/email-input-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import EmailInput from './email-input';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(EmailInput);

--- a/src/flag-icon/flag-icon-benchmark.jsx
+++ b/src/flag-icon/flag-icon-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import FlagIcon from './flag-icon';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(FlagIcon);

--- a/src/form-field/form-field-benchmark.jsx
+++ b/src/form-field/form-field-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import FormField from './form-field';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(FormField);

--- a/src/form/form-benchmark.jsx
+++ b/src/form/form-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Form from './form';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Form);

--- a/src/heading/heading-benchmark.jsx
+++ b/src/heading/heading-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Heading from './heading';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Heading, {
+    children: 'Heading'
+});

--- a/src/icon-button/icon-button-benchmark.jsx
+++ b/src/icon-button/icon-button-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import IconButton from './icon-button';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(IconButton);

--- a/src/icon/icon-benchmark.jsx
+++ b/src/icon/icon-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Icon from './icon';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Icon);

--- a/src/input-autocomplete/input-autocomplete-benchmark.jsx
+++ b/src/input-autocomplete/input-autocomplete-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import InputAutocomplete from './input-autocomplete';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(InputAutocomplete);

--- a/src/input-group/input-group-benchmark.jsx
+++ b/src/input-group/input-group-benchmark.jsx
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import InputGroup from './input-group';
+import Input from '../input';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(InputGroup, {
+    children: <Input key='1' />
+});

--- a/src/input/input-benchmark.jsx
+++ b/src/input/input-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Input from './input';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Input);

--- a/src/intl-phone-input/intl-phone-input-benchmark.jsx
+++ b/src/intl-phone-input/intl-phone-input-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import IntlPhoneInput from './intl-phone-input';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(IntlPhoneInput, {}, 50);

--- a/src/isolated-container/isolated-container-benchmark.jsx
+++ b/src/isolated-container/isolated-container-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import IsolatedContainer from './isolated-container';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(IsolatedContainer);

--- a/src/label/label-benchmark.jsx
+++ b/src/label/label-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Label from './label';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Label, {
+    children: 'Label'
+});

--- a/src/link/link-benchmark.jsx
+++ b/src/link/link-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Link from './link';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Link, {
+    children: 'Link'
+});

--- a/src/list/list-benchmark.jsx
+++ b/src/list/list-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import List from './list';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(List);

--- a/src/masked-input/masked-input-benchmark.jsx
+++ b/src/masked-input/masked-input-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import MaskedInput from './masked-input';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(MaskedInput, {
+    mask: '1111 1111 1111 1111'
+});

--- a/src/menu-item/menu-item-benchmark.jsx
+++ b/src/menu-item/menu-item-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import MenuItem from './menu-item';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(MenuItem, {
+    children: 'MenuItem'
+});

--- a/src/menu/menu-benchmark.jsx
+++ b/src/menu/menu-benchmark.jsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Menu from './menu';
+import { runBenchmark } from '../benchmark-utils';
+
+const MENU_ITEM1 = {
+    type: 'item',
+    content: 'MenuItem 1',
+    value: 'value1',
+    props: {
+        url: '#1'
+    }
+};
+
+const MENU_ITEM2 = {
+    type: 'item',
+    content: 'MenuItem 2',
+    value: 'value2',
+    props: {
+        url: '#2'
+    }
+};
+
+runBenchmark(Menu, {
+    content: [MENU_ITEM1, MENU_ITEM2]
+});

--- a/src/money-input/money-input-benchmark.jsx
+++ b/src/money-input/money-input-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import MoneyInput from './money-input';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(MoneyInput);

--- a/src/mq/mq-benchmark.jsx
+++ b/src/mq/mq-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Mq from './mq';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Mq, {
+    children: <div />
+});

--- a/src/notification/notification-benchmark.jsx
+++ b/src/notification/notification-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Notification from './notification';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Notification, {
+    children: 'Notification'
+});

--- a/src/paragraph/paragraph-benchmark.jsx
+++ b/src/paragraph/paragraph-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Paragraph from './paragraph';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Paragraph, {
+    children: 'Paragraph'
+});

--- a/src/phone-input/phone-input-benchmark.jsx
+++ b/src/phone-input/phone-input-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PhoneInput from './phone-input';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(PhoneInput);

--- a/src/plate/plate-benchmark.jsx
+++ b/src/plate/plate-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Plate from './plate';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Plate, {
+    children: 'Plate'
+});

--- a/src/popup-container-provider/popup-container-provider-benchmark.jsx
+++ b/src/popup-container-provider/popup-container-provider-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PopupContainerProvider from './popup-container-provider';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(PopupContainerProvider, {
+    children: <div>PopupContainerProvider</div>
+});

--- a/src/popup-header/popup-header-benchmark.jsx
+++ b/src/popup-header/popup-header-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import PopupHeader from './popup-header';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(PopupHeader, {
+    title: 'PopupHeader'
+});

--- a/src/popup/popup-benchmark.jsx
+++ b/src/popup/popup-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Popup from './popup';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Popup, {
+    children: 'Popup'
+}, 50);

--- a/src/progress-bar/progress-bar-benchmark.jsx
+++ b/src/progress-bar/progress-bar-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ProgressBar from './progress-bar';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(ProgressBar);

--- a/src/radio-group/radio-group-benchmark.jsx
+++ b/src/radio-group/radio-group-benchmark.jsx
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import RadioGroup from './radio-group';
+import Radio from '../radio';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(RadioGroup, {
+    children: <Radio key='1' />
+});

--- a/src/radio/radio-benchmark.jsx
+++ b/src/radio/radio-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Radio from './radio';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Radio);

--- a/src/render-in-container/render-in-container-benchmark.jsx
+++ b/src/render-in-container/render-in-container-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import RenderInContainer from './render-in-container';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(RenderInContainer, {
+    children: <div>RenderInContainer</div>
+});

--- a/src/resize-sensor/resize-sensor-benchmark.jsx
+++ b/src/resize-sensor/resize-sensor-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ResizeSensor from './resize-sensor';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(ResizeSensor);

--- a/src/resize-sensor/resize-sensor.jsx
+++ b/src/resize-sensor/resize-sensor.jsx
@@ -7,17 +7,6 @@ import React from 'react';
 import Type from 'prop-types';
 
 /**
- * Инстанцирует Resize Observer при наличии в браузере.
- *
- * @param {Function} onObserve Обработчик изменений в Resize Observer.
- * @returns {ResizeObserver|null}
- */
-function getObserver(onObserve) {
-    if (!global.ResizeObserver) return null;
-    return new global.ResizeObserver(onObserve);
-}
-
-/**
  * Компонент позволяющий слушать изменения размера родительского элемента.
  * Для использования разместите его в элементе об изменении размера, которого
  * вы хотите знать и добавьте внешний обработчик `onResize`.
@@ -36,58 +25,37 @@ class ResizeSensor extends React.Component {
      */
     iframe;
 
-    /**
-     * @type {ResizeObserver}
-     */
-    observer = getObserver(this.handleResize);
-
     componentDidMount() {
-        if (this.root) {
-            this.observer.observe(this.root);
-        }
-
-        if (this.iframe && this.iframe.contentWindow) {
+        if (this.iframe.contentWindow) {
             this.iframe.contentWindow.addEventListener('resize', this.handleResize);
         }
     }
 
     componentWillUnmount() {
-        if (this.root) {
-            this.observer.disconnect();
-        }
-
-        if (this.iframe && this.iframe.contentWindow) {
+        if (this.iframe.contentWindow) {
             this.iframe.contentWindow.removeEventListener('resize', this.handleResize);
         }
     }
 
     render() {
-        let style = {
+        let iframeStyle = {
             position: 'absolute',
             top: 0,
             left: 0,
             width: '100%',
             height: '100%',
+            background: 'transparent',
+            border: 'none',
             zIndex: -1
         };
 
         /* eslint-disable jsx-a11y/iframe-has-title */
         return (
-            global.ResizeObserver ?
-                <div
-                    ref={ (root) => { this.root = root; } }
-                    style={ style }
-                />
-                :
-                <iframe
-                    ref={ (iframe) => { this.iframe = iframe; } }
-                    style={ {
-                        ...style,
-                        background: 'transparent',
-                        border: 'none'
-                    } }
-                    tabIndex='-1'
-                />
+            <iframe
+                ref={ (iframe) => { this.iframe = iframe; } }
+                style={ iframeStyle }
+                tabIndex='-1'
+            />
         );
         /* eslint-enable jsx-a11y/iframe-has-title */
     }

--- a/src/resize-sensor/resize-sensor.jsx
+++ b/src/resize-sensor/resize-sensor.jsx
@@ -62,14 +62,12 @@ class ResizeSensor extends React.Component {
     }
 
     render() {
-        let iframeStyle = {
+        let style = {
             position: 'absolute',
             top: 0,
             left: 0,
             width: '100%',
             height: '100%',
-            background: 'transparent',
-            border: 'none',
             zIndex: -1
         };
 
@@ -78,12 +76,16 @@ class ResizeSensor extends React.Component {
             global.ResizeObserver ?
                 <div
                     ref={ (root) => { this.root = root; } }
-                    style={ iframeStyle }
+                    style={ style }
                 />
                 :
                 <iframe
                     ref={ (iframe) => { this.iframe = iframe; } }
-                    style={ iframeStyle }
+                    style={ {
+                        ...style,
+                        background: 'transparent',
+                        border: 'none'
+                    } }
                     tabIndex='-1'
                 />
         );

--- a/src/resize-sensor/resize-sensor.jsx
+++ b/src/resize-sensor/resize-sensor.jsx
@@ -7,6 +7,17 @@ import React from 'react';
 import Type from 'prop-types';
 
 /**
+ * Инстанцирует Resize Observer при наличии в браузере.
+ *
+ * @param {Function} onObserve Обработчик изменений в Resize Observer.
+ * @returns {ResizeObserver|null}
+ */
+function getObserver(onObserve) {
+    if (!global.ResizeObserver) return null;
+    return new global.ResizeObserver(onObserve);
+}
+
+/**
  * Компонент позволяющий слушать изменения размера родительского элемента.
  * Для использования разместите его в элементе об изменении размера, которого
  * вы хотите знать и добавьте внешний обработчик `onResize`.
@@ -25,37 +36,58 @@ class ResizeSensor extends React.Component {
      */
     iframe;
 
+    /**
+     * @type {ResizeObserver}
+     */
+    observer = getObserver(this.handleResize);
+
     componentDidMount() {
-        if (this.iframe.contentWindow) {
+        if (this.root) {
+            this.observer.observe(this.root);
+        }
+
+        if (this.iframe && this.iframe.contentWindow) {
             this.iframe.contentWindow.addEventListener('resize', this.handleResize);
         }
     }
 
     componentWillUnmount() {
-        if (this.iframe.contentWindow) {
+        if (this.root) {
+            this.observer.disconnect();
+        }
+
+        if (this.iframe && this.iframe.contentWindow) {
             this.iframe.contentWindow.removeEventListener('resize', this.handleResize);
         }
     }
 
     render() {
-        let iframeStyle = {
+        let style = {
             position: 'absolute',
             top: 0,
             left: 0,
             width: '100%',
             height: '100%',
-            background: 'transparent',
-            border: 'none',
             zIndex: -1
         };
 
         /* eslint-disable jsx-a11y/iframe-has-title */
         return (
-            <iframe
-                ref={ (iframe) => { this.iframe = iframe; } }
-                style={ iframeStyle }
-                tabIndex='-1'
-            />
+            global.ResizeObserver ?
+                <div
+                    ref={ (root) => { this.root = root; } }
+                    style={ style }
+                />
+                :
+                <iframe
+                    ref={ (iframe) => { this.iframe = iframe; } }
+                    style={ {
+                        ...style,
+                        background: 'transparent',
+                        border: 'none'
+                    } }
+                    tabIndex='-1'
+                />
         );
         /* eslint-enable jsx-a11y/iframe-has-title */
     }

--- a/src/select/select-benchmark.jsx
+++ b/src/select/select-benchmark.jsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Select from './select';
+import { runBenchmark } from '../benchmark-utils';
+
+const OPTIONS = [
+    {
+        value: 1,
+        text: 'Vk',
+        checkedText: 'Vkontakte'
+    },
+    {
+        value: 2,
+        text: 'Fb',
+        checkedText: 'Facebook'
+    },
+    {
+        value: 3,
+        text: 'Tw',
+        checkedText: 'Twitter'
+    }
+];
+
+runBenchmark(Select, {
+    options: OPTIONS
+}, 50);

--- a/src/select/select-test.jsx
+++ b/src/select/select-test.jsx
@@ -20,7 +20,8 @@ const OPTIONS = [
     },
     {
         value: 2,
-        text: 'Fb'
+        text: 'Fb',
+        checkedText: 'Facebook'
     },
     {
         value: 3,

--- a/src/sidebar/sidebar-benchmark.jsx
+++ b/src/sidebar/sidebar-benchmark.jsx
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Sidebar from './sidebar';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Sidebar, {
+    visible: true,
+    children: 'Sidebar'
+});

--- a/src/slide-down/slide-down-benchmark.jsx
+++ b/src/slide-down/slide-down-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import SlideDown from './slide-down';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(SlideDown, {
+    children: 'SlideDown'
+});

--- a/src/spin/spin-benchmark.jsx
+++ b/src/spin/spin-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Spin from './spin';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Spin, {
+    visible: true
+});

--- a/src/swipeable/swipeable-benchmark.jsx
+++ b/src/swipeable/swipeable-benchmark.jsx
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Swipeable from './swipeable';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Swipeable, {
+    children: <div>Swipeable</div>,
+    onSwipe: () => {}
+});

--- a/src/tab-item/tab-item-benchmark.jsx
+++ b/src/tab-item/tab-item-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import TabItem from './tab-item';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(TabItem);

--- a/src/tabs/tabs-benchmark.jsx
+++ b/src/tabs/tabs-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Tabs from './tabs';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Tabs);

--- a/src/tag-button/tag-button-benchmark.jsx
+++ b/src/tag-button/tag-button-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import TagButton from './tag-button';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(TagButton);

--- a/src/textarea/textarea-benchmark.jsx
+++ b/src/textarea/textarea-benchmark.jsx
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Textarea from './textarea';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(Textarea);

--- a/src/theme-provider/theme-provider-benchmark.jsx
+++ b/src/theme-provider/theme-provider-benchmark.jsx
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ThemeProvider from './theme-provider';
+import { runBenchmark } from '../benchmark-utils';
+
+runBenchmark(ThemeProvider, {
+    children: <div>ThemeProvider</div>
+});


### PR DESCRIPTION
Сейчас: iframe довольно жирен и иногда стреляет в тестах в определённых конфигурациях (не отрабатывает onResize).
Будет: Добавлено использование ResizeObserver API в ResizeSensor. В настоящий момент API доступно в десктопном Chrome (как раз 2 последние версии — с 64-й), на подходе Opera и  мобильный Chrome. Firefox — under construction. Исходя из статистики использования браузеров (на сайте/анкетах), сейчас у десктопного Chrome доля больше трети от всех пользователей. Используя Resize Observer скорость маунтинга/апдейта/анмаунтинга в компонентах где используется ResizeSensor (это Collapse, InputAutocomplete, Popup, Select) выросла в среднем на 2-3 раза:
 
<img width="1283" alt="screen shot 2018-04-06 at 15 59 40" src="https://user-images.githubusercontent.com/4638427/38422483-98399904-39b3-11e8-9644-05ea1fca6ea1.png">