### PR TITLE
fix(input): fix missing data-test-id attribute in input

### DIFF
--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -228,6 +228,7 @@ class Input extends React.Component {
                 ref={ (root) => {
                     this.root = root;
                 } }
+                data-test-id={ this.props['data-test-id'] }
             >
                 <span className={ cn('inner') }>
                     {

--- a/src/input/input.test.jsx
+++ b/src/input/input.test.jsx
@@ -195,6 +195,13 @@ describe('input', () => {
         expect(controlNode.props().autoComplete).toBe('email');
     });
 
+    it('should render with `data-test-id` attribute if it is set', () => {
+        const input = mount(<Input data-test-id='some value' />);
+        const rootNode = input.getDOMNode();
+
+        expect(rootNode.getAttribute('data-test-id')).toBe('some value');
+    });
+
     it('should set value from props', () => {
         const input = shallow(<Input value='text' />);
         const controlNode = input.find('input');


### PR DESCRIPTION
Применить в атрибуте неиспользуемый `data-test-id` prop в элементе input.

## Мотивация и контекст
В этом [коммите ](https://github.com/alfa-laboratory/arui-feather/commit/599bcf42e4347045b82fc824a571df9d8ce9a947#diff-a103783815939099d5b5bd3c9506451f) добавили атрибут `data-test-id` для `input` и других компонентов.  
Однако в следующем [коммите ](https://github.com/alfa-laboratory/arui-feather/commit/e5539ffdda99f8c603d66a58a798d2c87231869e#diff-a103783815939099d5b5bd3c9506451f) применение атрибута `data-test-id` в компоненте `input` удалили, но сам prop `data-test-id` оставили.
Кажется, нужно либо удалить его с концами, либо вернуть его использование обратно. Я вернул изменения обратно из вышеупомянутого коммита.
