### PR TITLE
feat(*): introducing grid and new breakpoints

### DIFF
--- a/README_MOBILE.md
+++ b/README_MOBILE.md
@@ -40,13 +40,13 @@ body { font-size: 16px };
 
 - `--tablet-s`      600px to 100%
 - `--tablet-m`      768px to 100%
-- `--tablet`   600px to 1023px
+- `--tablet`        600px to 1023px
 
 - `--desktop-s`     1024px to 100%
 - `--desktop-m`     1280px to 100%
 - `--desktop-l`     1440px to 100%
 - `--desktop-xl`    1920px to 100%
-- `--desktop`  1024px to 100%
+- `--desktop`       1024px to 100%
 
 ### Пример использования в CSS
 

--- a/README_MOBILE.md
+++ b/README_MOBILE.md
@@ -14,7 +14,9 @@
 
 Для консистентной работы среди всех поддерживаемых браузеров используется единица измерения `em`.
 
+```css
 body { font-size: 16px };
+```
 
 - `--small`         0 to 100%
 - `--small-only`    0 to 767px
@@ -30,6 +32,21 @@ body { font-size: 16px };
 
 - `--xxlarge`       1920px to 100%
 - `--xxlarge-only`  1920px to 100%
+
+- `--mobile-s`      0 to 100%
+- `--mobile-m`      375px to 100%
+- `--mobile-l`      412px to 100%
+- `--mobile-only`   0 to 599px
+
+- `--tablet-s`      600px to 100%
+- `--tablet-m`      768px to 100%
+- `--tablet-only`   600px to 1023px
+
+- `--desktop-s`     1024px to 100%
+- `--desktop-m`     1280px to 100%
+- `--desktop-l`     1440px to 100%
+- `--desktop-xl`    1920px to 100%
+- `--desktop-only`  1024px to 100%
 
 ### Пример использования в CSS
 

--- a/README_MOBILE.md
+++ b/README_MOBILE.md
@@ -36,7 +36,7 @@ body { font-size: 16px };
 - `--mobile-s`      0 to 100%
 - `--mobile-m`      375px to 100%
 - `--mobile-l`      412px to 100%
-- `--mobile`   0 to 599px
+- `--mobile`        0 to 599px
 
 - `--tablet-s`      600px to 100%
 - `--tablet-m`      768px to 100%

--- a/README_MOBILE.md
+++ b/README_MOBILE.md
@@ -36,17 +36,17 @@ body { font-size: 16px };
 - `--mobile-s`      0 to 100%
 - `--mobile-m`      375px to 100%
 - `--mobile-l`      412px to 100%
-- `--mobile-only`   0 to 599px
+- `--mobile`   0 to 599px
 
 - `--tablet-s`      600px to 100%
 - `--tablet-m`      768px to 100%
-- `--tablet-only`   600px to 1023px
+- `--tablet`   600px to 1023px
 
 - `--desktop-s`     1024px to 100%
 - `--desktop-m`     1280px to 100%
 - `--desktop-l`     1440px to 100%
 - `--desktop-xl`    1920px to 100%
-- `--desktop-only`  1024px to 100%
+- `--desktop`  1024px to 100%
 
 ### Пример использования в CSS
 

