### PR TITLE
feat(select): create select type with animated label

### DIFF
--- a/src/select/README.md
+++ b/src/select/README.md
@@ -94,6 +94,42 @@ const options = [
 </div>
 ```
 
+Select с лейблом
+```jsx
+const options = [
+    { value: '01', text: 'ИП Фридман М.М.' },
+    { value: '02', text: 'ООО «Виктори»' },
+    { value: '03', text: 'ФГУП НПП ВНИИЭМ' }
+];
+<div>
+    {
+        ['xl'].map(size => (
+            <div className='row' key={ size }>
+                <div className='column'>
+                    <Select
+                        label='Компания'
+                        animated={true}
+                        size={ size }
+                        mode='radio-check'
+                        options={ options }
+                    />
+                </div>
+                <div className='column'>
+                    <Select
+                        size={ size }
+                        label='Компания'
+                        animated={true}
+                        mode='radio-check'
+                        options={ options }
+                        disabled={ true }
+                    />
+                </div>
+            </div>
+        ))
+    }
+</div>
+```
+
 Select с тянущейся шириной
 ```jsx
 const options = [

--- a/src/select/select.css
+++ b/src/select/select.css
@@ -4,6 +4,16 @@
 
 @import '../vars.css';
 
+@define-mixin animated-label $parent, $scale, $translate {
+    $(parent).select_opened:not(.select_animated),
+    $(parent).select_has-value:not(.select_animated),
+    $(parent).select_animated.select_checked {
+        .select__top {
+            transform: scale($scale) translateY($translate);
+        }
+    }
+}
+
 :root {
     --top-scale-s: calc(strip(var(--font-size-xs)) / strip(var(--font-size-s)));
     --top-scale-m: calc(strip(var(--font-size-s)) / strip(var(--font-size-m)));
@@ -190,6 +200,12 @@
         min-width: 0;
         height: 100%;
     }
+
+    &_animated {
+        .select__placeholder {
+            visibility: hidden;
+        }
+    }
 }
 
 .select_size_s {
@@ -202,12 +218,7 @@
         line-height: 30px;
     }
 
-    &.select_opened,
-    &.select_has-value {
-        .select__top {
-            transform: scale(var(--top-scale-s)) translateY(-22px);
-        }
-    }
+    @mixin animated-label &, var(--top-scale-s), -22px;
 }
 
 .select_size_m {
@@ -220,12 +231,7 @@
         line-height: 40px;
     }
 
-    &.select_opened,
-    &.select_has-value {
-        .select__top {
-            transform: scale(var(--top-scale-m)) translateY(-30px);
-        }
-    }
+    @mixin animated-label &, var(--top-scale-m), -30px;
 }
 
 .select_size_l {
@@ -238,12 +244,7 @@
         line-height: 50px;
     }
 
-    &.select_opened,
-    &.select_has-value {
-        .select__top {
-            transform: scale(var(--top-scale-l)) translateY(-40px);
-        }
-    }
+    @mixin animated-label &, var(--top-scale-l), -40px;
 }
 
 .select_size_xl {
@@ -256,10 +257,5 @@
         line-height: 60px;
     }
 
-    &.select_opened,
-    &.select_has-value {
-        .select__top {
-            transform: scale(var(--top-scale-xl)) translateY(-50px);
-        }
-    }
+    @mixin animated-label &, var(--top-scale-xl), -50px;
 }

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -101,6 +101,8 @@ class Select extends React.Component {
         name: Type.string,
         /** Лейбл для поля */
         label: Type.node,
+        /** Анимация для лейбла по аналогии с компонентом Input */
+        animated: Type.bool,
         /** Подсказка в поле */
         placeholder: Type.string,
         /** Подсказка под полем */
@@ -185,7 +187,8 @@ class Select extends React.Component {
         equalPopupWidth: false,
         options: [],
         placeholder: 'Выберите:',
-        mobileMenuMode: 'native'
+        mobileMenuMode: 'native',
+        animated: false
     };
 
     static contextTypes = {
@@ -263,7 +266,8 @@ class Select extends React.Component {
                     'has-value': !!value,
                     invalid: !!this.props.error,
                     opened: this.getOpened(),
-                    'no-tick': this.props.hideTick
+                    'no-tick': this.props.hideTick,
+                    animated: this.props.animated
                 }) }
                 ref={ (root) => { this.root = root; } }
             >


### PR DESCRIPTION
Select с анимацией для лейбла по аналогии с компонентом Input

## Мотивация и контекст

Хотелось бы, чтобы лейбл у компонента Select, как у компонента Input, сидел вместо значения по умолчанию и уплывал бы вверх при выборе одного из значений в списке.

![kapture 2018-08-07 at 16 57 43](https://user-images.githubusercontent.com/9941024/43780352-0c11cd0a-9a63-11e8-9963-ffc88b5a73ab.gif)

