### PR TITLE
feat(vars): add negative gaps

### DIFF
--- a/src/vars.css
+++ b/src/vars.css
@@ -28,4 +28,18 @@
     --gap-3xl: 40px;
     --gap-4xl: 48px;
     --gap-5xl: 72px;
+
+    /**
+     * Отрицательные отступы
+     */
+    --gap-2xs-neg: -4px;
+    --gap-xs-neg: -8px;
+    --gap-s-neg: -12px;
+    --gap-m-neg: -16px;
+    --gap-l-neg: -20px;
+    --gap-xl-neg: -24px;
+    --gap-2xl-neg: -32px;
+    --gap-3xl-neg: -40px;
+    --gap-4xl-neg: -48px;
+    --gap-5xl-neg: -72px;
 }


### PR DESCRIPTION
<!--- Название для изменений -->
Negative analogues for all current gaps have been added.

## Мотивация и контекст
<!--- Почему эти изменения необходимы? Какую проблему они решают? -->
Often developers had to use records like `margin: calc(-1 * var(--gap-4xs));`, which are difficult to read and looks ugly in general. Some developers avoid using gaps in such cases at all. After this changes we can simply type `margin: var(--gap-4xl-neg);`
<!--- Если изменения исправляют открытый issue, прикрепите на него ссылку -->