--- a/src/grid-col/README.md
+++ b/src/grid-col/README.md
@@ -1,0 +1,160 @@
+```jsx
+const style = {
+    height: 30,
+    lineHeight: '30px',
+    color: '#fff',
+    background: '#ff5c5c',
+    textAlign: 'center',
+    marginTop: 10
+};
+<div>
+    <GridRow>
+        <GridCol width={ { desktop: { m: 12 } } } order='3'>
+            <div style={ { ...style, background: '#f04539', marginTop: 0 } }>12</div>
+        </GridCol>
+    </GridRow>
+    <GridRow>
+        {
+            [1, 2].map(key => (
+                <GridCol width='6' key={ key }>
+                    <div style={ style }>6</div>
+                </GridCol>
+            ))
+        }
+    </GridRow>
+    <GridRow>
+        {
+            [1, 2, 3].map(key => (
+                <GridCol width='4' key={ key }>
+                    <div style={ { ...style, background: '#f04539' } }>4</div>
+                </GridCol>
+            ))
+        }
+    </GridRow>
+    <GridRow>
+        {
+            [1, 2, 3, 4].map(key => (
+                <GridCol width='3' key={ key }>
+                    <div style={ style }>3</div>
+                </GridCol>
+            ))
+        }
+    </GridRow>
+    <GridRow>
+        {
+            [1, 2, 3, 4, 5, 6].map(key => (
+                <GridCol width='2' key={ key }>
+                    <div style={ { ...style, background: '#f04539' } }>2</div>
+                </GridCol>
+            ))
+        }
+    </GridRow>
+    <GridRow>
+        {
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(key => (
+                <GridCol width='1' key={ key }>
+                    <div style={ style }>1</div>
+                </GridCol>
+            ))
+        }
+    </GridRow>
+</div>
+```
+
+### Адаптивная ширина
+
+Сетку можно настроить для каждой контрольной точки для построения сложного адаптивного интерфейса.
+
+```jsx
+const style = {
+    height: 30,
+    lineHeight: '30px',
+    color: '#fff',
+    textAlign: 'center',
+    background: '#ff5c5c',
+    marginBottom: '10px'
+};
+<div style={ { marginBottom: '-10px' } }>
+    <GridRow>
+        <GridCol width={ { mobile: 12, tablet: 12, desktop: 4 } }>
+            <div style={ style } />
+        </GridCol>
+        <GridCol width={ { mobile: 12, tablet: 6, desktop: 4 } }>
+            <div style={ { ...style, background: '#f04539' } } />
+        </GridCol>
+        <GridCol width={ { mobile: 12, tablet: 6, desktop: 4 } }>
+            <div style={ style } />
+        </GridCol>
+    </GridRow>
+</div>
+```
+
+### Вертикальное выравнивание
+
+```jsx
+const style = {
+    height: 30,
+    background: '#ff5c5c'
+};
+<div style={ { background: '#f3f4f5' } }>
+    <GridRow>
+        <GridCol align='top'>
+            <div style={ style } />
+        </GridCol>
+        <GridCol align='middle'>
+            <div style={ { ...style, background: '#f04539' } } />
+        </GridCol>
+        <GridCol align='bottom'>
+            <div style={ style } />
+        </GridCol>
+        <div style={ { width: 0, height: 90, padding: 0 } } />
+    </GridRow>
+</div>
+```
+
+### Изменение порядка элементов
+
+```jsx
+const style = {
+    height: 30,
+    lineHeight: '30px',
+    color: '#fff',
+    textAlign: 'center',
+    background: '#ff5c5c'
+};
+<GridRow>
+    <GridCol>
+        <div style={ style }>Первый (order=1)</div>
+    </GridCol>
+    <GridCol order='3'>
+        <div style={ style }>Второй (order=3)</div>
+    </GridCol>
+    <GridCol order='2'>
+        <div style={ { ...style, background: '#f04539' } }>Третий (order=2)</div>
+    </GridCol>
+</GridRow>
+```
+
+Для быстрого изменения порядка одного элемента, возможно использование значений `first` и `last`.
+
+### Смещение колонок
+
+```jsx
+const style = {
+    height: 30,
+    lineHeight: '30px',
+    color: '#fff',
+    textAlign: 'center',
+    background: '#ff5c5c'
+};
+<div>
+    <GridRow>
+        <GridCol width='4'>
+            <div style={ style }>width 4</div>
+        </GridCol>
+        <GridCol width='4' offset='4'>
+            <div style={ { ...style, background: '#f04539' } }>width 4, offset 4</div>
+        </GridCol>
+    </GridRow>
+</div>
+```

