### PR TITLE
fix(amount component): now does not explode if passing minority 0

### DIFF
--- a/src/amount/amount.test.jsx
+++ b/src/amount/amount.test.jsx
@@ -92,4 +92,20 @@ describe('amount', () => {
         // eslint-disable-next-line no-irregular-whitespace
         expect(amount.text()).toContain(`999 ${CURRENCY_MAP.BYR}`);
     });
+
+    it('should render when minority equals 0', () => {
+        let amount = mount(
+            <Amount
+                amount={ {
+                    value: 999,
+                    currency: {
+                        code: 'ZWD',
+                        minority: 0
+                    }
+                } }
+            />
+        );
+        // eslint-disable-next-line no-irregular-whitespace
+        expect(amount.text()).toContain(`999 ${CURRENCY_MAP.ZWD}`);
+    });
 });

--- a/src/lib/format-amount.js
+++ b/src/lib/format-amount.js
@@ -60,8 +60,11 @@ function splitAmount(amount, partSize = 3, splitter = THINSP, splitFrom = 5) {
 export function formatAmount(amount) {
     const {
         value,
-        currency: { minority, code }
+        currency: { code }
     } = amount;
+
+    let { minority } = amount.currency;
+    minority = minority === 0 ? 1 : minority; // because Math.log(0) => -Infinity
 
     const fractionDigits = Math.log(minority) * Math.LOG10E;
     const valueAbsStr = (Math.abs(value) / minority).toFixed(fractionDigits);


### PR DESCRIPTION
Теперь в компонент `Amount` можно передавать `0` в свойстве `amount.currency.minority`  и это не приведёт к ошибке.

## Мотивация и контекст
Пользователь компонента может по ошибке передать ноль в minority. Это приводит к тому, что компонент перестаёт отображаться.

Проверить проблему сейчас можно здесь https://design.alfabank.ru/components/amount