### PR TITLE
fix(tab-button): checked with focused styles

### DIFF
--- a/src/tag-button/tag-button.css
+++ b/src/tag-button/tag-button.css
@@ -84,6 +84,10 @@
 
     &.tag-button_focused {
         background: color(var(--color-background-alfa-on-white) a(.55));
+
+        &.tag-button_checked {
+            background: color(var(--color-background-alfa-on-white) a(.55));
+        }
     }
 
     &.tag-button_pressed {
@@ -113,6 +117,10 @@
 
     &.tag-button_focused {
         background: color(var(--color-background-alfa-on-color) a(.14));
+
+        &.tag-button_checked {
+            background: color(var(--color-background-alfa-on-color) a(.55));
+        }
     }
 
     &.tag-button_pressed {

--- a/src/tag-button/tag-button.css
+++ b/src/tag-button/tag-button.css
@@ -119,7 +119,7 @@
         background: color(var(--color-background-alfa-on-color) a(.14));
 
         &.tag-button_checked {
-            background: color(var(--color-background-alfa-on-color) a(.55));
+            background: color(var(--color-background-alfa-on-color));
         }
     }
 


### PR DESCRIPTION
## Мотивация и контекст
TabButton (и, как следствие, CheckBox/Radio type = button checked) с параметром checked={true} не "подсвечивал" при фокусе.
Теперь кнопка с checked={true} меняет цвет, когда получает фокус.