### PR TITLE
fix(calendar): focus when select month or year

### DIFF
--- a/src/calendar/calendar.jsx
+++ b/src/calendar/calendar.jsx
@@ -338,6 +338,8 @@ class Calendar extends React.Component {
             this.setState({
                 isMonthSelection: false
             });
+
+            this.root.focus();
         }
     }
 
@@ -392,6 +394,8 @@ class Calendar extends React.Component {
             this.setState({
                 isYearSelection: false
             });
+
+            this.root.focus();
         }
     }
 


### PR DESCRIPTION
## Мотивация и контекст
Исправлено поведение CalendarInput, когда, после выбора месяца или года, календарь не закрывался, при click outside.