### PR TITLE
chore(window): window to typescript

### DIFF
--- a/src/lib/window.test.tsx
+++ b/src/lib/window.test.tsx
@@ -18,13 +18,13 @@ describe('isEventOusideBounds', () => {
     ({
         left, right, top, bottom, pageX, pageY, isOutside
     }) => {
-        const element = {
-            getBoundingClientRect: jest.fn().mockReturnValue({
-                left, right, top, bottom
-            })
-        };
+        const element = document.createElement('div');
 
-        const result = isEventOusideBounds({ pageX, pageY }, element);
+        element.getBoundingClientRect = jest.fn().mockReturnValue({
+            left, right, top, bottom
+        });
+
+        const result = isEventOusideBounds({ pageX, pageY } as any, element);
 
         expect(result).toBe(isOutside);
     });
@@ -44,13 +44,14 @@ describe('isEventOutsideClientBounds', () => {
     ({
         left, right, top, bottom, clientX, clientY, isOutside
     }) => {
-        const element = {
-            getBoundingClientRect: jest.fn().mockReturnValue({
-                left, right, top, bottom
-            })
-        };
+        const event = new MouseEvent('click', { clientX, clientY });
+        const element = document.createElement('div');
 
-        const result = isEventOutsideClientBounds({ clientX, clientY }, element);
+        element.getBoundingClientRect = jest.fn().mockReturnValue({
+            left, right, top, bottom
+        });
+
+        const result = isEventOutsideClientBounds(event, element);
 
         expect(result).toBe(isOutside);
     });
@@ -58,19 +59,20 @@ describe('isEventOutsideClientBounds', () => {
 
 describe('isNodeOutsideElement', () => {
     it('should return `false` if node contains element', () => {
-        const element = {
-            contains: jest.fn().mockReturnValue(true)
-        };
+        const element = document.createElement('div');
+        const node = document.createElement('div');
 
-        const result = isNodeOutsideElement({}, element);
+        element.contains = jest.fn().mockReturnValue(true);
+
+        const result = isNodeOutsideElement(node, element);
 
         expect(result).toBe(false);
     });
 
     it('should return `false` if node equals element', () => {
-        const element = {
-            contains: jest.fn().mockReturnValue(false)
-        };
+        const element = document.createElement('div');
+
+        element.contains = jest.fn().mockReturnValue(false);
 
         const result = isNodeOutsideElement(element, element);
 
@@ -78,11 +80,12 @@ describe('isNodeOutsideElement', () => {
     });
 
     it('should return `true` if node doesn\'t contains element', () => {
-        const element = {
-            contains: jest.fn().mockReturnValue(false)
-        };
+        const element = document.createElement('div');
+        const node = document.createElement('div');
 
-        const result = isNodeOutsideElement({}, element);
+        element.contains = jest.fn().mockReturnValue(false);
+
+        const result = isNodeOutsideElement(node, element);
 
         expect(result).toBe(true);
     });

--- a/src/lib/window.ts
+++ b/src/lib/window.ts
@@ -2,22 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// @ts-nocheck
-
 import deprecated from 'deprecated-decorator';
 
 /**
  * Check that mouse was outside element.
- *
- * @param {Object} event - MouseEvent
- * @param {Element} element - Element to check bounds
- * @returns {Boolean}
  */
 export const isEventOusideBounds = deprecated({
     name: 'isEventOusideBounds',
     alternative: 'isEventOutsideClientBounds',
     version: '12.0.1'
-}, (event, element) => {
+} as any, (event: MouseEvent, element: Element): boolean => {
     const rect = element.getBoundingClientRect();
 
     return ((event.pageX < rect.left || event.pageX > rect.right) ||
@@ -26,23 +20,15 @@ export const isEventOusideBounds = deprecated({
 
 /**
  * Check that node is outside given element.
- *
- * @param {Node} node Node to search
- * @param {Node} element Element that shouldn't contain node
- * @returns {Boolean}
  */
-export function isNodeOutsideElement(node, element) {
+export function isNodeOutsideElement(node: Element, element: Element): boolean {
     return !(element.contains(node) || element === node);
 }
 
 /**
  * Check that mouse was outside element.
- *
- * @param {Object} event - MouseEvent
- * @param {React.Element} element - Element to check bounds
- * @returns {Boolean}
  */
-export function isEventOutsideClientBounds(event, element) {
+export function isEventOutsideClientBounds(event: MouseEvent, element: Element): boolean {
     const rect = element.getBoundingClientRect();
 
     return event.clientX < rect.left || event.clientX > rect.right ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -3046,6 +3046,11 @@ beeper@^1.0.0:
   resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
   integrity sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=
 
+bem-cn-fast@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bem-cn-fast/-/bem-cn-fast-1.0.2.tgz#ec52816084876ea49ca4701681220dedf0687821"
+  integrity sha1-7FKBYISHbqScpHAWgSIN7fBoeCE=
+
 bem-react-classname@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/bem-react-classname/-/bem-react-classname-1.1.0.tgz#9d61fc2dde16ec53533684f03a74d94202e18447"
@@ -4053,6 +4058,15 @@ clsx@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
   integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==
+
+cn-decorator@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cn-decorator/-/cn-decorator-2.1.0.tgz#5cc0ecb81fa20515387f20c4fe422c74daa8ea73"
+  integrity sha1-XMDsuB+iBRU4fyDE/kIsdNqo6nM=
+  dependencies:
+    bem-cn-fast "^1.0.2"
+    decamelize "^1.2.0"
+    prop-types "^15.6.0"
 
 co@3.1.0:
   version "3.1.0"


### PR DESCRIPTION
## Мотивация и контекст
https://github.com/alfa-laboratory/arui-feather/issues/1021

Пришлось немного переписать тесты.
Апдейт yarn.lock, потому что `cn-decorator` куда-то потерялся