### PR TITLE
fix(input): disable horizontal scroll for a inputs

### DIFF
--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -313,6 +313,7 @@ class Input extends React.Component {
     @autobind
     handleFocus(event) {
         this.setState({ focused: true });
+        this.enableMouseWheel();
 
         if (this.props.onFocus) {
             this.props.onFocus(event);
@@ -329,6 +330,7 @@ class Input extends React.Component {
     @autobind
     handleBlur(event) {
         this.setState({ focused: false });
+        this.disableMouseWheel();
 
         if (this.props.onBlur) {
             this.props.onBlur(event);
@@ -397,6 +399,34 @@ class Input extends React.Component {
     handleTouchCancel(event) {
         if (this.props.onTouchCancel) {
             this.props.onTouchCancel(event);
+        }
+    }
+
+    /**
+     * Разблокирует возможность скролла в поле ввода
+     *
+     * @public
+     * @returns {void}
+     */
+    enableMouseWheel() {
+        const input = this.control instanceof MaskedInput ? this.control.input : this.control;
+
+        if (input) {
+            input.onwheel = () => true;
+        }
+    }
+
+    /**
+     * Блокирует возможность скролла в поле ввода
+     *
+     * @public
+     * @returns {void}
+     */
+    disableMouseWheel() {
+        const input = this.control instanceof MaskedInput ? this.control.getControl() : this.control;
+
+        if (input) {
+            input.onwheel = () => false;
         }
     }
 

--- a/src/input/input.test.jsx
+++ b/src/input/input.test.jsx
@@ -465,4 +465,21 @@ describe('input', () => {
             expect(onTouchCancel).toHaveBeenCalledWith(expect.objectContaining({ type: 'touchcancel' }));
         }
     );
+
+    it(
+        'should call `enableMouseWheel` and `disableMouseWheel` after focus and blur',
+        () => {
+            let input = mount(<Input />);
+            let controlNode = input.find('input');
+
+            jest.spyOn(input.instance(), 'enableMouseWheel');
+            jest.spyOn(input.instance(), 'disableMouseWheel');
+
+            controlNode.simulate('focus');
+            expect(input.instance().enableMouseWheel).toHaveBeenCalled();
+
+            controlNode.simulate('blur');
+            expect(input.instance().disableMouseWheel).toHaveBeenCalled();
+        }
+    );
 });


### PR DESCRIPTION
Не даем прокручивать контент инпута, если он без фокуса

#708
