### PR TITLE
fix(input): fix caret color

### DIFF
--- a/src/input/input_theme_alfa-on-color.css
+++ b/src/input/input_theme_alfa-on-color.css
@@ -23,6 +23,7 @@
         &:-webkit-autofill:focus,
         &:-webkit-autofill:active {
             -webkit-text-fill-color: var(--color-content-alfa-on-color) !important;
+            caret-color: var(--color-content-alfa-on-color);
         }
     }
 

--- a/src/input/input_theme_alfa-on-white.css
+++ b/src/input/input_theme_alfa-on-white.css
@@ -23,6 +23,7 @@
         &:-webkit-autofill:focus,
         &:-webkit-autofill:active {
             -webkit-text-fill-color: var(--color-content-alfa-on-white) !important;
+            caret-color: var(--color-content-alfa-on-white);
         }
     }
 


### PR DESCRIPTION
Фикс цвета каретки в input.

## Мотивация и контекст
В поле ввода, после выбора одного из предложенных элементов (имеются ввиду те значения, которые пользователь уже раньше когда-то вбивал и они сохранились в браузере) каретка становится черного цвета (это заметно только в темной теме) и совершенно незаметна.
Этот маленький фикс исправляет данную проблему.
