### PR TITLE
fix(button): text align in full width button

### DIFF
--- a/src/button/button.css
+++ b/src/button/button.css
@@ -49,6 +49,12 @@
 
     &_width_available {
         width: 100%;
+
+        .button__text {
+            display: block;
+            width: 100%;
+            text-align: center;
+        }
     }
 
     &_type_link {


### PR DESCRIPTION
В Safari на iOS 10 у кнопки с width='available' текст выравнивался не по центру, а по левому краю:

![ios-button-width-available](https://user-images.githubusercontent.com/109410/42514496-3d23e8ae-8462-11e8-919b-8d33e783a7ea.png)