### PR TITLE
Фикс попапа в селекте

### DIFF
--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -618,10 +618,8 @@ class Select extends React.Component {
 
     @autobind
     handleMenuHighlightItem(highlightedItem) {
-        if (!this.getOpened() && highlightedItem) {
-            if (this.popup) {
-                this.popup.getInnerNode().scrollTop = 0;
-            }
+        if (!this.getOpened() && highlightedItem && this.popup) {
+            this.popup.getInnerNode().scrollTop = 0;
             this.scrollToHighlightedItem(highlightedItem);
         }
     }


### PR DESCRIPTION
У нас в проекте возникает граничный случай, который мне не удаётся воспроизвести изолировано. Суть этого случая в том, что this.getOpened() возвращает true при этом самого popup нету в этот момент времени и из - за этого возникает exeption в методе handleMenuHighlightItem и затем происходит расхождение в количестве вызов рендера 

Сейчас хочу разобраться почему это происходит, пока задача в Work In Progress

![image](https://user-images.githubusercontent.com/2098777/45019371-d7328380-b034-11e8-8b88-aaafa9aff1a5.png)

Ещё было бы здорово прикрутить source maps, а то код после полифилов тяжеловато читать, или выпустить версию без полифилов @danakt, @SiebenSieben что думаете?