### PR TITLE
fix(input): incorrect disabled input styles (#781)

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -571,6 +571,7 @@
             background-color: rgba(11, 31, 53, 0.1);
             border-bottom-color: rgba(11, 31, 53, 0.15);
             border-bottom-style: var(--border-style-control-disabled);
+            box-shadow: none;
         }
 
         .input__control {

--- a/src/input/input_theme_alfa-on-color.css
+++ b/src/input/input_theme_alfa-on-color.css
@@ -22,7 +22,7 @@
         &:-webkit-autofill:hover,
         &:-webkit-autofill:focus,
         &:-webkit-autofill:active {
-            -webkit-text-fill-color: var(--color-content-alfa-on-color) !important;
+            -webkit-text-fill-color: var(--color-content-alfa-on-color);
             caret-color: var(--color-content-alfa-on-color);
         }
     }
@@ -62,11 +62,19 @@
         .input__box {
             border-bottom-color: var(--color-border-control-disabled-alfa-on-color);
             border-bottom-style: var(--border-style-control-disabled);
+            box-shadow: none;
         }
 
         &,
         .input__control {
             color: var(--color-content-disabled-alfa-on-color);
+
+            &:-webkit-autofill,
+            &:-webkit-autofill:hover,
+            &:-webkit-autofill:focus,
+            &:-webkit-autofill:active {
+                -webkit-text-fill-color: var(--color-content-disabled-alfa-on-color);
+            }
         }
 
         .input__control::placeholder {

--- a/src/input/input_theme_alfa-on-white.css
+++ b/src/input/input_theme_alfa-on-white.css
@@ -22,7 +22,7 @@
         &:-webkit-autofill:hover,
         &:-webkit-autofill:focus,
         &:-webkit-autofill:active {
-            -webkit-text-fill-color: var(--color-content-alfa-on-white) !important;
+            -webkit-text-fill-color: var(--color-content-alfa-on-white);
             caret-color: var(--color-content-alfa-on-white);
         }
     }
@@ -62,11 +62,19 @@
         .input__box {
             border-bottom-color: var(--color-border-control-disabled-alfa-on-white);
             border-bottom-style: var(--border-style-control-disabled);
+            box-shadow: none;
         }
 
         &,
         .input__control {
             color: var(--color-content-disabled-alfa-on-white);
+
+            &:-webkit-autofill,
+            &:-webkit-autofill:hover,
+            &:-webkit-autofill:focus,
+            &:-webkit-autofill:active {
+                -webkit-text-fill-color: var(--color-content-disabled-alfa-on-white);
+            }
         }
 
         .input__control::placeholder {


### PR DESCRIPTION
## Мотивация и контекст
Решение проблемы с некорректными стилями заблокированного Input (#781)
Проблема наблюдалась
- при автоматической блокировке поля (передается пропс disabled) при достижении определенных условий. В этом случае оставалась лишняя нижняя граница.
- при выборе варианта из нативного автозаполнения браузера. В этом случае к тексту не применялся стиль заблокированного Input.