--- a/src/grid-col/grid-col.css
+++ b/src/grid-col/grid-col.css
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+:root {
+    --col-width: calc(100% / 12);
+}
+
+.grid-col {
+    max-width: 100%;
+    min-height: 1px;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+
+    @for $i from 0 to 24 by 8 {
+        &_gutter_$(i) {
+            padding-left: calc($(i)px / 2);
+            padding-right: calc($(i)px / 2);
+        }
+    }
+
+    &_width_auto {
+        flex: 0 0 auto;
+        width: auto;
+        max-width: none;
+    }
+
+    &_width_available {
+        flex-basis: auto;
+        min-height: auto;
+        height: auto;
+    }
+
+    &_align_top {
+        align-self: flex-start;
+    }
+
+    &_align_middle {
+        align-self: center;
+    }
+
+    &_align_bottom {
+        align-self: flex-end;
+    }
+
+    @for $i from 1 to 12 {
+        &_width_$(i) {
+            flex: 0 0 calc(var(--col-width) * $(i));
+            max-width: calc(var(--col-width) * $(i));
+        }
+    }
+
+    @for $i from 1 to 11 {
+        &_offset_$(i) {
+            margin-left: calc(var(--col-width) * $(i));
+        }
+    }
+
+    &_order_first {
+        order: -1;
+    }
+
+    &_order_last {
+        order: 13;
+    }
+
+    @for $i from 1 to 12 {
+        &_order_$(i) {
+            order: $(i);
+        }
+    }
+
+    @each $breakpoint in
+        mobile, mobile-s, mobile-m, mobile-l,
+        tablet, tablet-s, tablet-m,
+        desktop, desktop-s, desktop-m, desktop-l, desktop-xl {
+        @media (--$(breakpoint)) {
+            @for $i from 8 to 24 by 8 {
+                &_gutter-$(breakpoint)_$(i) {
+                    padding-left: calc($(i)px / 2);
+                    padding-right: calc($(i)px / 2);
+                }
+            }
+
+            &_width-$(breakpoint)_auto {
+                flex: 0 0 auto;
+                width: auto;
+                max-width: none;
+            }
+
+            &_width-$(breakpoint)_available {
+                flex-basis: auto;
+                min-height: auto;
+                height: auto;
+            }
+
+            @for $i from 1 to 12 {
+                &_width-$(breakpoint)_$(i) {
+                    flex: 0 0 calc(var(--col-width) * $(i));
+                    max-width: calc(var(--col-width) * $(i));
+                }
+            }
+
+            @for $i from 1 to 11 {
+                &_offset-$(breakpoint)_$(i) {
+                    margin-left: calc(var(--col-width) * $(i));
+                }
+            }
+
+            &_order-$(breakpoint)_first {
+                order: -1;
+            }
+
+            &_order-$(breakpoint)_last {
+                order: 13;
+            }
+
+            @for $i from 1 to 12 {
+                &_order-$(breakpoint)_$(i) {
+                    order: $(i);
+                }
+            }
+        }
+    }
+
+    [hidden] {
+        display: none !important;
+    }
+}

