### PR TITLE
feat(input): restore error message on blur

### DIFF
--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -358,6 +358,7 @@ class Input extends React.Component {
     handleBlur(event) {
         this.setState({ focused: false });
         this.disableMouseWheel();
+        this.restoreError();
 
         if (this.props.onBlur) {
             this.props.onBlur(event);
@@ -560,7 +561,7 @@ class Input extends React.Component {
     }
 
     /**
-     * Изменяет текущение значение поля ввода и генерирует событие об этом.
+     * Изменяет текущее значение поля ввода и генерирует событие об этом.
      *
      * @param {String} value Новое значение
      */
@@ -592,6 +593,19 @@ class Input extends React.Component {
         if (this.props.resetError) {
             this.setState({
                 error: null
+            });
+        }
+    }
+
+    /**
+     * Восстанавливает состояние ошибки.
+     *
+     * @returns {void}
+     */
+    restoreError() {
+        if (this.props.resetError) {
+            this.setState({
+                error: this.props.error
             });
         }
     }


### PR DESCRIPTION
<!--- Название для изменений -->
Возврат ошибки при блюре компонента

## Мотивация и контекст
<!--- Почему эти изменения необходимы? Какую проблему они решают? -->
В https://github.com/alfa-laboratory/arui-feather/pull/855 был реализован сброс ошибки, когда пользователь фокусируется в компоненте. При блюре (если пользователь не вносил изменения в инпут) ошибка не возвращается, что вводит пользователя в заблуждение. Данный PR устраняет эту проблему.
<!--- Если изменения исправляют открытый issue, прикрепите на него ссылку -->
