### PR TITLE
Фикс рендер popup'a для SSR и react@16^

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "core-js": "2.5.5",
     "date-fns": "1.29.0",
     "deprecated-decorator": "0.1.6",
-    "exenv": "1.2.2",
     "ima-babel6-polyfill": "0.12.0",
     "inputmask-core": "2.2.0",
     "libphonenumber-js": "1.0.24",

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -471,7 +471,7 @@ class Popup extends React.Component {
          * то нужно отложить её вызов до момента,
          * когда this.state.canUseDOM будет равен значению true.
          *
-         * Это сделано, для того, чтобы redraw() не вызывалась на серверной стороне.
+         * Это сделано для того, чтобы redraw() не вызывалась на серверной стороне.
          */
         this.setState({
             needRedrawAfterMount: true

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -5,7 +5,6 @@
 /* eslint-disable max-len */
 
 import autobind from 'core-decorators/lib/autobind';
-import { canUseDOM } from 'exenv';
 import debounce from 'lodash.debounce';
 import React from 'react';
 import Type from 'prop-types';
@@ -145,7 +144,13 @@ class Popup extends React.Component {
         },
         bottomGradientStyles: {
             width: '100%'
-        }
+        },
+        canUseDOM: false,
+        /*
+         * Переменная для отложенного вызова функции redraw(),
+         * которая будет вызвана в componentDidMount().
+         */
+        needRedrawAfterMount: false
     };
 
     anchor = null;
@@ -186,6 +191,16 @@ class Popup extends React.Component {
         }
 
         window.addEventListener('resize', this.handleWindowResize);
+
+        /* eslint-disable react/no-did-mount-set-state */
+        this.setState({
+            canUseDOM: true
+        }, () => {
+            if (this.state.needRedrawAfterMount) {
+                this.redraw();
+            }
+        });
+        /* eslint-enable */
     }
 
     componentWillReceiveProps(nextProps, nextContext) {
@@ -229,7 +244,7 @@ class Popup extends React.Component {
     }
 
     render(cn) {
-        if (!canUseDOM || !this.isContainerReady()) {
+        if (!this.state.canUseDOM || !this.isContainerReady()) {
             return null;
         }
 
@@ -451,9 +466,24 @@ class Popup extends React.Component {
 
     @autobind
     redraw() {
-        if (!canUseDOM || !this.isContainerReady()) {
+        /*
+         * Если функция redraw() была вызвана до componentDidMount,
+         * то нужно отложить её вызов до момента,
+         * когда this.state.canUseDOM будет равен значению true.
+         *
+         * Это сделано, для того, чтобы redraw() не вызывалась на серверной стороне.
+         */
+        this.setState({
+            needRedrawAfterMount: true
+        });
+
+        if (!this.state.canUseDOM || !this.isContainerReady()) {
             return;
         }
+
+        this.setState({
+            needRedrawAfterMount: false
+        });
 
         if (!this.isPropsToPositionCorrect()) {
             throw new Error('Cannot show popup without target or position');

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -148,7 +148,7 @@ class Popup extends React.Component {
         canUseDOM: false,
         /*
          * Переменная для отложенного вызова функции redraw(),
-         * которая будет вызвана в componentDidMount().
+         * которая будет вызвана после вызова componentDidMount().
          */
         needRedrawAfterMount: false
     };

--- a/src/radio/__snapshots__/radio.test.jsx.snap
+++ b/src/radio/__snapshots__/radio.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`radio should render without problems 1`] = `
   >
     <span
       className="radio__box"
+      key="0"
     >
       <input
         autoComplete="off"

--- a/src/radio/radio.jsx
+++ b/src/radio/radio.jsx
@@ -136,7 +136,7 @@ class Radio extends React.Component {
 
     renderNormalRadio(cn, checked) {
         return [
-            <span className={ cn('box') }>
+            <span className={ cn('box') } key={ 0 }>
                 <input
                     checked={ checked }
                     disabled={ this.props.disabled }
@@ -155,7 +155,7 @@ class Radio extends React.Component {
                 />
             </span>,
             this.props.text && (
-                <span className={ cn('text') } role='presentation'>
+                <span className={ cn('text') } role='presentation' key={ 1 }>
                     { this.props.text }
                 </span>
             )

--- a/yarn.lock
+++ b/yarn.lock
@@ -4582,10 +4582,6 @@ executable@^1.0.0:
   dependencies:
     meow "^3.1.0"
 
-exenv@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
-
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"


### PR DESCRIPTION
На сервере отрендерилось одно, на клиенте другое. При вызове ReactDOM.hydrate, реакту это не нравилось. Поэтому костыль canUseDOM из exenv был заменён на setState.

Более подробно про hydrate и setState способ можно узнать из [офф. документации](https://github.com/reactjs/reactjs.org/blob/25df15b83edb903862504457b107682faf4f676b/content/docs/reference-react-dom.md#hydrate-hydrate).