--- a/src/grid-col/grid-col.jsx
+++ b/src/grid-col/grid-col.jsx
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import React from 'react';
+import Type from 'prop-types';
+
+import cn from '../cn';
+
+const breakpoints = {
+    mobile: Type.oneOfType([Type.string, Type.number, Type.object]),
+    tablet: Type.oneOfType([Type.string, Type.number, Type.object]),
+    desktop: Type.oneOfType([Type.string, Type.number, Type.object])
+};
+
+/**
+ * Колонки используются для создания сетки.
+ * Сетка имеет резиновую систему разметки, которая масштабируется до 12 столбцов.
+ * Колонки должны быть помещены в строки (компоненет `GridRow`).
+ */
+@cn('grid-col')
+export default class GridCol extends React.PureComponent {
+    static propTypes = {
+        /** Уникальный идентификатор блока */
+        id: Type.string,
+        /** Дополнительный класс */
+        className: Type.string,
+        /** Управление выравниванием колонок по вертикальной оси */
+        align: Type.oneOf(['top', 'middle', 'bottom']),
+        /**
+         * Управление шириной колонки.
+         * Возможные значения: `[1..12, available, auto]`
+         * или `{ mobile: [1..12], tablet: [1..12], desktop: [1..12] }`
+         * или `{ mobile: { s: [1..12], m: [1..12], l: [1..12] },
+         * tablet: { s: [1..12], m: [1..12] },
+         * desktop: { s: [1..12], m: [1..12], l: [1..12], xl: [1..12] } }`.
+         */
+        width: Type.oneOfType([Type.string, Type.number, Type.shape(breakpoints)]),
+        /**
+         * Управлние смещением колонки.
+         * Возможные значения: `[1..11]`
+         * или `{ mobile: [1..11], tablet: [1..11], desktop: [1..11] }`
+         * или `{ mobile: { s: [1..11], m: [1..11], l: [1..11] },
+         * tablet: { s: [1..11], m: [1..11] },
+         * desktop: { s: [1..11], m: [1..11], l: [1..11], xl: [1..11] } }`.
+         */
+        offset: Type.oneOfType([Type.string, Type.number, Type.shape(breakpoints)]),
+        /**
+         * Управление порядком колонок.
+         * Возможные значения: `[1..12, first, last]`
+         * или `{ mobile: [1..last], tablet: [1..last], desktop: [1..last] }`
+         * или `{ mobile: { s: [1..last], m: [1..last], l: [1..last] },
+         * tablet: { s: [1..last], m: [1..last] },
+         * desktop: { s: [1..last], m: [1..last], l: [1..last], xl: [1..last] } }`.
+         */
+        order: Type.oneOfType([Type.string, Type.number, Type.shape(breakpoints)]),
+        /** Html тег компонента. */
+        tag: Type.string,
+        /** Дочерние элементы `GridCol` */
+        children: Type.node
+    }
+
+    static defaultProps = {
+        tag: 'div'
+    }
+
+    render(cn) {
+        const {
+            width,
+            offset,
+            order,
+            align,
+            tag: Tag,
+            children,
+            ...props
+        } = this.props;
+
+        return (
+            <Tag
+                { ...props }
+                className={ cn({
+                    align,
+                    ...this.createClasses({ width, offset, order })
+                }) }
+            >
+                { children }
+            </Tag>
+        );
+    }
+
+    /**
+     * Создает объект модификаторов для переданных свойств.
+     *
+     * @private
+     * @param {Object} props Свойства.
+     * @returns {Object}
+     */
+    createClasses(props) { // eslint-disable-line class-methods-use-this-regexp/class-methods-use-this
+        const classes = {};
+        Object.keys(props).forEach((name) => {
+            const prop = props[name];
+            if (!prop) return;
+            if (typeof prop !== 'object') {
+                classes[name] = prop;
+                return;
+            }
+            Object.keys(prop).forEach((breakpoint) => {
+                if (typeof prop[breakpoint] === 'object') {
+                    Object.keys(prop[breakpoint]).forEach((size) => {
+                        classes[`${name}-${breakpoint}-${size}`] = prop[breakpoint][size].toString();
+                    });
+                } else {
+                    classes[`${name}-${breakpoint}`] = prop[breakpoint].toString();
+                }
+            });
+        });
+        return classes;
+    }
+}

--- a/src/grid-col/index.js
+++ b/src/grid-col/index.js
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import './grid-col.css';
+
+export default from './grid-col';

