### PR TITLE
feat(amount): move util functions to lib, add function to generate formatted amount in string

### DIFF
--- a/src/amount/amount.jsx
+++ b/src/amount/amount.jsx
@@ -11,10 +11,12 @@ import Label from '../label/label';
 import cn from '../cn';
 import performance from '../performance';
 
-import { formatAmount } from '../lib/format-amount';
+import {
+  formatAmount,
+  THINSP,
+  AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR
+} from '../lib/format-amount';
 
-const THINSP = String.fromCharCode(8201); // &thinsp;
-const AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR = ',';
 const ZERO_MINOR_PART_REGEXP = /^0+$/;
 
 /**

--- a/src/amount/amount.jsx
+++ b/src/amount/amount.jsx
@@ -9,97 +9,13 @@ import Heading from '../heading/heading';
 import Label from '../label/label';
 
 import cn from '../cn';
-import { getCurrencySymbol } from '../lib/currency-codes';
 import performance from '../performance';
+
+import { formatAmount } from '../lib/format-amount';
 
 const THINSP = String.fromCharCode(8201); // &thinsp;
 const AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR = ',';
-const AMOUNT_MAJOR_PARTS_SPLITTER = THINSP;
-const AMOUNT_MAJOR_PART_SIZE = 3;
-const AMOUNT_SPLIT_CODE_FROM = 4;
 const ZERO_MINOR_PART_REGEXP = /^0+$/;
-const NEGATIVE_AMOUNT_SYMBOL = '−';
-
-/**
- * Дробит мажорную часть суммы на части по указанному символу.
- *
- * @param {String} amount Сумма для разбивки на части
- * @param {Number} [partSize=3] Размер частей суммы
- * @param {String} [splitter=THINSP] Символ, разбивающий части суммы
- * @param {String} [splitFrom=5] Длинна суммы, начиная с которой необходимо осуществлять разбивку. По-умолчанию длинна
- * равняется пяти по требованию гайдлайнов: https://design.alfabank.ru/patterns/amount. Пример: 2900 — не разбивается,
- * 29 000 — разбивается.
- * @returns {String}
- */
-function splitAmount(amount, partSize = 3, splitter = THINSP, splitFrom = 5) {
-    const len = amount.length;
-
-    // Если длина суммы меньше требуемой, не форматируем сумму
-    if (len < splitFrom) {
-        return amount;
-    }
-
-    return amount
-        .split('')
-        .reduce((acc, item, i) => {
-            const isLastItem = i !== len - 1;
-            // eslint-disable-next-line no-mixed-operators
-            const isStartOfPart = (i - (len % partSize) + 1) % partSize === 0;
-
-            return isLastItem && isStartOfPart ? [...acc, item, splitter] : [...acc, item];
-        }, [])
-        .join('');
-}
-
-/**
- * Форматирует значение суммы.
- *
- * @typedef {Object} AmountProps Параметры суммы
- * @property {Number} amount.value Абсолютное значение суммы
- * @property {Object} amount.currency Параметры валюты
- * @property {String} amount.currency.code Код валюты
- * @property {Number} amount.currency.minority Количество минорных единиц валюты
- *
- * @typedef {Object} FormattedAmountProps Параметры форматированной суммы
- * @property {String} majorPart Мажорная часть суммы
- * @property {String} minorPart Минорная часть суммы
- * @property {String} value Валюта целиком
- * @property {String} currencySymbol Символ валюты
- *
- * @param {AmountProps} amount Параметры суммы
- * @returns {FormattedAmountProps}
- */
-function formatAmount(amount) {
-    const {
-        value,
-        currency: { minority, code }
-    } = amount;
-
-    const fractionDigits = Math.log(minority) * Math.LOG10E;
-    const valueAbsStr = (Math.abs(value) / minority).toFixed(fractionDigits);
-
-    const [majorPart, minorPart] = valueAbsStr.split('.');
-
-    const majorPartSplitted = splitAmount(
-        majorPart,
-        AMOUNT_MAJOR_PART_SIZE,
-        AMOUNT_MAJOR_PARTS_SPLITTER,
-        AMOUNT_SPLIT_CODE_FROM
-    );
-
-    const majorPartFormatted = value < 0 ? NEGATIVE_AMOUNT_SYMBOL + majorPartSplitted : majorPartSplitted;
-
-    const formattedValueStr = minorPart
-        ? majorPartFormatted + AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR + minorPart
-        : majorPartFormatted;
-
-    return {
-        majorPart: majorPartFormatted,
-        minorPart,
-        value: formattedValueStr,
-        currencySymbol: getCurrencySymbol(code)
-    };
-}
 
 /**
  * Компонент для отображения суммы, согласно следующему гайдлайну:

--- a/src/amount/amount.jsx
+++ b/src/amount/amount.jsx
@@ -12,9 +12,9 @@ import cn from '../cn';
 import performance from '../performance';
 
 import {
-  formatAmount,
-  THINSP,
-  AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR
+    formatAmount,
+    THINSP,
+    AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR
 } from '../lib/format-amount';
 
 const ZERO_MINOR_PART_REGEXP = /^0+$/;

--- a/src/lib/format-amount.js
+++ b/src/lib/format-amount.js
@@ -1,12 +1,12 @@
 import { getCurrencySymbol } from './currency-codes';
 
-const THINSP = String.fromCharCode(8201); // &thinsp;
-const AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR = ',';
+export const THINSP = String.fromCharCode(8201); // &thinsp;
+export const AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR = ',';
+
 const AMOUNT_MAJOR_PARTS_SPLITTER = THINSP;
 const AMOUNT_MAJOR_PART_SIZE = 3;
 const AMOUNT_SPLIT_CODE_FROM = 4;
 const NEGATIVE_AMOUNT_SYMBOL = '−';
-
 
 /**
  * Дробит мажорную часть суммы на части по указанному символу.
@@ -108,5 +108,5 @@ export function formatAmountToString(amount) {
         currencySymbol
     } = formatAmount(amount);
 
-    return `${value} ${currencySymbol}`;
+    return `${value}${THINSP}${currencySymbol}`;
 }

--- a/src/lib/format-amount.js
+++ b/src/lib/format-amount.js
@@ -1,0 +1,112 @@
+import { getCurrencySymbol } from './currency-codes';
+
+const THINSP = String.fromCharCode(8201); // &thinsp;
+const AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR = ',';
+const AMOUNT_MAJOR_PARTS_SPLITTER = THINSP;
+const AMOUNT_MAJOR_PART_SIZE = 3;
+const AMOUNT_SPLIT_CODE_FROM = 4;
+const NEGATIVE_AMOUNT_SYMBOL = '−';
+
+
+/**
+ * Дробит мажорную часть суммы на части по указанному символу.
+ *
+ * @param {String} amount Сумма для разбивки на части
+ * @param {Number} [partSize=3] Размер частей суммы
+ * @param {String} [splitter=THINSP] Символ, разбивающий части суммы
+ * @param {String} [splitFrom=5] Длинна суммы, начиная с которой необходимо осуществлять разбивку. По-умолчанию длинна
+ * равняется пяти по требованию гайдлайнов: https://design.alfabank.ru/patterns/amount. Пример: 2900 — не разбивается,
+ * 29 000 — разбивается.
+ * @returns {String}
+ */
+function splitAmount(amount, partSize = 3, splitter = THINSP, splitFrom = 5) {
+    const len = amount.length;
+
+    // Если длина суммы меньше требуемой, не форматируем сумму
+    if (len < splitFrom) {
+        return amount;
+    }
+
+    return amount
+        .split('')
+        .reduce((acc, item, i) => {
+            const isLastItem = i !== len - 1;
+            // eslint-disable-next-line no-mixed-operators
+            const isStartOfPart = (i - (len % partSize) + 1) % partSize === 0;
+
+            return isLastItem && isStartOfPart ? [...acc, item, splitter] : [...acc, item];
+        }, [])
+        .join('');
+}
+
+/**
+ * Форматирует значение суммы.
+ *
+ * @typedef {Object} AmountProps Параметры суммы
+ * @property {Number} amount.value Абсолютное значение суммы
+ * @property {Object} amount.currency Параметры валюты
+ * @property {String} amount.currency.code Код валюты
+ * @property {Number} amount.currency.minority Количество минорных единиц валюты
+ *
+ * @typedef {Object} FormattedAmountProps Параметры форматированной суммы
+ * @property {String} majorPart Мажорная часть суммы
+ * @property {String} minorPart Минорная часть суммы
+ * @property {String} value Валюта целиком
+ * @property {String} currencySymbol Символ валюты
+ *
+ * @param {AmountProps} amount Параметры суммы
+ * @returns {FormattedAmountProps}
+ */
+export function formatAmount(amount) {
+    const {
+        value,
+        currency: { minority, code }
+    } = amount;
+
+    const fractionDigits = Math.log(minority) * Math.LOG10E;
+    const valueAbsStr = (Math.abs(value) / minority).toFixed(fractionDigits);
+
+    const [majorPart, minorPart] = valueAbsStr.split('.');
+
+    const majorPartSplitted = splitAmount(
+        majorPart,
+        AMOUNT_MAJOR_PART_SIZE,
+        AMOUNT_MAJOR_PARTS_SPLITTER,
+        AMOUNT_SPLIT_CODE_FROM
+    );
+
+    const majorPartFormatted = value < 0 ? NEGATIVE_AMOUNT_SYMBOL + majorPartSplitted : majorPartSplitted;
+
+    const formattedValueStr = minorPart
+        ? majorPartFormatted + AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR + minorPart
+        : majorPartFormatted;
+
+    return {
+        majorPart: majorPartFormatted,
+        minorPart,
+        value: formattedValueStr,
+        currencySymbol: getCurrencySymbol(code)
+    };
+}
+
+/**
+ * Форматирует значение суммы и возвращает в виде строки.
+ * Использует функционал formatAmount
+ *
+ * @typedef {Object} AmountProps Параметры суммы
+ * @property {Number} amount.value Абсолютное значение суммы
+ * @property {Object} amount.currency Параметры валюты
+ * @property {String} amount.currency.code Код валюты
+ * @property {Number} amount.currency.minority Количество минорных единиц валюты
+ *
+ * @param {AmountProps} amount Параметры суммы
+ * @returns {String} Форматированная сумма в виде строки
+ */
+export function formatAmountToString(amount) {
+    const {
+        value,
+        currencySymbol
+    } = formatAmount(amount);
+
+    return `${value} ${currencySymbol}`;
+}

