### PR TITLE
fix(*): fix demo theming

### DIFF
--- a/src/amount/entrypoint-for-demo.ts
+++ b/src/amount/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/attach/entrypoint-for-demo.ts
+++ b/src/attach/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/button/entrypoint-for-demo.ts
+++ b/src/button/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/calendar-input/entrypoint-for-demo.ts
+++ b/src/calendar-input/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/calendar/entrypoint-for-demo.ts
+++ b/src/calendar/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/card-input/entrypoint-for-demo.ts
+++ b/src/card-input/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/checkbox-group/entrypoint-for-demo.ts
+++ b/src/checkbox-group/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/checkbox/entrypoint-for-demo.ts
+++ b/src/checkbox/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/collapse/entrypoint-for-demo.ts
+++ b/src/collapse/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/dropdown/entrypoint-for-demo.ts
+++ b/src/dropdown/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/dropzone/entrypoint-for-demo.ts
+++ b/src/dropzone/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/email-input/entrypoint-for-demo.ts
+++ b/src/email-input/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/flag-icon/entrypoint-for-demo.ts
+++ b/src/flag-icon/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/form-field/entrypoint-for-demo.ts
+++ b/src/form-field/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/form/entrypoint-for-demo.ts
+++ b/src/form/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/grid-col/entrypoint-for-demo.ts
+++ b/src/grid-col/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/grid-row/entrypoint-for-demo.ts
+++ b/src/grid-row/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/heading/entrypoint-for-demo.ts
+++ b/src/heading/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/icon-button/entrypoint-for-demo.ts
+++ b/src/icon-button/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/icon/entrypoint-for-demo.ts
+++ b/src/icon/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/input-autocomplete/entrypoint-for-demo.ts
+++ b/src/input-autocomplete/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/input-group/entrypoint-for-demo.ts
+++ b/src/input-group/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/input/entrypoint-for-demo.ts
+++ b/src/input/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -10,5 +10,5 @@ import './input_theme_alfa-on-color.css';
 import './input_theme_alfa-on-white.css';
 import './input.css';
 
-export * from './input';
 export { default } from './input';
+export * from './input';

--- a/src/intl-phone-input/entrypoint-for-demo.ts
+++ b/src/intl-phone-input/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/isolated-container/entrypoint-for-demo.ts
+++ b/src/isolated-container/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/label/entrypoint-for-demo.ts
+++ b/src/label/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/link/entrypoint-for-demo.ts
+++ b/src/link/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/list-header/entrypoint-for-demo.ts
+++ b/src/list-header/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/list/entrypoint-for-demo.ts
+++ b/src/list/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/masked-input/entrypoint-for-demo.ts
+++ b/src/masked-input/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/menu-item/entrypoint-for-demo.ts
+++ b/src/menu-item/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/menu/entrypoint-for-demo.ts
+++ b/src/menu/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/money-input/entrypoint-for-demo.ts
+++ b/src/money-input/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/mq/entrypoint-for-demo.ts
+++ b/src/mq/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/notification/entrypoint-for-demo.ts
+++ b/src/notification/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/paragraph/entrypoint-for-demo.ts
+++ b/src/paragraph/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/phone-input/entrypoint-for-demo.ts
+++ b/src/phone-input/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/plate/entrypoint-for-demo.ts
+++ b/src/plate/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/popup-container-provider/entrypoint-for-demo.ts
+++ b/src/popup-container-provider/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/popup-header/entrypoint-for-demo.ts
+++ b/src/popup-header/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/popup/entrypoint-for-demo.ts
+++ b/src/popup/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/progress-bar/entrypoint-for-demo.ts
+++ b/src/progress-bar/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/radio-group/entrypoint-for-demo.ts
+++ b/src/radio-group/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/radio/entrypoint-for-demo.ts
+++ b/src/radio/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/resize-sensor/entrypoint-for-demo.ts
+++ b/src/resize-sensor/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/select/entrypoint-for-demo.ts
+++ b/src/select/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/sidebar/entrypoint-for-demo.ts
+++ b/src/sidebar/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/slide-down/entrypoint-for-demo.ts
+++ b/src/slide-down/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/spin/entrypoint-for-demo.ts
+++ b/src/spin/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/swipeable/entrypoint-for-demo.ts
+++ b/src/swipeable/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/tab-item/entrypoint-for-demo.ts
+++ b/src/tab-item/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/tabs/entrypoint-for-demo.ts
+++ b/src/tabs/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/tag-button/entrypoint-for-demo.ts
+++ b/src/tag-button/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/textarea/entrypoint-for-demo.ts
+++ b/src/textarea/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/theme-provider/entrypoint-for-demo.ts
+++ b/src/theme-provider/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';

--- a/src/toggle/entrypoint-for-demo.ts
+++ b/src/toggle/entrypoint-for-demo.ts
@@ -1,0 +1,2 @@
+// REMOVE AFTER UPGRADE STYLEGUIDIST
+export { default } from './index';


### PR DESCRIPTION
Если сейчас зайти на демку - видно что стили поехали.
Все потому что глобальный класс компонента который неявно делается стайлгайдистом смотрит не на дефолтный экспорт а на класс, не обернутый withTheme. Раньше у нас этой проблемы не было потому что был один экспорт.
https://github.com/styleguidist/react-styleguidist/pull/1504/files
вот тут это правится, но у нас пока нет возможности обновить стайлагйдист, а люди плачут. Предлагаю порешать так, на время