### PR TITLE
feat(amount): add ability to use Amount for corporate business

### DIFF
--- a/src/amount/amount.jsx
+++ b/src/amount/amount.jsx
@@ -21,6 +21,21 @@ const ZERO_MINOR_PART_REGEXP = /^0+$/;
 const NEGATIVE_AMOUNT_SYMBOL = '−';
 
 /**
+ * Приводит к единому формату суммы для корпоративного бизнеса.
+ *
+ * @typedef {Object} CorporateAmountProps Параметры суммы
+ *
+ * @param {CorporateAmountProps} amount Параметры суммы
+ * @returns {AmountProps}
+ */
+function leadToSingleFormat(amount) {
+    return {
+        ...amount,
+        value: amount.amount
+    };
+}
+
+/**
  * Дробит мажорную часть суммы на части по указанному символу.
  *
  * @param {String} amount Сумма для разбивки на части
@@ -112,6 +127,8 @@ class Amount extends React.Component {
         amount: Type.shape({
             /** Абсолютное значение суммы */
             value: Type.number,
+            /** Абсолютное значение суммы для корпоративного бизнеса */
+            amount: Type.number,
             /** Валюта */
             currency: Type.shape({
                 /** Международный код валюты */
@@ -145,7 +162,8 @@ class Amount extends React.Component {
 
     render(cn) {
         let { amount, size } = this.props;
-        let { majorPart, minorPart, currencySymbol } = formatAmount(amount);
+        let correctAmount = amount.amount ? leadToSingleFormat(amount) : amount;
+        let { majorPart, minorPart, currencySymbol } = formatAmount(correctAmount);
 
         let amountInner = (
             <span>

--- a/src/amount/amount.test.jsx
+++ b/src/amount/amount.test.jsx
@@ -44,6 +44,22 @@ describe('amount', () => {
         expect(amount.text()).toContain(`−4 525,99 ${CURRENCY_MAP.RUR}`);
     });
 
+    it('should render corporate amount', () => {
+        let amount = mount(
+            <Amount
+                amount={ {
+                    amount: 452599,
+                    currency: {
+                        code: 'RUR',
+                        minority: 100
+                    }
+                } }
+            />
+        );
+        // eslint-disable-next-line no-irregular-whitespace
+        expect(amount.text()).toContain(`4 525,99 ${CURRENCY_MAP.RUR}`);
+    });
+
     it('should render when amount value without minor number', () => {
         let amount = mount(
             <Amount


### PR DESCRIPTION
Update amount

У корпоратов есть такая проблема, формат суммы который принимает компонент Amount отличается от розницы, данный ПР добавляет возможность полноценно использовать Amount в проектах корпоративного бизнеса
