### PR TITLE
fix(input): add tabIndex for clear button

### DIFF
--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -289,6 +289,7 @@ class Input extends React.Component {
                     <IconButton
                         className={ cn('clear') }
                         size={ this.props.size }
+                        tabIndex={-1}
                         onClick={ this.handleClearClick }
                     >
                         <IconClose

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -289,7 +289,7 @@ class Input extends React.Component {
                     <IconButton
                         className={ cn('clear') }
                         size={ this.props.size }
-                        tabIndex={-1}
+                        tabIndex={ -1 }
                         onClick={ this.handleClearClick }
                     >
                         <IconClose


### PR DESCRIPTION
<!--- Название для изменений -->
Исправляет проблему с переходами между группой инпутов с помощью кнопки TAB.

## Мотивация и контекст
<!--- Почему эти изменения необходимы? Какую проблему они решают? -->
На данный момент для кнопки очистки нет никаких A11Y вещей и соответственно переход на неё через TAB визуально не меняет отображение этой кнопки, что вводит в заблуждение пользователей.
При этом для пользователя важнее перейти на другое поле, а не очистить текущее поле. Но в рамках больших форм прописывать tabIndex для каждого инпута — это боль.
В дальнейшем можно будет сделать что-то типа *clearTabIndex*, чтобы иметь возможность управлять её tabIndex-ом.
