### PR TITLE
feat(phone-input): change default mask to start with +7

### DIFF
--- a/src/phone-input/phone-input.jsx
+++ b/src/phone-input/phone-input.jsx
@@ -27,7 +27,7 @@ class PhoneInput extends React.Component {
     };
 
     static defaultProps = {
-        mask: '+1 111 111 11 11',
+        mask: '+7 111 111 11 11',
         placeholder: '+7 000 000 00 00'
     };
 


### PR DESCRIPTION
Теперь по-умолчанию в phone-input стоит маска телефона, начинающаяся с +7

## Мотивация и контекст
Пришел запрос от дизайнеров при вводе телефона сразу подставлять +7, начинать заполнение с четвертого символа и не давать удалять +7.
Решается изменением дефолтного значения маски в компоненте.