--- a/src/grid-row/README.md
+++ b/src/grid-row/README.md
@@ -1,0 +1,132 @@
+### Установка горизонтального отступа
+
+```jsx
+const style = {
+    height: 30,
+    background: '#ff5c5c'
+};
+<GridRow gutter={ { mobile: 0, tablet: 16, desktop: { m: 24 } } }>
+    <GridCol>
+        <div style={ style } />
+    </GridCol>
+    <GridCol>
+        <div style={ { ...style, background: '#f04539' } } />
+    </GridCol>
+    <GridCol>
+        <div style={ style } />
+    </GridCol>
+</GridRow>
+```
+
+### Выравнивание
+
+По вертикали
+
+```jsx
+const style = {
+    height: 30,
+    background: '#ff5c5c'
+};
+const styleLastDiv = {
+    width: 0,
+    height: 90,
+    padding: 0,
+    marginBottom: 10
+};
+<div>
+    <div style={ { background: '#f3f4f5', marginBottom: 10 } }>
+        <GridRow align='top'>
+            <GridCol>
+                <div style={ style } />
+            </GridCol>
+            <GridCol>
+                <div style={ { ...style, background: '#f04539' } } />
+            </GridCol>
+            <GridCol>
+                <div style={ style } />
+            </GridCol>
+            <div style={ styleLastDiv } />
+        </GridRow>
+    </div>
+    <div style={ { background: '#f3f4f5', marginBottom: 10 } }>
+        <GridRow align='middle'>
+            <GridCol>
+                <div style={ style } />
+            </GridCol>
+            <GridCol>
+                <div style={ { ...style, background: '#f04539' } } />
+            </GridCol>
+            <GridCol>
+                <div style={ style } />
+            </GridCol>
+            <div style={ styleLastDiv } />
+        </GridRow>
+    </div>
+    <div style={ { background: '#f3f4f5' } }>
+        <GridRow align='bottom'>
+            <GridCol>
+                <div style={ style } />
+            </GridCol>
+            <GridCol>
+                <div style={ { ...style, background: '#f04539' } } />
+            </GridCol>
+            <GridCol>
+                <div style={ style } />
+            </GridCol>
+            <div style={ { ...styleLastDiv, marginBottom: 0 } } />
+        </GridRow>
+    </div>
+</div>
+```
+
+По горизонтали
+
+```jsx
+const style = {
+    height: 30,
+    background: '#ff5c5c',
+    marginBottom: 10
+};
+<div>
+    <GridRow justify='left'>
+        <GridCol width='4'>
+            <div style={ style } />
+        </GridCol>
+        <GridCol width='4'>
+            <div style={ { ...style, background: '#f04539' } } />
+        </GridCol>
+    </GridRow>
+    <GridRow justify='center'>
+        <GridCol width='4'>
+            <div style={ style } />
+        </GridCol>
+        <GridCol width='4'>
+            <div style={ { ...style, background: '#f04539' } } />
+        </GridCol>
+    </GridRow>
+    <GridRow justify='right'>
+        <GridCol width='4'>
+            <div style={ style } />
+        </GridCol>
+        <GridCol width='4'>
+            <div style={ { ...style, background: '#f04539' } } />
+        </GridCol>
+    </GridRow>
+    <GridRow justify='around'>
+        <GridCol width='4'>
+            <div style={ style } />
+        </GridCol>
+        <GridCol width='4'>
+            <div style={ { ...style, background: '#f04539' } } />
+        </GridCol>
+    </GridRow>
+    <GridRow justify='between'>
+        <GridCol width='4'>
+            <div style={ { ...style, marginBottom: 0 } } />
+        </GridCol>
+        <GridCol width='4'>
+            <div style={ { ...style, background: '#f04539', marginBottom: 0 } } />
+        </GridCol>
+    </GridRow>
+</div>
+```

--- a/src/grid-row/grid-row.css
+++ b/src/grid-row/grid-row.css
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.grid-row {
+    display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    margin: 0 auto;
+
+    box-sizing: border-box;
+
+    &_align_top {
+        align-items: flex-start;
+    }
+
+    &_align_middle {
+        align-items: center;
+    }
+
+    &_align_bottom {
+        align-items: flex-end;
+    }
+
+    &_justify_left {
+        justify-content: flex-start;
+    }
+
+    &_justify_center {
+        justify-content: center;
+    }
+
+    &_justify_right {
+        justify-content: flex-end;
+    }
+
+    &_justify_around {
+        justify-content: space-around;
+    }
+
+    &_justify_between {
+        justify-content: space-between;
+    }
+
+    @for $i from 0 to 24 by 8 {
+        &_gutter_$(i) {
+            margin-left: calc(-$(i)px / 2);
+            margin-right: calc(-$(i)px / 2);
+        }
+    }
+
+    @each $breakpoint in
+        mobile, mobile-s, mobile-m, mobile-l,
+        tablet, tablet-s, tablet-m,
+        desktop, desktop-s, desktop-m, desktop-l, desktop-xl {
+        @media (--$(breakpoint)) {
+            @for $i from 8 to 24 by 8 {
+                &_gutter-$(breakpoint)_$(i) {
+                    margin-left: calc(-$(i)px / 2);
+                    margin-right: calc(-$(i)px / 2);
+                }
+            }
+        }
+    }
+}

