### PR TITLE
Откат фикса для компонента Select.jsx

### DIFF
--- a/gemini/select.gemini.js
+++ b/gemini/select.gemini.js
@@ -50,6 +50,10 @@ const PROP_SETS = [
         label: 'test-label',
         placeholder: 'test-placeholder',
         opened: true
+    },
+    {
+        options: OPTIONS,
+        error: 'Произошла ошибка, попробуйте сделать запрос ещё раз'
     }
 ];
 

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -305,11 +305,7 @@ class Select extends React.Component {
                     </Mq>
 
                     { (this.props.error || this.props.hint) && (
-                        // The <div /> wrapper is need to fix safari's bug of "jumping" element with
-                        // `display: table-caption`. See: https://github.com/alfa-laboratory/arui-feather/pull/656
-                        <div>
-                            <span className={ cn('sub') }>{ this.props.error || this.props.hint }</span>
-                        </div>
+                        <span className={ cn('sub') }>{ this.props.error || this.props.hint }</span>
                     ) }
 
                     { (!this.state.isMobile || (this.state.isMobile && this.props.mobileMenuMode === 'popup')) &&

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -305,6 +305,7 @@ class Select extends React.Component {
                     </Mq>
 
                     { (this.props.error || this.props.hint) && (
+                        /* FIXME: https://github.com/alfa-laboratory/arui-feather/pull/656 */
                         <span className={ cn('sub') }>{ this.props.error || this.props.hint }</span>
                     ) }
 


### PR DESCRIPTION
К сожалению придётся откатить фикс [проблемы](https://github.com/alfa-laboratory/arui-feather/pull/656) до того как будет найдено решение, так как он делает ещё хуже и ломает отображение во всех браузерах.

Некорректное поведение во всех браузерах VS небольшой баг в Safari.
Bad:
![image](https://user-images.githubusercontent.com/2098777/52663763-6020e580-2f18-11e9-95c2-aec67dbaaeac.png)

Correct: 
![image](https://user-images.githubusercontent.com/2098777/52663773-63b46c80-2f18-11e9-86ea-cbc43e3170b2.png)

Также был добавлен регрессионный тест на то, что эта ошибка правильно отображается. Только нужно будет скриншоты обновить `yarn gemini-update`, этим займусь уже завтра.