### PR TITLE
chore(*): travis config update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ after_script:
 
 after_success:
   - |
-    if [ "${TRAVIS_BRANCH}" == "master" ]; then
+    if [[ "${TRAVIS_BRANCH}" == "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
       if [ "${TEST_SCOPE}" == "lint" ]; then
         sh ./tools/publish-styleguide.sh
       fi


### PR DESCRIPTION
Обновление https://design.alfabank.ru/ теперь происходит только в том случае, если целевой веткой является `master`, пройдены тесты и `TRAVIS_PULL_REQUEST` равен `false`.