--- a/src/lib/format-amount.test.jsx
+++ b/src/lib/format-amount.test.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { formatAmountToString } from './format-amount';
+import { formatAmountToString, THINSP } from './format-amount';
 
 describe('format-amount-to-string', () => {
     it('should return formatted RUR amount in string', () => {
@@ -15,6 +15,6 @@ describe('format-amount-to-string', () => {
         };
         const result = formatAmountToString(amount);
 
-        expect(result).toBe('1 234 567 \u20bd');
+        expect(result).toBe(`1${THINSP}234${THINSP}567${THINSP}\u20bd`);
     });
 });

--- a/src/lib/format-amount.test.jsx
+++ b/src/lib/format-amount.test.jsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { formatAmountToString, formatAmount } from './format-amount';
+
+describe('format-amount-to-string', () => {
+    it('should return formatted RUR amount in string', () => {
+        const amount = {
+            value: 1234567,
+            currency: {
+                code: 'RUR',
+                minority: 1
+            }
+        };
+        const result = formatAmountToString(amount);
+        const {
+            value,
+            currencySymbol
+        } = formatAmount(amount);
+
+        expect(result).toBe(`${value} ${currencySymbol}`);
+    });
+});

--- a/src/lib/format-amount.test.jsx
+++ b/src/lib/format-amount.test.jsx
@@ -15,6 +15,6 @@ describe('format-amount-to-string', () => {
         };
         const result = formatAmountToString(amount);
 
-        expect(result).toBe(`1 234 567 \u20bd`);
+        expect(result).toBe('1 234 567 \u20bd');
     });
 });

--- a/src/lib/format-amount.test.jsx
+++ b/src/lib/format-amount.test.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { formatAmountToString, formatAmount } from './format-amount';
+import { formatAmountToString } from './format-amount';
 
 describe('format-amount-to-string', () => {
     it('should return formatted RUR amount in string', () => {
@@ -14,11 +14,7 @@ describe('format-amount-to-string', () => {
             }
         };
         const result = formatAmountToString(amount);
-        const {
-            value,
-            currencySymbol
-        } = formatAmount(amount);
 
-        expect(result).toBe(`${value} ${currencySymbol}`);
+        expect(result).toBe(`1 234 567 \u20bd`);
     });
 });


### PR DESCRIPTION
Утилитарные функции `amount` должны лежать отдельно

## Мотивация и контекст
1. Это позволяет использовать их независимо от самого компонента, для форматирования сумм
2. Проблема, которая решается сейчас -> Отображение `checkedText` в `Select`