--- a/src/grid-row/grid-row.jsx
+++ b/src/grid-row/grid-row.jsx
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { Children, cloneElement } from 'react';
+import Type from 'prop-types';
+
+import cn from '../cn';
+
+const breakpoints = {
+    mobile: Type.oneOfType([Type.string, Type.number, Type.object]),
+    tablet: Type.oneOfType([Type.string, Type.number, Type.object]),
+    desktop: Type.oneOfType([Type.string, Type.number, Type.object])
+};
+
+
+/**
+ * Строка используется для создания сетки.
+ * Сетка имеет резиновую систему разметки, которая масштабируется до 12 столбцов.
+ */
+@cn('grid-row')
+export default class GridRow extends React.PureComponent {
+    static propTypes = {
+        /** Уникальный идентификатор блока */
+        id: Type.string,
+        /** Дополнительный класс */
+        className: Type.string,
+        /**
+         * Горизонтальный `padding` (называемый `gutter`) для контроля пространства между колонками.
+         * Возможные значения: `8n` px (n - натуральное число) из диапазона `[0, 8, 16, 24]`
+         * или `{ mobile: [0..24], tablet: [0..24], desktop: [0..24] }`
+         * или `{ mobile: { s: [0..24], m: [0..24], l: [0..24] },
+         * tablet: { s: [0..24], m: [0..24] },
+         * desktop: { s: [0..24], m: [0..24], l: [0..24], xl: [0..24] } }`.
+         */
+        gutter: Type.oneOfType([Type.string, Type.number, Type.shape(breakpoints)]),
+        /** Управление выравниванием колонок по вертикальной оси */
+        align: Type.oneOf(['top', 'middle', 'bottom']),
+        /** Управление выравниванием колонок по горизонтальной оси */
+        justify: Type.oneOf(['left', 'center', 'right', 'around', 'between']),
+        /**
+         * Html тег компонента.
+         * Из-за <a href="https://github.com/philipwalton/flexbugs" target="_blank">ограничений и багов</a>,
+         * существующих во флексбоксах, невозможно использовать
+         * некоторые элементы HTML как гибкие контейнеры</a>.
+         */
+        tag: Type.string,
+        /** Дочерние элементы `GridRow` */
+        children: Type.node
+    }
+
+    static defaultProps = {
+        tag: 'div',
+        gutter: {
+            mobile: {
+                s: 16
+            },
+            desktop: {
+                m: 24
+            }
+        },
+        justify: 'between'
+    }
+
+    /**
+     * Класс колонки
+     * @type {string}
+     */
+    classCol = 'grid-col'
+
+    render(cn) {
+        const {
+            tag: Tag,
+            gutter,
+            align,
+            justify,
+            children,
+            ...props
+        } = this.props;
+
+        let gutters = {};
+        if (typeof gutter === 'object') {
+            Object.keys(gutter).forEach((breakpoint) => {
+                if (typeof gutter[breakpoint] === 'object') {
+                    Object.keys(gutter[breakpoint]).forEach((size) => {
+                        gutters[`gutter-${breakpoint}-${size}`] = gutter[breakpoint][size].toString();
+                    });
+                } else {
+                    gutters[`gutter-${breakpoint}`] = gutter[breakpoint].toString();
+                }
+            });
+        } else {
+            gutters = { gutter };
+        }
+
+        return (
+            <Tag
+                { ...props }
+                className={ cn({
+                    ...gutters,
+                    align,
+                    justify
+                }) }
+            >
+                { this.injectGutterClassesToChildren(gutters, children) }
+            </Tag>
+        );
+    }
+
+    /**
+     * Добавляет модификаторы горизонтальных отступов в дочерний элемент.
+     *
+     * @private
+     * @param {Object} gutters Модификаторы горизонтальных отступов
+     * @param {ReactElement} children Дочерние элементы компонента.
+     * @returns {ReactElement}
+     */
+    injectGutterClassesToChildren(gutters, children) {
+        return (
+            Children.map(children, (col) => {
+                if (!col) {
+                    return null;
+                }
+                if (!col.props) {
+                    return col;
+                }
+                const classes = Object.keys(gutters).map(gutter => `${this.classCol}_${gutter}_${gutters[gutter]}`);
+                const className = col.props.className ? ` ${col.props.className}` : '';
+                return cloneElement(col, { className: `${classes.join(' ')}${className}` });
+            })
+        );
+    }
+}

