### PR TITLE
fix(select): style for .select_view_filled

### DIFF
--- a/src/select/select.css
+++ b/src/select/select.css
@@ -336,6 +336,7 @@
             .select__top {
                 font-size: var(--font-size-xs);
                 transform: translateY(-8px);
+                width: auto;
             }
         }
     }
@@ -383,6 +384,7 @@
             .select__top {
                 font-size: var(--font-size-s);
                 transform: translateY(-12px);
+                width: auto;
             }
         }
     }


### PR DESCRIPTION
## Мотивация и контекст
Исправление ширины для select с классом .select_view_filled

Если использовать select с классом .select_view_filled, то ширина выставляется на 100+% когда transform по X нету. Соответственно блок селекта занимает больше места по оси X что приводит к появлению ненужного скролла