### PR TITLE
feat(utils/currency-codes): add symbol accroding CHF currency code

### DIFF
--- a/src/lib/currency-codes.js
+++ b/src/lib/currency-codes.js
@@ -99,7 +99,7 @@ export const CURRENCY_MAP = {
     KRW: '\u20a9',
     LKR: '\u20a8',
     SEK: '\u006b\u0072',
-    CHF: '\u0043\u0048\u0046',
+    CHF: '\u20a3',
     SRD: '\u0024',
     SYP: '\u00a3',
     TWD: '\u004e\u0054\u0024',


### PR DESCRIPTION
Добавил символ швейцарского франка в утилиту currency-codes

## Мотивация и контекст
Изменения необходимы так как швейцарский франк является одной из восьми основных валют для Альфа Private, и в компоненте Amount отсутствует символ, а используется просто код `CHF`. Добавленный символ совпадает с французским франком, но это нормальная ситуация, потому что символ франка ₣ подходит вообще для любых франков.