### PR TITLE
fix(select): add placeholder color and right display for text

### DIFF
--- a/src/select/select.css
+++ b/src/select/select.css
@@ -79,7 +79,7 @@
 
     .select-button {
         overflow: hidden;
-        display: flex;
+        display: inline-block;
         position: relative;
         width: 100%;
         margin: 0;

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -301,7 +301,7 @@ class Select extends React.Component {
                 onFocus={ this.handleButtonFocus }
                 onBlur={ this.handleButtonBlur }
             >
-                { this.renderButtonContent() }
+                { this.renderButtonContent(cn) }
                 { !this.props.hideTick &&
                     <IconButton
                         className={ cn('tick') }
@@ -465,7 +465,7 @@ class Select extends React.Component {
         );
     }
 
-    renderButtonContent() {
+    renderButtonContent(cn) {
         let checkedItems = this.getCheckedItems(this.props.options);
 
         if (this.props.renderButtonContent) {

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -473,7 +473,12 @@ class Select extends React.Component {
         }
 
         let checkedItemsText = checkedItems.map(item => item.checkedText || item.text).join(', ');
-        return checkedItemsText || this.props.placeholder;
+        return checkedItemsText ||
+            (
+                <span className={ cn('placeholder') }>
+                    { this.props.placeholder }
+                </span>
+            );
     }
 
     renderMobileHeader(cn) {

--- a/src/select/select_theme_alfa-on-color.css
+++ b/src/select/select_theme_alfa-on-color.css
@@ -6,7 +6,8 @@
 
 .select_theme_alfa-on-color {
     .select__top,
-    .select__sub {
+    .select__sub,
+    .select__placeholder {
         color: var(--color-content-minor-alfa-on-color);
     }
 

--- a/src/select/select_theme_alfa-on-white.css
+++ b/src/select/select_theme_alfa-on-white.css
@@ -6,7 +6,8 @@
 
 .select_theme_alfa-on-white {
     .select__top,
-    .select__sub {
+    .select__sub,
+    .select_placeholder {
         color: var(--color-content-minor-alfa-on-white);
     }
 

--- a/src/select/select_theme_alfa-on-white.css
+++ b/src/select/select_theme_alfa-on-white.css
@@ -7,7 +7,7 @@
 .select_theme_alfa-on-white {
     .select__top,
     .select__sub,
-    .select_placeholder {
+    .select__placeholder {
         color: var(--color-content-minor-alfa-on-white);
     }
 


### PR DESCRIPTION
Цвет для placeholder, изменение display для правильного сокращения строки
## Мотивация и контекст
Если значение в select длинное (или их несколько), то строка не сокращалась как в инпуте, а залазила на стрелочку. Изменения display: flex; на display: inline-block; исправляет этот баг.

Цвет плейсхолдера в селекте не соответствовал плейсхолдерам других компонентов (например инпут обычный). Добавил вывод плейсхолдера через <span> с классом и соответствующими стилями.
