### PR TITLE
fix(intl-phone-input): fix calling setCountry after loadUtil

### DIFF
--- a/src/intl-phone-input/intl-phone-input.jsx
+++ b/src/intl-phone-input/intl-phone-input.jsx
@@ -47,8 +47,7 @@ class IntlPhoneInput extends React.Component {
     asYouType;
 
     componentDidMount() {
-        this.loadUtil();
-        this.setCountry();
+        this.loadUtil().finally(this.setCountry);
     }
 
     componentWillUpdate(nextProps, nextState) {


### PR DESCRIPTION
Фикс применения маски на номер телефона, переданного по дефолту.

## Мотивация и контекст
В componentDidMount вызывается 2 функции подряд (loadUtil(асинхронная) и setCountry), в свою очередь setCountry вызывает setValue, которому необходима утилита (маска телефонного номера) загружающаяся в loadUtil. Таким образом setValue не получив этой утилиты просто подставляет исходное значение не применяя на него маску.

Этот PR решает проблему применения маски на номер телефона, переданного в value по дефолту при создании компонента.
