### PR TITLE
feat(select): changed style for label if has value in select

### DIFF
--- a/src/select/select.css
+++ b/src/select/select.css
@@ -223,6 +223,8 @@
     &.select_has-value {
         .select__top {
             transform: scale(var(--top-scale-s)) translateY(-22px);
+            width: calc((2 - var(--top-scale-s)) * 100)%;
+            padding-right: 0;
         }
     }
 }
@@ -242,6 +244,8 @@
     &.select_has-value {
         .select__top {
             transform: scale(var(--top-scale-m)) translateY(-30px);
+            width: calc((2 - var(--top-scale-m)) * 100)%;
+            padding-right: 0;
         }
     }
 }
@@ -261,6 +265,8 @@
     &.select_has-value {
         .select__top {
             transform: scale(var(--top-scale-l)) translateY(-40px);
+            width: calc((2 - var(--top-scale-l)) * 100)%;
+            padding-right: 0;
         }
     }
 }
@@ -280,6 +286,8 @@
     &.select_has-value {
         .select__top {
             transform: scale(var(--top-scale-xl)) translateY(-50px);
+            width: calc((2 - var(--top-scale-xl)) * 100)%;
+            padding-right: 0;
         }
     }
 }


### PR DESCRIPTION
Поправлен стили лейбла в Select компоненте

Проблема:
Текст лейбла не заполняет 100% ширины при выбранном значение в селекте
![Screenshot 2019-09-11 at 16 11 42](https://user-images.githubusercontent.com/3061978/64702516-5f066580-d4b3-11e9-8aee-4c0898679f06.png)

После исправлений:
![Screenshot 2019-09-11 at 16 17 01](https://user-images.githubusercontent.com/3061978/64702573-75142600-d4b3-11e9-9045-6d38c19ffecb.png)
<img width="575" alt="Screenshot 2019-09-11 at 16 45 21" src="https://user-images.githubusercontent.com/3061978/64702657-9aa12f80-d4b3-11e9-831a-3d336a75e9fc.png">


