### PR TITLE
feat(autocomplete): insert popup after focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -745,7 +745,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -4290,7 +4290,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
@@ -6561,7 +6561,7 @@
       "dependencies": {
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         }
@@ -7381,7 +7381,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {

--- a/src/input-autocomplete/input-autocomplete-test.jsx
+++ b/src/input-autocomplete/input-autocomplete-test.jsx
@@ -27,6 +27,10 @@ const OPTIONS2 = [
 function renderInputAutocomplete(props = {}) {
     let inputAutocomplete = render(<InputAutocomplete { ...props } />);
 
+    return getInputNodes(inputAutocomplete);
+}
+
+function getInputNodes(inputAutocomplete) {
     let inputNode = inputAutocomplete.node.querySelector('.input');
     let controlNode = inputAutocomplete.node.querySelector('input');
     let popupNode = document.querySelector('.popup');
@@ -39,7 +43,7 @@ function renderInputAutocomplete(props = {}) {
     };
 }
 
-describe('input-autocomplete', () => {
+describe.only('input-autocomplete', () => {
     let originalWindowScrollTo = window.scrollTo;
 
     beforeEach(() => {
@@ -69,6 +73,23 @@ describe('input-autocomplete', () => {
 
         expect(popupNode).to.have.class('popup');
         expect(controlNode).to.have.class('input__control');
+    });
+
+    it('should not render popup with options and `popupOnFocus`', () => {
+        let { popupNode } = renderInputAutocomplete({ options: OPTIONS, popupOnFocus: true });
+
+        expect(popupNode).not.to.exist;
+    });
+
+    it('should render popup after focus with `popupOnFocus`', (done) => {
+        let { inputAutocomplete } = renderInputAutocomplete({ options: OPTIONS, popupOnFocus: true });
+        inputAutocomplete.instance.focus();
+
+        setTimeout(() => {
+            let { popupNode } = getInputNodes(inputAutocomplete);
+            expect(popupNode).to.have.class('popup');
+            done();
+        }, 0);
     });
 
     it('should set class on public focus method', (done) => {

--- a/src/input-autocomplete/input-autocomplete-test.jsx
+++ b/src/input-autocomplete/input-autocomplete-test.jsx
@@ -87,7 +87,7 @@ describe('input-autocomplete', () => {
 
         setTimeout(() => {
             let { popupNode } = getInputNodes(inputAutocomplete);
-            expect(popupNode).to.have.class('popup');
+            expect(popupNode).to.exist;
 
             inputAutocomplete.instance.blur();
             done();

--- a/src/input-autocomplete/input-autocomplete-test.jsx
+++ b/src/input-autocomplete/input-autocomplete-test.jsx
@@ -76,13 +76,13 @@ describe.only('input-autocomplete', () => {
     });
 
     it('should not render popup with options and `popupOnFocus`', () => {
-        let { popupNode } = renderInputAutocomplete({ options: OPTIONS, popupOnFocus: true });
+        let { popupNode } = renderInputAutocomplete({ options: OPTIONS, renderPopupOnFucus: true });
 
         expect(popupNode).not.to.exist;
     });
 
     it('should render popup after focus with `popupOnFocus`', (done) => {
-        let { inputAutocomplete } = renderInputAutocomplete({ options: OPTIONS, popupOnFocus: true });
+        let { inputAutocomplete } = renderInputAutocomplete({ options: OPTIONS, renderPopupOnFucus: true });
         inputAutocomplete.instance.focus();
 
         setTimeout(() => {

--- a/src/input-autocomplete/input-autocomplete-test.jsx
+++ b/src/input-autocomplete/input-autocomplete-test.jsx
@@ -43,7 +43,7 @@ function getInputNodes(inputAutocomplete) {
     };
 }
 
-describe.only('input-autocomplete', () => {
+describe('input-autocomplete', () => {
     let originalWindowScrollTo = window.scrollTo;
 
     beforeEach(() => {

--- a/src/input-autocomplete/input-autocomplete-test.jsx
+++ b/src/input-autocomplete/input-autocomplete-test.jsx
@@ -76,18 +76,20 @@ describe('input-autocomplete', () => {
     });
 
     it('should not render popup with options and `popupOnFocus`', () => {
-        let { popupNode } = renderInputAutocomplete({ options: OPTIONS, renderPopupOnFucus: true });
+        let { popupNode } = renderInputAutocomplete({ options: OPTIONS, renderPopupOnFocus: true });
 
         expect(popupNode).not.to.exist;
     });
 
     it('should render popup after focus with `popupOnFocus`', (done) => {
-        let { inputAutocomplete } = renderInputAutocomplete({ options: OPTIONS, renderPopupOnFucus: true });
+        let { inputAutocomplete } = renderInputAutocomplete({ options: OPTIONS, renderPopupOnFocus: true });
         inputAutocomplete.instance.focus();
 
         setTimeout(() => {
             let { popupNode } = getInputNodes(inputAutocomplete);
             expect(popupNode).to.have.class('popup');
+
+            inputAutocomplete.instance.blur();
             done();
         }, 0);
     });

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -59,6 +59,8 @@ class InputAutocomplete extends React.Component {
             'top-left', 'top-center', 'top-right', 'left-top', 'left-center', 'left-bottom', 'right-top',
             'right-center', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right'
         ])),
+        /** Вставляет попап со списком только если элемент активен */
+        popupOnFocus: Type.bool,
         /**
          * Обработчик выбора пункта в выпадающем меню
          * @param checkedItem
@@ -76,7 +78,8 @@ class InputAutocomplete extends React.Component {
         updateValueOnItemSelect: true,
         directions: ['bottom-left', 'bottom-right', 'top-left', 'top-right'],
         equalPopupWidth: false,
-        closeOnSelect: false
+        closeOnSelect: false,
+        popupOnFocus: false
     };
 
     state = {
@@ -168,6 +171,9 @@ class InputAutocomplete extends React.Component {
     }
 
     renderPopup(cn) {
+        if (this.props.popupOnFocus && !this.state.inputFocused) {
+            return null;
+        }
         let formattedOptionsList = this.props.options
             ? this.formatOptionsList(this.props.options)
             : [];

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -60,7 +60,7 @@ class InputAutocomplete extends React.Component {
             'right-center', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right'
         ])),
         /** Вставляет попап со списком только если элемент активен */
-        popupOnFocus: Type.bool,
+        renderPopupOnFucus: Type.bool,
         /**
          * Обработчик выбора пункта в выпадающем меню
          * @param checkedItem
@@ -79,7 +79,7 @@ class InputAutocomplete extends React.Component {
         directions: ['bottom-left', 'bottom-right', 'top-left', 'top-right'],
         equalPopupWidth: false,
         closeOnSelect: false,
-        popupOnFocus: false
+        renderPopupOnFucus: false
     };
 
     state = {
@@ -171,9 +171,6 @@ class InputAutocomplete extends React.Component {
     }
 
     renderPopup(cn) {
-        if (this.props.popupOnFocus && !this.state.inputFocused) {
-            return null;
-        }
         let formattedOptionsList = this.props.options
             ? this.formatOptionsList(this.props.options)
             : [];
@@ -187,6 +184,9 @@ class InputAutocomplete extends React.Component {
             return null;
         }
 
+        if (this.props.renderPopupOnFucus && !opened) {
+            return null;
+        }
         return [
             <ResizeSensor onResize={ this.updatePopupStyles } key='popup-sensor' />,
             <Popup

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -60,7 +60,7 @@ class InputAutocomplete extends React.Component {
             'right-center', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right'
         ])),
         /** Вставляет попап со списком только если элемент активен */
-        renderPopupOnFucus: Type.bool,
+        renderPopupOnFocus: Type.bool,
         /**
          * Обработчик выбора пункта в выпадающем меню
          * @param checkedItem
@@ -79,7 +79,7 @@ class InputAutocomplete extends React.Component {
         directions: ['bottom-left', 'bottom-right', 'top-left', 'top-right'],
         equalPopupWidth: false,
         closeOnSelect: false,
-        renderPopupOnFucus: false
+        renderPopupOnFocus: false
     };
 
     state = {
@@ -184,7 +184,7 @@ class InputAutocomplete extends React.Component {
             return null;
         }
 
-        if (this.props.renderPopupOnFucus && !opened) {
+        if (this.props.renderPopupOnFocus && !opened) {
             return null;
         }
         return [


### PR DESCRIPTION
<!--- Название для изменений -->
Попап со списком элементов вставлять в DOM только если input активен
## Мотивация и контекст
<!--- Почему эти изменения необходимы? Какую проблему они решают? -->
При большом количестве таких элементов на странице рендер выполняется очень долго, порядка секунды.
Идея в том, что бы рендерить список только если input получил фокус.
Для того, что бы не ломать обратную совместимость добавлен флаг, включающий лайт режим.

<!--- Если изменения исправляют открытый issue, прикрепите на него ссылку -->
