### PR TITLE
fix(input): fix input sub

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -28,7 +28,9 @@
 
     &__box {
         overflow: hidden;
-        display: table-cell;
+        display: inline-block;
+        vertical-align: top;
+        width: 100%;
         position: relative;
         user-select: none;
         transition-duration: 250ms;
@@ -51,6 +53,11 @@
         transition-duration: 200ms;
         transition-property: color, transform;
         transition-timing-function: cubic-bezier(.25, .1, .25, 1);
+    }
+
+    &__sub-wrapper {
+        display: table;
+        width: 100%;
     }
 
     &__sub {

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -217,10 +217,13 @@ class Input extends React.Component {
                     }
                     { this.renderContent(cn, MaskedInput) }
                     {
-                        (this.props.error || this.props.hint) &&
-                        <span className={ cn('sub') }>
-                            { this.props.error || this.props.hint }
-                        </span>
+                        (this.props.error || this.props.hint) && (
+                            <div className={ cn('sub-wrapper') }>
+                                <span className={ cn('sub') }>
+                                    { this.props.error || this.props.hint }
+                                </span>
+                            </div>
+                        )
                     }
                 </span>
             </span>


### PR DESCRIPTION
Фикс [issue](https://github.com/alfa-laboratory/arui-feather/issues/780) с прыгающим хинтом у инпута.

## Мотивация и контекст
Фиксит багу `table-caption` в Safari.
Поправил стили и разметку по аналогии с селектом, где был аналогичный баг. 
