### PR TITLE
fix(tab-item): change default view prop to 'default' in TabItem

### DIFF
--- a/src/tab-item/__snapshots__/tab-item.test.jsx.snap
+++ b/src/tab-item/__snapshots__/tab-item.test.jsx.snap
@@ -7,10 +7,10 @@ exports[`tab-item renders without problems 1`] = `
   pseudo={false}
   size="l"
   tabIndex={0}
-  view="dark"
+  view="default"
 >
   <a
-    className="tab-item tab-item_view_dark tab-item_size_l tab-item_theme_alfa-on-white"
+    className="tab-item tab-item_view_default tab-item_size_l tab-item_theme_alfa-on-white"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}

--- a/src/tab-item/tab-item.jsx
+++ b/src/tab-item/tab-item.jsx
@@ -13,7 +13,7 @@ import cn from '../cn';
 class TabItem extends Link {
     static defaultProps = {
         size: 'l',
-        view: 'dark',
+        view: 'default',
         disabled: false,
         checked: false,
         pseudo: false,


### PR DESCRIPTION
Изменен дефолтный `view` prop с несуществующего значения `dark` на `default` в компоненте `TabItem`, чтобы пофиксить warning.

## Мотивация и контекст
По дефолту prop `view` ставится в `dark`. Это вызывает warning у потребителя компонента:
> Invalid prop `view` of value `dark` supplied to `TabItem`, expected one of ["default", "blue"]

PropTypes для компонента `TabItem` определены в `Link`, от которого он наследуется. В указанных значениях `view` у `Link` нет значения `dark`.
