### PR TITLE
fix(menu): input-autocomplete highlight fix

### DIFF
--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -119,7 +119,7 @@ class Menu extends React.Component {
     componentWillReceiveProps(nextProps) {
         if (this.props.mode !== 'check' && this.state.checkedItems[0] &&
             nextProps.checkedItems[0] !== this.state.checkedItems[0]) {
-            let highlightedItem = null;
+            let highlightedItem;
 
             this.menuItemList.forEach((item, index, menuItemList) => {
                 if (item.ref === nextProps.checkedItems[0]) {


### PR DESCRIPTION
Изменение дефолтного значения переменной highlightedItem с null на undefined

## Мотивация и контекст
Ломается повторный highlight в inputAutocomplete (можно наблюдать на нашей странице со стайлгайдом, в разделе "Автокомплит с автозакрытием после выбора". Один раз что-то выбрали, второй раз на hover компоненты не подсвечиваются и навигация стрелочками клавиатуры не работает). Проблема наблюдается на всех(!) проектах, которые используют инпут-автокомплит(например на рублёвке). 

Первые два примера в стайлгайдисте не ломаются, потому что сам компонент не перерендеривается и componentWillReceiveProps в менюхе повторно не срабатывает и не выставляет highlightedItem в null

Поскольку в компоненте Menu везде стоят такие проверки:

     let highlightedItem = this.props.highlightedItem === undefined
            ? this.state.highlightedItem
            : this.props.highlightedItem;.

то this.props.highlightedItem, выставленный в null, ломает подсветку и навигацию стрелочками. 
Можно рассмотреть несколько решений. Мне кажется я реализовал самое простое. Дискасс, лайк, апрув
