### PR TITLE
fix(mq): correct d.ts for mq-decorator

### DIFF
--- a/src/mq/decorator.d.ts
+++ b/src/mq/decorator.d.ts
@@ -2,4 +2,4 @@ interface ClassDecorator {
     <TFunction extends Function>(target: TFunction): TFunction | void;
 }
 
-export default function mqDecorator(query: string, propName: string = 'mqMatch'): ClassDecorator;
+export default function mqDecorator(query: string, propName?: string): ClassDecorator;


### PR DESCRIPTION
Фикс типов для mq-decorator

## Мотивация и контекст
Текущие типы просто не компилятся.