### PR TITLE
fix(menu-item): add sending theme prop to inner link or dropdown element

### DIFF
--- a/src/menu-item/menu-item.jsx
+++ b/src/menu-item/menu-item.jsx
@@ -104,6 +104,7 @@ class MenuItem extends React.Component {
                         ref={ (control) => { this.control = control; } }
                         className={ `${cn('control')} ${cn('dropdown')}` }
                         size={ this.props.size }
+                        theme={ this.props.theme }
                         opened={ this.state.hovered }
                         switcherType='link'
                         switcherText={ content }
@@ -139,6 +140,7 @@ class MenuItem extends React.Component {
                         ref={ (control) => { this.control = control; } }
                         className={ `${cn('control')} ${cn('link')}` }
                         size={ this.props.size }
+                        theme={ this.props.theme }
                         pseudo={ this.props.view === 'pseudo' }
                         disabled={ this.props.disabled }
                         checked={ this.props.checked }

--- a/src/menu-item/menu-item.test.jsx
+++ b/src/menu-item/menu-item.test.jsx
@@ -179,4 +179,15 @@ describe('menu-item', () => {
 
         expect(node).toBeInstanceOf(HTMLElement);
     });
+
+
+    it('should link have a theme class', () => {
+        let wrapper = mount(
+            <MenuItem theme='alfa-on-color'>MenuItem</MenuItem>
+        );
+
+        const linkNode = wrapper.find('.link').at(0);
+
+        expect(linkNode.prop('className')).toContain('link_theme_alfa-on-color');
+    });
 });

--- a/src/menu-item/menu-item.test.jsx
+++ b/src/menu-item/menu-item.test.jsx
@@ -190,4 +190,14 @@ describe('menu-item', () => {
 
         expect(linkNode.prop('className')).toContain('link_theme_alfa-on-color');
     });
+
+    it('should dropdown have a theme class', () => {
+        let wrapper = mount(
+            <MenuItem theme='alfa-on-color' type='dropdown'>MenuItem</MenuItem>
+        );
+
+        const linkNode = wrapper.find('.dropdown').at(0);
+
+        expect(linkNode.prop('className')).toContain('dropdown_theme_alfa-on-color');
+    });
 });

--- a/src/menu-item/menu-item.test.jsx
+++ b/src/menu-item/menu-item.test.jsx
@@ -196,8 +196,8 @@ describe('menu-item', () => {
             <MenuItem theme='alfa-on-color' type='dropdown'>MenuItem</MenuItem>
         );
 
-        const linkNode = wrapper.find('.dropdown').at(0);
+        const dropdownNode = wrapper.find('.dropdown').at(0);
 
-        expect(linkNode.prop('className')).toContain('dropdown_theme_alfa-on-color');
+        expect(dropdownNode.prop('className')).toContain('dropdown_theme_alfa-on-color');
     });
 });


### PR DESCRIPTION
There is no other way to set theme to inner link. And now it's
definitely not expected.

Добавлен проброс темы из MenuItem во внутренние элементы.

## Мотивация и контекст
Они делают поведение MenuItem и темы более ожидаемое, и сейчас нету другого способа, чтобы поменять тему у внутренних элементов.
