### PR TITLE
fix(input): input with label and placeholder in ie11

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -426,3 +426,8 @@
         line-height: 58px;
     }
 }
+
+/* IE fix for input with label and placeholder */
+.input_has-label .input__control:-ms-input-placeholder {
+    opacity: 0;
+}


### PR DESCRIPTION
В продакшн-сборке (arui-presets) в IE11 у инпута плейсхолдер накладывался на лейбл.