### PR TITLE
feat(*): reduce bundle size, remove prop-types in production

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["arui-presets/babel"]
+  "presets": ["arui-presets/babel"],
+  "plugins": [
+    ["transform-react-remove-prop-types", {"mode": "wrap"}]
+  ]
 }

--- a/src/attach/attach.jsx
+++ b/src/attach/attach.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/attach/attach.jsx
+++ b/src/attach/attach.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/button/button.jsx
+++ b/src/button/button.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/button/button.jsx
+++ b/src/button/button.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import formatDate from 'date-fns/format';
 import Type from 'prop-types';

--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import formatDate from 'date-fns/format';
 import Type from 'prop-types';

--- a/src/calendar/calendar.jsx
+++ b/src/calendar/calendar.jsx
@@ -4,7 +4,7 @@
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/calendar/calendar.jsx
+++ b/src/calendar/calendar.jsx
@@ -4,7 +4,7 @@
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/checkbox-group/checkbox-group.jsx
+++ b/src/checkbox-group/checkbox-group.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import createFragment from 'react-addons-create-fragment';
 import React from 'react';
 import Type from 'prop-types';

--- a/src/checkbox-group/checkbox-group.jsx
+++ b/src/checkbox-group/checkbox-group.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import createFragment from 'react-addons-create-fragment';
 import React from 'react';
 import Type from 'prop-types';

--- a/src/checkbox/checkbox.jsx
+++ b/src/checkbox/checkbox.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/checkbox/checkbox.jsx
+++ b/src/checkbox/checkbox.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/collapse/collapse.jsx
+++ b/src/collapse/collapse.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/collapse/collapse.jsx
+++ b/src/collapse/collapse.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/dropdown/dropdown.jsx
+++ b/src/dropdown/dropdown.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/dropdown/dropdown.jsx
+++ b/src/dropdown/dropdown.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/form/form.jsx
+++ b/src/form/form.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/form/form.jsx
+++ b/src/form/form.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -4,7 +4,7 @@
 
 /* eslint react/prop-types: 0 */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -4,7 +4,7 @@
 
 /* eslint react/prop-types: 0 */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/intl-phone-input/intl-phone-input.jsx
+++ b/src/intl-phone-input/intl-phone-input.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 
 import FlagIcon from '../flag-icon/flag-icon';

--- a/src/intl-phone-input/intl-phone-input.jsx
+++ b/src/intl-phone-input/intl-phone-input.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 
 import FlagIcon from '../flag-icon/flag-icon';

--- a/src/link/link.jsx
+++ b/src/link/link.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/link/link.jsx
+++ b/src/link/link.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/masked-input/masked-input.jsx
+++ b/src/masked-input/masked-input.jsx
@@ -4,7 +4,7 @@
 
 /* eslint react/prop-types: 0 */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/masked-input/masked-input.jsx
+++ b/src/masked-input/masked-input.jsx
@@ -4,7 +4,7 @@
 
 /* eslint react/prop-types: 0 */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/menu-item/menu-item.jsx
+++ b/src/menu-item/menu-item.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/menu-item/menu-item.jsx
+++ b/src/menu-item/menu-item.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -4,7 +4,7 @@
 
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import styleType from 'react-style-proptype';
 import Type from 'prop-types';

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -4,7 +4,7 @@
 
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import styleType from 'react-style-proptype';
 import Type from 'prop-types';

--- a/src/money-input/money-input.jsx
+++ b/src/money-input/money-input.jsx
@@ -4,7 +4,7 @@
 
 /* eslint react/prop-types: 0 */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/money-input/money-input.jsx
+++ b/src/money-input/money-input.jsx
@@ -4,7 +4,7 @@
 
 /* eslint react/prop-types: 0 */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/mq/decorator.jsx
+++ b/src/mq/decorator.jsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import { getMatchMedia, releaseMatchMedia } from '../lib/match-media';
 
 

--- a/src/mq/decorator.jsx
+++ b/src/mq/decorator.jsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import { getMatchMedia, releaseMatchMedia } from '../lib/match-media';
 
 

--- a/src/mq/mq.jsx
+++ b/src/mq/mq.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 import Modernizr from '../modernizr';

--- a/src/mq/mq.jsx
+++ b/src/mq/mq.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 import Modernizr from '../modernizr';

