### PR TITLE
feat(select): ResizeSensor on focus only

### DIFF
--- a/src/select/__snapshots__/select.test.jsx.snap
+++ b/src/select/__snapshots__/select.test.jsx.snap
@@ -138,26 +138,6 @@ exports[`select should render without problem 1`] = `
                   </span>
                 </span>
               </IconButton>
-              <ResizeSensor
-                key="addon-sensor"
-                onResize={[Function]}
-              >
-                <iframe
-                  style={
-                    Object {
-                      "background": "transparent",
-                      "border": "none",
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "top": 0,
-                      "width": "100%",
-                      "zIndex": -1,
-                    }
-                  }
-                  tabIndex="-1"
-                />
-              </ResizeSensor>
             </span>
           </span>
         </button>

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -273,6 +273,12 @@ class Select extends React.Component {
         });
     }
 
+    componentDidUpdate() {
+        if (this.state.opened) {
+            this.updatePopupStyles();
+        }
+    }
+
     render(cn, SelectButton, Popup) {
         let value = this.getValue();
 
@@ -364,7 +370,10 @@ class Select extends React.Component {
                         <ToggledIcon size={ tickSize } />
                     </IconButton>
                 ) }
-                <ResizeSensor key='addon-sensor' onResize={ this.updatePopupStyles } />
+
+                { this.getOpened() && (
+                    <ResizeSensor key='addon-sensor' onResize={ this.updatePopupStyles } />
+                ) }
             </SelectButton>
         );
     }


### PR DESCRIPTION
При большом количестве элементов начинаются проблемы с производительностью из-за ResizeSensor, убираем его до открытия Popup.