### PR TITLE
fix(intl-phone-input): styles when switch input

### DIFF
--- a/src/intl-phone-input/intl-phone-input.jsx
+++ b/src/intl-phone-input/intl-phone-input.jsx
@@ -226,18 +226,23 @@ class IntlPhoneInput extends React.Component {
         let relatedTarget = getRelatedTarget(event);
         let hasMatchedRelatedTarget = relatedTarget === event.target;
         let hasSelectRelatedTarget = false;
+        let isSwitchBetweenRelatedTargers = false;
 
         // Check classNames matching in select's button (relatedTarget) & menu (focused target)
         if (relatedTarget.classList && event.target.classList) {
             hasSelectRelatedTarget = Array.from(relatedTarget.classList).some(item => /select/.test(item)) ===
                 Array.from(event.target.classList).some(item => /select/.test(item));
+
+            isSwitchBetweenRelatedTargers =
+                !Object.values(focusedState).some(item => item) &&
+                !Array.from(event.target.classList).some(item => /select/.test(item)) &&
+                Array.from(relatedTarget.classList).some(item => /select/.test(item));
         }
 
         if (event.type === 'focus') {
-            if (hasMatchedRelatedTarget || hasSelectRelatedTarget) {
+            if (hasMatchedRelatedTarget || hasSelectRelatedTarget || isSwitchBetweenRelatedTargers) {
                 // If we have smth already focused, do not do anything
                 let alreadyInFocus = Object.values(focusedState).some(item => item);
-
                 if (!alreadyInFocus) {
                     this.setState(nextFocusedStateItem);
 
@@ -249,7 +254,7 @@ class IntlPhoneInput extends React.Component {
         }
 
         if (event.type === 'blur') {
-            if (relatedTarget === document.body) {
+            if (!hasMatchedRelatedTarget) {
                 // Set all values in focusedState to false cause we are blurring now
                 this.setState(
                     Object.keys(focusedState).reduce((result, item) => {


### PR DESCRIPTION
## Мотивация и контекст
Исправлено поведение компонента, когда
* в случае переключения между компонентами intl-phone-input, не устанавливалось состояние focused.
* в случае, когда открывался, а потом закрывался без выбора список кодов стран, не устанавливалось состояние focused.

[Неправильная работа focus в IntlPhoneInput #758](https://github.com/alfa-laboratory/arui-feather/issues/758)