--- a/src/notification/notification.jsx
+++ b/src/notification/notification.jsx
@@ -4,7 +4,7 @@
 
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/notification/notification.jsx
+++ b/src/notification/notification.jsx
@@ -4,7 +4,7 @@
 
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/plate/plate.jsx
+++ b/src/plate/plate.jsx
@@ -4,7 +4,7 @@
 
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/plate/plate.jsx
+++ b/src/plate/plate.jsx
@@ -4,7 +4,7 @@
 
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/popup-header/popup-header.jsx
+++ b/src/popup-header/popup-header.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import Type from 'prop-types';
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 
 import IconClose from '../icon/ui/close';
 import IconButton from '../icon-button/icon-button';

--- a/src/popup-header/popup-header.jsx
+++ b/src/popup-header/popup-header.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import Type from 'prop-types';
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 
 import IconClose from '../icon/ui/close';
 import IconButton from '../icon-button/icon-button';

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import { canUseDOM } from 'exenv';
 import debounce from 'lodash.debounce';
 import React from 'react';

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import { canUseDOM } from 'exenv';
 import debounce from 'lodash.debounce';
 import React from 'react';

--- a/src/radio-group/radio-group.jsx
+++ b/src/radio-group/radio-group.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import createFragment from 'react-addons-create-fragment';
 import React from 'react';
 import Type from 'prop-types';

--- a/src/radio-group/radio-group.jsx
+++ b/src/radio-group/radio-group.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import createFragment from 'react-addons-create-fragment';
 import React from 'react';
 import Type from 'prop-types';

--- a/src/radio/radio.jsx
+++ b/src/radio/radio.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/radio/radio.jsx
+++ b/src/radio/radio.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/render-in-container/render-in-container.jsx
+++ b/src/render-in-container/render-in-container.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import deprecated from 'deprecated-decorator';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/render-in-container/render-in-container.jsx
+++ b/src/render-in-container/render-in-container.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import deprecated from 'deprecated-decorator';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/resize-sensor/resize-sensor.jsx
+++ b/src/resize-sensor/resize-sensor.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/resize-sensor/resize-sensor.jsx
+++ b/src/resize-sensor/resize-sensor.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import createFragment from 'react-addons-create-fragment';
 import React from 'react';
 import Type from 'prop-types';

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import createFragment from 'react-addons-create-fragment';
 import React from 'react';
 import Type from 'prop-types';

--- a/src/sidebar/sidebar.jsx
+++ b/src/sidebar/sidebar.jsx
@@ -4,7 +4,7 @@
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/sidebar/sidebar.jsx
+++ b/src/sidebar/sidebar.jsx
@@ -4,7 +4,7 @@
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import Type from 'prop-types';
 

--- a/src/slide-down/slide-down.jsx
+++ b/src/slide-down/slide-down.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import Type from 'prop-types';
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 
 import cn from '../cn';
 import performance from '../performance';

--- a/src/slide-down/slide-down.jsx
+++ b/src/slide-down/slide-down.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import Type from 'prop-types';
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 
 import cn from '../cn';
 import performance from '../performance';

--- a/src/swipeable/swipeable.jsx
+++ b/src/swipeable/swipeable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Type from 'prop-types';
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 
 import performance from '../performance';
 

--- a/src/swipeable/swipeable.jsx
+++ b/src/swipeable/swipeable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Type from 'prop-types';
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 
 import performance from '../performance';
 

--- a/src/textarea/textarea.jsx
+++ b/src/textarea/textarea.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { autobind } from 'core-decorators';
+import autobind from 'core-decorators/es/autobind';
 import React from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import Type from 'prop-types';

--- a/src/textarea/textarea.jsx
+++ b/src/textarea/textarea.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import autobind from 'core-decorators/es/autobind';
+import autobind from 'core-decorators/lib/autobind';
 import React from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import Type from 'prop-types';


### PR DESCRIPTION
Уменьшение production билда приложений

## Мотивация и контекст
На данный момент из продакшн билдов не удаляются проптайпы, поскольку `transform-react-remove-prop-types` плагин на уровне проектов не может вырезать проптайпы из скомпиленного кода. 
Плюс в бандл попадают все декораторы из core-decorators, а используется при этом только один.