### PR TITLE
fix(money-input): label and currency style fix

### DIFF
--- a/src/money-input/README.md
+++ b/src/money-input/README.md
@@ -10,3 +10,12 @@ C символом валюты
     bold={ true }
 />
 ```
+
+```jsx
+<MoneyInput
+    showCurrency={ true }
+    currencyCode='USD'
+    bold={ true }
+    label='Лейбл'
+/>
+```

--- a/src/money-input/money-input.css
+++ b/src/money-input/money-input.css
@@ -44,7 +44,6 @@
         }
 
         .input_has-label & {
-            top: 28px;
             line-height: inherit;
         }
     }
@@ -52,7 +51,7 @@
     &__value {
         margin-right: 0.25em;
         color: transparent;
-        font-weight: bold;
+        font-weight: var(--font-weight-normal);
     }
 
     &_currency {
@@ -66,10 +65,6 @@
                 + .input__control {
                     padding-left: 0;
                 }
-            }
-
-            .input__top {
-                padding-left: 12px;
             }
         }
     }


### PR DESCRIPTION
> После обновления arui-feather до 14.0.0 появился баг с компонентом money-input — при наличии label съезжает символ валюты.

Демка с фиксом: https://deploy-preview-838--arui-feather.netlify.com/#!/MoneyInput