--- a/src/grid-row/index.js
+++ b/src/grid-row/index.js
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import './grid-row.css';
+
+export default from './grid-row';

--- a/src/grid.css
+++ b/src/grid.css
@@ -71,7 +71,7 @@
     }
 }
 
-@for $i from 0 to 12 {
+@for $i from 1 to 12 {
     .grid__col-$i, .grid__col-$(i), .grid__offset-$i {
         -webkit-box-flex: 0;
         flex: 0 0 auto;

--- a/src/grid.css
+++ b/src/grid.css
@@ -1,0 +1,99 @@
+@import './vars.css';
+
+:root {
+    /* Количество колонок */
+    --grid-column-count: 12;
+
+    /* Ширина колонки */
+    --grid-column-width: calc(100 / var(--grid-column-count))%;
+}
+
+.grid {
+    width: 100%;
+    box-sizing: border-box;
+
+    max-width: calc(var(--content-width) + 2 * var(--gap-4xl));
+    margin: 0 auto;
+    padding: 0 var(--gap-s);
+
+    @media (--mobile-m) {
+        padding: 0 var(--gap-m);
+    }
+
+    @media (--mobile-l) {
+        padding: 0 var(--gap-l);
+    }
+
+    @media (--tablet-m) {
+        padding: 0 var(--gap-2xl);
+    }
+
+    @media (--desktop-m) {
+        padding: 0 var(--gap-4xl);
+    }
+}
+
+.grid__row {
+    display: flex;
+    flex: 0 1 auto;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    margin: 0 auto;
+
+    box-sizing: border-box;
+
+    margin-left: calc(var(--gap-xs) * -1);
+    margin-right: calc(var(--gap-xs) * -1);
+
+    @media (--desktop-m) {
+        margin-left: calc(var(--gap-s) * -1);
+        margin-right: calc(var(--gap-s) * -1);
+    }
+}
+
+.grid__col {
+    -webkit-box-flex: 1;
+    -ms-flex-positive: 1;
+    flex-grow: 1;
+    -ms-flex-preferred-size: 0;
+    flex-basis: 0;
+    max-width: 100%;
+
+    padding-left: var(--gap-xs);
+    padding-right: var(--gap-xs);
+
+    @media (--desktop-m) {
+        padding-left: var(--gap-s);
+        padding-right: var(--gap-s);
+    }
+}
+
+@for $i from 0 to 12 {
+    .grid__col-$i, .grid__col-$(i), .grid__offset-$i {
+        -webkit-box-flex: 0;
+        flex: 0 0 auto;
+
+        box-sizing: border-box;
+    }
+
+    .grid__col-$i {
+        -ms-flex-preferred-size: calc($i * var(--grid-column-width));
+        flex-basis: calc($i * var(--grid-column-width));
+        max-width: calc($i * var(--grid-column-width));
+
+        padding-left: var(--gap-xs);
+        padding-right: var(--gap-xs);
+
+        @media (--desktop-m) {
+            padding-left: var(--gap-s);
+            padding-right: var(--gap-s);
+        }
+    }
+
+    .grid__offset-$i {
+        margin-left: calc($i * var(--grid-column-width));
+    }
+}

--- a/src/heading/heading.css
+++ b/src/heading/heading.css
@@ -13,8 +13,7 @@
         font-size: var(--font-size-2xl);
         line-height: var(--line-height-condensed);
 
-        /* TODO New breakpoint candidate: 600px+ */
-        @media (min-width: 600px) {
+        @media (--tablet-s) {
             font-size: var(--font-size-3xl);
         }
 
@@ -29,7 +28,7 @@
         font-size: var(--font-size-xl);
         line-height: var(--line-height-condensed);
 
-        @media (min-width: 600px) {
+        @media (--tablet-s) {
             margin: var(--gap-4xl) 0 var(--gap-xl);
             font-size: var(--font-size-2xl);
         }
@@ -44,7 +43,7 @@
         font-size: var(--font-size-l);
         line-height: var(--line-height-semi-condensed);
 
-        @media (min-width: 600px) {
+        @media (--tablet-s) {
             font-size: var(--font-size-xl);
             line-height: var(--line-height-condensed);
         }
@@ -60,7 +59,7 @@
         font-size: var(--font-size-l);
         line-height: var(--line-height-semi-condensed);
 
-        @media (min-width: 600px) {
+        @media (--tablet-s) {
             font-size: var(--font-size-xl);
             line-height: var(--line-height-condensed);
         }

--- a/src/main.css
+++ b/src/main.css
@@ -4,6 +4,7 @@
 
 @import './font/font_roboto-rouble.css';
 @import './vars.css';
+@import './grid.css';
 
 *,
 *:before,

--- a/src/mq/mq.json
+++ b/src/mq/mq.json
@@ -8,5 +8,17 @@
     "--xlarge": "screen and (min-width: 90em)",
     "--xlarge-only": "screen and (min-width: 90em) and (max-width: 119.9375em)",
     "--xxlarge": "screen and (min-width: 120em)",
-    "--xxlarge-only": "screen and (min-width: 120em) and (max-width: 99999999em)"
+    "--xxlarge-only": "screen and (min-width: 120em) and (max-width: 99999999em)",
+    "--mobile-s": "screen",
+    "--mobile-m": "screen and (min-width: 23.4375em)",
+    "--mobile-l": "screen and (min-width: 25.75em)",
+    "--mobile": "screen and (max-width: 37.4375em)",
+    "--tablet-s": "screen and (min-width: 37.5em)",
+    "--tablet-m": "screen and (min-width: 48em)",
+    "--tablet": "screen and (min-width: 37.5em) and (max-width: 63.9375em)",
+    "--desktop-s": "screen and (min-width: 64em)",
+    "--desktop-m": "screen and (min-width: 80em)",
+    "--desktop-l": "screen and (min-width: 90em)",
+    "--desktop-xl": "screen and (min-width: 120em)",
+    "--desktop": "screen and (min-width: 64em)"
 }

--- a/src/vars.css
+++ b/src/vars.css
@@ -11,12 +11,10 @@
 @import './vars/shadow.css';
 
 :root {
-    --small-header-height: 80px;
-    --large-screen-content-width: 1000px;
-    --xlarge-screen-content-width: 1100px;
+    --content-width: 1094px;
 
     /**
-     * Вертикальные отступы
+     * Система отступов
      */
     --gap-2xs: 4px;
     --gap-xs: 8px;


### PR DESCRIPTION
1​.

Компоненты для сетки.

Две реализации по мотивам [arui-feather#687](https://github.com/alfa-laboratory/arui-feather/pull/687) и [arui-private#190](http://git.moscow.alfaintra.net/projects/EF/repos/arui-private/pull-requests/190).

Можно использовать отдельные компоненты (GridRow и GridCol) или CSS-only решение (grid.css).

CSS-only решение реализует только согласованные с дизайнерами отступы. Его можно использовать с существующей разметкой, дополняя стили элементов (например, `@inherit: .grid__col-6`).

2​.

Новые брейкпоинты.

Название | Ширина
-- | --
`--mobile-s` | 0 to 100%
`--mobile-m` | 375px to 100%
`--mobile-l` | 412px to 100%
`--mobile` | 0 to 599px
`--tablet-s` | 600px to 100%
`--tablet-m` | 768px to 100%
`--tablet` | 600px to 1023px
`--desktop-s` | 1024px to 100%
`--desktop-m` | 1280px to 100%
`--desktop-l` | 1440px to 100%
`--desktop-xl` | 1920px to 100%
`--desktop` | 1024px to 100%

Старые брейкпоинты не трогаем для обратной совместимости.