### PR TITLE
feat(button): add data-test-id property to button component

### DIFF
--- a/src/button/button.jsx
+++ b/src/button/button.jsx
@@ -58,7 +58,7 @@ class Button extends React.Component {
         /** Дочерние элементы `Button` */
         children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
         /** Идентификатор для систем автоматизированного тестирования */
-        testId: Type.string,
+        'data-test-id': Type.string,
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
@@ -157,7 +157,7 @@ class Button extends React.Component {
             tabIndex: this.props.disabled ? '-1' : this.props.tabIndex,
             disabled: this.props.disabled,
             formNoValidate: isButton ? this.props.formNoValidate : null,
-            'data-test-id': this.props.testId,
+            'data-test-id': this.props['data-test-id'],
             className: cn({
                 disabled: this.props.disabled,
                 pseudo: this.props.pseudo,

--- a/src/button/button.jsx
+++ b/src/button/button.jsx
@@ -57,6 +57,8 @@ class Button extends React.Component {
         checked: Type.bool,
         /** Дочерние элементы `Button` */
         children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),
+        /** Идентификатор для систем автоматизированного тестирования */
+        testId: Type.string,
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
@@ -155,6 +157,7 @@ class Button extends React.Component {
             tabIndex: this.props.disabled ? '-1' : this.props.tabIndex,
             disabled: this.props.disabled,
             formNoValidate: isButton ? this.props.formNoValidate : null,
+            'data-test-id': this.props.testId,
             className: cn({
                 disabled: this.props.disabled,
                 pseudo: this.props.pseudo,


### PR DESCRIPTION
Add `data-test-id` property to button component for autotests

## Мотивация и контекст
In most cases autotest suits uses test locators to perform desired actions with located elements. `id` property is not always suitable for this purpose as it should be unique on page, and this is not always logically achievable.
`className` property is not suitable as well as it can be changed in future if styles are modified or project structure partially changed. Property `data-test-id` is usually used to make distinct way to locate DOM element.
____________________
В большинстве случаев средства автоматического тестирования используют тестовые локаторы для выполнения необходимых действий над найденными элементами. Свойство `id` не всегда подходит для этих целей, так как должно быть уникальным на странице, а это не всегда достижимо с логической точки зрения.
Свойство `className` также не подходит, так как его значение может поменяться при работе со стилями или при изменении структуры проекта. Свойство `data-test-id` обычно используется с целью нахождения нужного элемента в дереве.