### PR TITLE
Added data-test-id property to all components (for autotests)

### DIFF
--- a/src/amount/amount.jsx
+++ b/src/amount/amount.jsx
@@ -51,7 +51,9 @@ class Amount extends React.Component {
         /** Дополнительный класс */
         className: Type.string,
         /** Идентификатор компонента в DOM */
-        id: Type.string
+        id: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -74,7 +76,11 @@ class Amount extends React.Component {
         );
 
         return (
-            <div className={ cn({ bold: this.props.bold }) } id={ this.props.id }>
+            <div
+                className={ cn({ bold: this.props.bold }) }
+                id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
+            >
                 { this.props.isHeading ? (
                     <Heading size={ size }>{ amountInner }</Heading>
                 ) : (

--- a/src/attach/attach.jsx
+++ b/src/attach/attach.jsx
@@ -156,7 +156,9 @@ class Attach extends React.Component {
          * Обработчик события снятия курсора с кнопки
          * @param {React.MouseEvent} event
          */
-        onMouseLeave: Type.func
+        onMouseLeave: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -200,6 +202,7 @@ class Attach extends React.Component {
                 onMouseEnter={ this.handleMouseEnter }
                 onMouseLeave={ this.handleMouseLeave }
                 ref={ (root) => { this.root = root; } }
+                data-test-id={ this.props['data-test-id'] }
             >
                 { this.renderButton(cn) }
                 { this.renderStatusText(cn) }

--- a/src/button/button.jsx
+++ b/src/button/button.jsx
@@ -157,7 +157,6 @@ class Button extends React.Component {
             tabIndex: this.props.disabled ? '-1' : this.props.tabIndex,
             disabled: this.props.disabled,
             formNoValidate: isButton ? this.props.formNoValidate : null,
-            'data-test-id': this.props['data-test-id'],
             className: cn({
                 disabled: this.props.disabled,
                 pseudo: this.props.pseudo,
@@ -179,7 +178,8 @@ class Button extends React.Component {
             onMouseUp: this.handleMouseUp,
             onMouseOut: this.handleMouseOut,
             onKeyDown: this.handleKeyDown,
-            onKeyUp: this.handleKeyUp
+            onKeyUp: this.handleKeyUp,
+            'data-test-id': this.props['data-test-id']
         };
 
         let buttonContent = [

--- a/src/calendar-input/calendar-input.jsx
+++ b/src/calendar-input/calendar-input.jsx
@@ -169,7 +169,9 @@ class CalendarInput extends React.Component {
          * Обработчик события нажатия на клавишу клавиатуры в момент, когда фокус находится на текстовом поле
          * @param {React.KeyboardEvent} event
          */
-        onInputKeyDown: Type.func
+        onInputKeyDown: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -281,6 +283,7 @@ class CalendarInput extends React.Component {
         return (
             <span
                 className={ cn({ width: this.props.width }) }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <span
                     { ...wrapperProps }

--- a/src/calendar/calendar.jsx
+++ b/src/calendar/calendar.jsx
@@ -105,7 +105,9 @@ class Calendar extends React.Component {
          * Обработчик снятия фокуса
          * @param {React.FocusEvent} event
          */
-        onBlur: Type.func
+        onBlur: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -163,6 +165,7 @@ class Calendar extends React.Component {
                 onFocus={ this.handleFocus }
                 onKeyDown={ this.props.isKeyboard && this.handleKeyDown }
                 onKeyUp={ this.props.isKeyboard && this.handleKeyUp }
+                data-test-id={ this.props['data-test-id'] }
             >
                 { this.renderTitle(cn) }
                 <table className={ cn('layout') }>

--- a/src/card-input/card-input.jsx
+++ b/src/card-input/card-input.jsx
@@ -22,7 +22,9 @@ class CardInput extends React.Component {
     static propTypes = {
         ...Input.propTypes,
         /** Подсказка в текстовом поле */
-        placeholder: Type.string
+        placeholder: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {

--- a/src/checkbox-group/checkbox-group.jsx
+++ b/src/checkbox-group/checkbox-group.jsx
@@ -54,7 +54,9 @@ class CheckBoxGroup extends React.Component {
          * Обработчик изменения значения 'checked' одного из дочерних радио-кнопок
          * @param {string[]} value
          */
-        onChange: Type.func
+        onChange: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -119,6 +121,7 @@ class CheckBoxGroup extends React.Component {
                 tabIndex='-1'
                 onFocus={ this.handleFocus }
                 onBlur={ this.handleBlur }
+                data-test-id={ this.props['data-test-id'] }
             >
                 {
                     !!this.props.label &&

--- a/src/checkbox/checkbox.jsx
+++ b/src/checkbox/checkbox.jsx
@@ -84,7 +84,9 @@ class CheckBox extends React.Component {
          * Обработчик события снятия курсора с чекбокса
          * @param {React.MouseEvent} event
          */
-        onMouseLeave: Type.func
+        onMouseLeave: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -125,6 +127,7 @@ class CheckBox extends React.Component {
                 ref={ (root) => {
                     this.root = root;
                 } }
+                data-test-id={ this.props['data-test-id'] }
             >
                 { this.props.type === 'button'
                     ? this.renderButtonCheckbox(cn, checked, TagButton)

--- a/src/collapse/collapse.jsx
+++ b/src/collapse/collapse.jsx
@@ -39,7 +39,9 @@ class Collapse extends React.Component {
          * Обработчик смены состояний `expanded/collapsed`
          * @param {boolean} isExpanded
          */
-        onExpandedChange: Type.func
+        onExpandedChange: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -79,6 +81,7 @@ class Collapse extends React.Component {
                     expanded
                 }) }
                 id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <div
                     ref={ (content) => { this.content = content; } }

--- a/src/dropdown/dropdown.jsx
+++ b/src/dropdown/dropdown.jsx
@@ -98,7 +98,9 @@ class Dropdown extends React.Component {
          * Обработчик события клика попапа за пределами попапа
          * @param {React.MouseEvent} event
          */
-        onPopupClickOutside: Type.func
+        onPopupClickOutside: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -126,7 +128,11 @@ class Dropdown extends React.Component {
 
     render(cn) {
         return (
-            <div className={ cn() } id={ this.props.id }>
+            <div
+                className={ cn() }
+                id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
+            >
                 { this.renderSwitcher(cn) }
                 { this.renderPopup(cn) }
             </div>

--- a/src/flag-icon/flag-icon.jsx
+++ b/src/flag-icon/flag-icon.jsx
@@ -30,7 +30,9 @@ class FlagIcon extends React.Component {
         /** Тема компонента */
         theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
         /** Дополнительный класс */
-        className: Type.oneOfType([Type.func, Type.string])
+        className: Type.oneOfType([Type.func, Type.string]),
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -48,6 +50,7 @@ class FlagIcon extends React.Component {
                     mode: this.props.mode,
                     size: this.props.size
                 }) }
+                data-test-id={ this.props['data-test-id'] }
             />
         );
     }

--- a/src/form-field/form-field.jsx
+++ b/src/form-field/form-field.jsx
@@ -25,7 +25,9 @@ class FormField extends React.Component {
         /** Размер компонента */
         size: Type.oneOf(['s', 'm', 'l', 'xl']),
         /** Тема компонента */
-        theme: Type.oneOf(['alfa-on-color', 'alfa-on-white'])
+        theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -37,6 +39,7 @@ class FormField extends React.Component {
             <div
                 className={ cn({ size: this.props.size }) }
                 id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
             >
                 { this.props.children }
             </div>

--- a/src/form/form.jsx
+++ b/src/form/form.jsx
@@ -46,7 +46,9 @@ class Form extends React.Component {
          * Обработчик отправки формы
          * @param {React.FormEvent} event
          */
-        onSubmit: Type.func
+        onSubmit: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -73,6 +75,7 @@ class Form extends React.Component {
                 id={ this.props.id }
                 name={ this.props.name }
                 onSubmit={ this.handleSubmit }
+                data-test-id={ this.props['data-test-id'] }
             >
                 { this.props.children }
                 {

--- a/src/grid-col/grid-col.jsx
+++ b/src/grid-col/grid-col.jsx
@@ -65,7 +65,9 @@ export default class GridCol extends React.PureComponent {
         /** Html тег компонента. */
         tag: Type.string,
         /** Дочерние элементы `GridCol` */
-        children: Type.node
+        children: Type.node,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     }
 
     static defaultProps = {

--- a/src/grid-row/grid-row.jsx
+++ b/src/grid-row/grid-row.jsx
@@ -46,7 +46,9 @@ export default class GridRow extends React.PureComponent {
          */
         tag: Type.string,
         /** Дочерние элементы `GridRow` */
-        children: Type.node
+        children: Type.node,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     }
 
     static defaultProps = {

--- a/src/heading/heading.jsx
+++ b/src/heading/heading.jsx
@@ -32,7 +32,9 @@ class Heading extends React.Component {
         /** Дополнительный класс */
         className: Type.string,
         /** Идентификатор компонента в DOM */
-        id: Type.string
+        id: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -44,7 +46,8 @@ class Heading extends React.Component {
             className: cn({
                 size: this.props.size
             }),
-            id: this.props.id
+            id: this.props.id,
+            'data-test-id': this.props['data-test-id']
         };
 
         return React.createElement(`h${HEADING_LEVEL[this.props.size]}`,

--- a/src/icon/icon.jsx
+++ b/src/icon/icon.jsx
@@ -26,7 +26,9 @@ class Icon extends React.Component {
         /** Размер иконки */
         size: Type.oneOf(['xs', 's', 'm', 'l', 'xl', 'xxl', 'xxxl']),
         /** Тема компонента */
-        theme: Type.oneOf(['alfa-on-color', 'alfa-on-white'])
+        theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -48,6 +50,7 @@ class Icon extends React.Component {
             <span
                 className={ cn(mods) }
                 id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
             />
         );
     }

--- a/src/input-autocomplete/input-autocomplete.jsx
+++ b/src/input-autocomplete/input-autocomplete.jsx
@@ -72,7 +72,9 @@ class InputAutocomplete extends React.Component {
          */
         onItemSelect: Type.func,
         /** Закрытие выпадающего списка в случае, если произошел выбор элемента */
-        closeOnSelect: Type.bool
+        closeOnSelect: Type.bool,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {

--- a/src/input-group/input-group.jsx
+++ b/src/input-group/input-group.jsx
@@ -25,7 +25,9 @@ class InputGroup extends React.Component {
         /** Дополнительный класс */
         className: Type.string,
         /** Идентификатор компонента в DOM */
-        id: Type.string
+        id: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     render(cn) {
@@ -61,6 +63,7 @@ class InputGroup extends React.Component {
                 id={ this.props.id }
                 role='group'
                 tabIndex='-1'
+                data-test-id={ this.props['data-test-id'] }
             >
                 { createFragment(inputGroupParts) }
             </span>

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -160,7 +160,9 @@ class Input extends React.Component {
          * Обработчик, вызываемый перед началом ввода в маскированное поле
          * @param {React.ChangeEvent} event
          */
-        onProcessMaskInputEvent: Type.func
+        onProcessMaskInputEvent: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -216,6 +218,7 @@ class Input extends React.Component {
                     invalid: !!this.props.error
                 }) }
                 ref={ (root) => { this.root = root; } }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <span className={ cn('inner') }>
                     {

--- a/src/label/label.jsx
+++ b/src/label/label.jsx
@@ -26,7 +26,9 @@ class Label extends React.Component {
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Управление возможностью рендерить компонент в одну сроку */
-        isNoWrap: Type.bool
+        isNoWrap: Type.bool,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -42,6 +44,7 @@ class Label extends React.Component {
                     'no-wrap': this.props.isNoWrap
                 }) }
                 id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <span className={ cn('inner') }>
                     { this.props.children }

--- a/src/link/link.jsx
+++ b/src/link/link.jsx
@@ -74,7 +74,9 @@ class Link extends React.Component {
         /**
          * Обработчик клика по disabled ссылке
          */
-        onDisabledClick: Type.func
+        onDisabledClick: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -118,7 +120,8 @@ class Link extends React.Component {
             onFocus: this.handleFocus,
             onBlur: this.handleBlur,
             onMouseEnter: this.handleMouseEnter,
-            onMouseLeave: this.handleMouseLeave
+            onMouseLeave: this.handleMouseLeave,
+            'data-test-id': this.props['data-test-id']
         };
 
         if (this.props.target === '_blank') {

--- a/src/list-header/list-header.jsx
+++ b/src/list-header/list-header.jsx
@@ -23,12 +23,17 @@ class ListHeader extends React.Component {
         /** Идентификатор компонента в DOM */
         id: Type.string,
         /** Вид компонента */
-        view: Type.oneOf(['transparent', 'filled'])
+        view: Type.oneOf(['transparent', 'filled']),
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     render(cn) {
         return (
-            <div className={ cn({ filled: this.props.view === 'filled' }) }>
+            <div
+                className={ cn({ filled: this.props.view === 'filled' }) }
+                data-test-id={ this.props['data-test-id'] }
+            >
                 <span className={ cn('title') }>{ this.props.title }</span>
                 { this.props.description && <span className={ cn('description') }>, { this.props.description }</span> }
             </div>

--- a/src/list/list.jsx
+++ b/src/list/list.jsx
@@ -29,7 +29,9 @@ class List extends React.Component {
         /** Дополнительный класс */
         className: Type.string,
         /** Идентификатор компонента в DOM */
-        id: Type.string
+        id: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     render(cn) {
@@ -48,7 +50,8 @@ class List extends React.Component {
             className: cn({
                 type: this.props.type
             }),
-            id: this.props.id
+            id: this.props.id,
+            'data-test-id': this.props['data-test-id']
         };
 
         return React.createElement(

--- a/src/masked-input/masked-input.jsx
+++ b/src/masked-input/masked-input.jsx
@@ -83,7 +83,9 @@ class MaskedInput extends React.Component {
          */
         onProcessInputEvent: Type.func,
         /** Признак что пробелы удалять не надо */
-        useWhitespaces: Type.bool
+        useWhitespaces: Type.bool,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     /**

--- a/src/menu-item/menu-item.jsx
+++ b/src/menu-item/menu-item.jsx
@@ -74,7 +74,9 @@ class MenuItem extends React.Component {
          * Обработчик события снятия курсора с элемента меню
          * @param {React.MouseEvent} event
          */
-        onMouseLeave: Type.func
+        onMouseLeave: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -94,7 +96,8 @@ class MenuItem extends React.Component {
         let content = this.props.children || this.props.value;
         let itemElement;
         let menuItemProps = {
-            ref: (root) => { this.root = root; }
+            ref: (root) => { this.root = root; },
+            'data-test-id': this.props['data-test-id']
         };
 
         switch (this.props.type) {

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -113,7 +113,9 @@ class Menu extends React.Component {
          * Обработчик события выделения элемента меню, принимает на вход переменную типа HighlightedItem
          * @param highlightedItem
          */
-        onHighlightItem: Type.func
+        onHighlightItem: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -193,6 +195,7 @@ class Menu extends React.Component {
                 onKeyUp={ this.handleKeyUp }
                 onFocus={ this.handleFocus }
                 onBlur={ this.handleBlur }
+                data-test-id={ this.props['data-test-id'] }
             >
                 { !!this.props.content && this.renderMenuItemList(cn, this.props.content) }
             </div>

--- a/src/money-input/money-input.jsx
+++ b/src/money-input/money-input.jsx
@@ -71,7 +71,9 @@ class MoneyInput extends React.Component {
         /** Отображение символа валюты */
         showCurrency: Type.bool,
         /** Международный код валюты */
-        currencyCode: Type.string
+        currencyCode: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -119,6 +121,7 @@ class MoneyInput extends React.Component {
                     bold: this.props.bold,
                     width: this.props.width
                 }) }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <Input
                     { ...this.props }

--- a/src/notification/notification.jsx
+++ b/src/notification/notification.jsx
@@ -81,7 +81,9 @@ class Notification extends React.Component {
          * Обработчик клика по компоненту
          * @param {React.MouseEvent} event
          */
-        onClick: Type.func
+        onClick: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -152,6 +154,7 @@ class Notification extends React.Component {
                     onMouseLeave={ this.handleMouseLeave }
                     onClick={ this.handleClick }
                     onKeyDown={ this.handleKeyDown }
+                    data-test-id={ this.props['data-test-id'] }
                 >
                     <div className={ cn('icon') }>
                         {

--- a/src/paragraph/paragraph.jsx
+++ b/src/paragraph/paragraph.jsx
@@ -26,12 +26,18 @@ class Paragraph extends React.Component {
         /** Дополнительный класс */
         className: Type.string,
         /** Идентификатор компонента в DOM */
-        id: Type.string
+        id: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     render(cn) {
         return (
-            <p className={ cn({ view: this.props.view }) } id={ this.props.id }>
+            <p
+                className={ cn({ view: this.props.view }) }
+                id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
+            >
                 { this.props.mark &&
                     <span className={ cn('marker') }>{ this.props.mark }</span>
                 }

--- a/src/plate/plate.jsx
+++ b/src/plate/plate.jsx
@@ -48,7 +48,9 @@ class Plate extends React.Component {
          * Обработчик события нажатия на клавишу клавиатуры в момент, когда фокус находится на компоненте
          * @param {React.KeyboardEvent} event
          */
-        onKeyDown: Type.func
+        onKeyDown: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -77,6 +79,7 @@ class Plate extends React.Component {
                     onClick={ this.handleClick }
                     onKeyDown={ this.handleKeyDown }
                     ref={ (node) => { this.root = node; } }
+                    data-test-id={ this.props['data-test-id'] }
                 >
                     <div className={ cn('content') }>
                         { this.props.children }

--- a/src/popup-container-provider/popup-container-provider.jsx
+++ b/src/popup-container-provider/popup-container-provider.jsx
@@ -54,7 +54,9 @@ class PopupContainerProvider extends React.Component {
         /** Объект со стилями */
         style: styleType,
         /** Тема компонента */
-        theme: Type.oneOf(['alfa-on-color', 'alfa-on-white'])
+        theme: Type.oneOf(['alfa-on-color', 'alfa-on-white']),
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static childContextTypes = {
@@ -86,6 +88,7 @@ class PopupContainerProvider extends React.Component {
                 id={ this.props.id }
                 ref={ (positioningContainer) => { this.positioningContainer = positioningContainer; } }
                 style={ this.props.style }
+                data-test-id={ this.props['data-test-id'] }
             >
                 { this.props.children }
                 <IsolatedContainer

--- a/src/popup-header/popup-header.jsx
+++ b/src/popup-header/popup-header.jsx
@@ -33,7 +33,9 @@ class PopupHeader extends React.Component {
          * Обработчик клика по кнопке закрытия
          * @param {React.MouseEvent} event
          */
-        onCloserClick: Type.func
+        onCloserClick: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     render(cn) {
@@ -43,6 +45,7 @@ class PopupHeader extends React.Component {
                     size: this.props.size
                 }) }
                 id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <IconButton
                     className={ cn('closer') }

--- a/src/popup/popup.jsx
+++ b/src/popup/popup.jsx
@@ -112,7 +112,9 @@ class Popup extends React.Component {
         /** Максимальная высота попапа */
         maxHeight: Type.number,
         /** Указатель на родительский элемент */
-        for: Type.string
+        for: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -270,6 +272,7 @@ class Popup extends React.Component {
                 } }
                 onMouseEnter={ this.handleMouseEnter }
                 onMouseLeave={ this.handleMouseLeave }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <div className={ cn('container') }>
                     {

--- a/src/progress-bar/progress-bar.jsx
+++ b/src/progress-bar/progress-bar.jsx
@@ -16,7 +16,9 @@ class ProgressBar extends React.Component {
         /** Размер компонента */
         size: Type.oneOf(['m']),
         /** Дополнительный класс */
-        className: Type.string
+        className: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -28,7 +30,10 @@ class ProgressBar extends React.Component {
         const styles = { width: `${this.props.percent}%` };
 
         return (
-            <div className={ cn({ size: this.props.size }) }>
+            <div
+                className={ cn({ size: this.props.size }) }
+                data-test-id={ this.props['data-test-id'] }
+            >
                 <div
                     style={ styles }
                     className={ cn('current-value') }

--- a/src/radio-group/radio-group.jsx
+++ b/src/radio-group/radio-group.jsx
@@ -58,7 +58,9 @@ class RadioGroup extends React.Component {
          * Обработчик изменения значения 'checked' одного из дочерних радио-кнопок
          * @param {string} value
          */
-        onChange: Type.func
+        onChange: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -122,6 +124,7 @@ class RadioGroup extends React.Component {
                 tabIndex='-1'
                 onFocus={ this.handleFocus }
                 onBlur={ this.handleBlur }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <div className={ cn('inner') }>
                     {

--- a/src/radio/radio.jsx
+++ b/src/radio/radio.jsx
@@ -82,7 +82,9 @@ class Radio extends React.Component {
          * Обработчик события снятия курсора с радио-кнопки
          * @param {React.MouseEvent} event
          */
-        onMouseLeave: Type.func
+        onMouseLeave: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -126,6 +128,7 @@ class Radio extends React.Component {
                 ref={ (label) => {
                     this.label = label;
                 } }
+                data-test-id={ this.props['data-test-id'] }
             >
                 { this.props.type === 'button'
                     ? this.renderButtonRadio(cn, checked, TagButton)

--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -188,7 +188,9 @@ class Select extends React.Component {
         /** Кастомный метод рендера содержимого кнопки, принимает на вход: массив элементов типа CheckedOption */
         renderButtonContent: Type.func,
         /** Максимальная высота попапа */
-        maxHeight: Type.number
+        maxHeight: Type.number,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -304,6 +306,7 @@ class Select extends React.Component {
                 ref={ (root) => {
                     this.root = root;
                 } }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <span className={ cn('inner') }>
                     <input id={ this.props.id } name={ this.props.name } type='hidden' value={ value } />

--- a/src/sidebar/sidebar.jsx
+++ b/src/sidebar/sidebar.jsx
@@ -86,7 +86,9 @@ class Sidebar extends React.Component {
          * Обработчик клика на элемент закрытия
          * @param {React.MouseEvent} event
          */
-        onCloserClick: Type.func
+        onCloserClick: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -147,7 +149,11 @@ class Sidebar extends React.Component {
         let contentStyle = { marginRight: this.state.isMobile ? 0 : `-${offset}px` };
 
         return (
-            <PopupContainerProvider className={ cn({ visible }) } style={ style }>
+            <PopupContainerProvider
+                className={ cn({ visible }) }
+                style={ style }
+                data-test-id={ this.props['data-test-id'] }
+            >
                 <div
                     role='button'
                     tabIndex='-1'

--- a/src/slide-down/slide-down.jsx
+++ b/src/slide-down/slide-down.jsx
@@ -31,7 +31,9 @@ class SlideDown extends React.Component {
         /** Обработчик события начала анимации */
         onAnimationStart: Type.func,
         /** Обработчик события окончания анимации */
-        onAnimationEnd: Type.func
+        onAnimationEnd: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     state = {
@@ -65,6 +67,7 @@ class SlideDown extends React.Component {
                 }
                 onTransitionEnd={ this.handleTransitionEnd }
                 ref={ (slideDown) => { this.slideDown = slideDown; } }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <div
                     className={ cn('content', { expanded: this.state.isHeightAuto }) }

--- a/src/spin/spin.jsx
+++ b/src/spin/spin.jsx
@@ -24,7 +24,9 @@ class Spin extends React.Component {
         /** Дополнительный класс */
         className: Type.string,
         /** Идентификатор компонента в DOM */
-        id: Type.string
+        id: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -40,6 +42,7 @@ class Spin extends React.Component {
                     visible: this.props.visible
                 }) }
                 id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
             />
         );
     }

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -25,7 +25,9 @@ export default class Tabs extends React.Component {
         /** Дополнительный класс */
         className: Type.string,
         /** Идентификатор компонента в DOM */
-        id: Type.string
+        id: Type.string,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -34,7 +36,11 @@ export default class Tabs extends React.Component {
 
     render(cn) {
         return (
-            <div className={ cn({ scrollable: this.props.scrollable }) } id={ this.props.id }>
+            <div
+                className={ cn({ scrollable: this.props.scrollable }) }
+                id={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
+            >
                 <div className={ cn('panel') }>
                     <div className={ cn('content') }>
                         { this.props.children }

--- a/src/textarea/textarea.jsx
+++ b/src/textarea/textarea.jsx
@@ -100,7 +100,9 @@ class Textarea extends React.Component {
          * Обработчик события keyDown
          * @param {React.KeyboardEvent} event
          */
-        onKeyDown: Type.func
+        onKeyDown: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     static defaultProps = {
@@ -167,6 +169,7 @@ class Textarea extends React.Component {
                     'has-value': !!value
                 }) }
                 ref={ (root) => { this.root = root; } }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <span className={ cn('inner') }>
                     {

--- a/src/toggle/toggle.jsx
+++ b/src/toggle/toggle.jsx
@@ -46,7 +46,9 @@ class Toggle extends React.Component {
          * Обработчик снятия фокуса компонента
          * @param {React.FocusEvent} event
          */
-        onBlur: Type.func
+        onBlur: Type.func,
+        /** Идентификатор для систем автоматизированного тестирования */
+        'data-test-id': Type.string
     };
 
     state = {
@@ -70,6 +72,7 @@ class Toggle extends React.Component {
                 onMouseDown={ this.handleUnfocus }
                 onMouseUp={ this.handleUnfocus }
                 htmlFor={ this.props.id }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <span className={ cn('wrapper') }>
                     <input


### PR DESCRIPTION
Added data-test-id property to all components (for autotests)

## Мотивация и контекст
In most cases autotest suits uses test locators to perform desired actions with located elements. `id` property is not always suitable for this purpose as it should be unique on page, and this is not always logically achievable.
`className` property is not suitable as well as it can be changed in future if styles are modified or project structure partially changed. Property `data-test-id` is usually used to make distinct way to locate DOM element.
____________________
В большинстве случаев средства автоматического тестирования используют тестовые локаторы для выполнения необходимых действий над найденными элементами. Свойство `id` не всегда подходит для этих целей, так как должно быть уникальным на странице, а это не всегда достижимо с логической точки зрения.
Свойство `className` также не подходит, так как его значение может поменяться при работе со стилями или при изменении структуры проекта. Свойство `data-test-id` обычно используется с целью нахождения нужного элемента в дереве.
____________________
Логическое продолжение истории https://github.com/alfa-laboratory/arui-feather/pull/824
