### PR TITLE
fix(calendar-input.css): fix input text color on ios

### DIFF
--- a/src/calendar-input/calendar-input.css
+++ b/src/calendar-input/calendar-input.css
@@ -47,7 +47,7 @@
 }
 
 .calendar-input_theme_alfa-on-color {
-    .calendar-input__native-control + .calendar-input__custom-control {
+    .calendar-input__custom-control {
         .input__control:disabled {
             -webkit-text-fill-color: var(--color-content-alfa-on-color) !important;
         }
@@ -55,7 +55,7 @@
 }
 
 .calendar-input_theme_alfa-on-white {
-    .calendar-input__native-control + .calendar-input__custom-control {
+    .calendar-input__custom-control {
         .input__control:disabled {
             -webkit-text-fill-color: var(--color-content-alfa-on-white) !important;
         }


### PR DESCRIPTION
<!--- Название для изменений -->
Синий текст внутри `CalendarInput` на iPhone
## Мотивация и контекст
Сейчас на iPhone внутри `CalanderInput`(без фоллбэка на нативный контрол) выводится текст синего цвета
![simulator screen shot - iphone 8 - 2018-05-16 at 12 34 43](https://user-images.githubusercontent.com/10559998/40114058-2704a69a-5914-11e8-9561-ce52ac521a6a.png)
