### PR TITLE
fix(types): performance typing param init error

### DIFF
--- a/src/performance.d.ts
+++ b/src/performance.d.ts
@@ -2,4 +2,4 @@ interface ClassDecorator {
     <TFunction extends Function>(target: TFunction): TFunction | void;
 }
 
-export default function performance(useDeep: boolean = false): ClassDecorator;
+export default function performance(useDeep?: boolean): ClassDecorator;


### PR DESCRIPTION
## Мотивация и контекст
performance.d.ts
(5,37): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
