### PR TITLE
feat(attach): truncate filename

### DIFF
--- a/src/attach/attach.test.tsx
+++ b/src/attach/attach.test.tsx
@@ -153,4 +153,37 @@ describe('attach', () => {
         expect(statusNode.text()).toContain('Нет файла');
         expect(controlNode.props().value).toBeFalsy();
     });
+
+    it('should truncate the filename if the maxFilenameLength prop is passed', () => {
+        const attach = mount(<Attach maxFilenameLength={ 30 } />);
+        const controlNode = attach.find('.attach__control');
+
+        controlNode.simulate('change', {
+            target: {
+                files: [{
+                    name: 'so_long_filename_it_definitely_has_more_than_30_symbols.txt', type: 'application/text'
+                }]
+            }
+        });
+
+        const fileLongNameNode = attach.find('.attach__text');
+
+        expect(fileLongNameNode.text()).toContain('so_long_filena…30_symbols.txt');
+
+        const clearButtonNode = attach.find('.attach__clear');
+
+        clearButtonNode.simulate('click');
+
+        controlNode.simulate('change', {
+            target: {
+                files: [{
+                    name: 'it_has_just_26_symbols.txt', type: 'application/text'
+                }]
+            }
+        });
+
+        const fileShortNameNode = attach.find('.attach__text');
+
+        expect(fileShortNameNode.text()).toContain('it_has_just_26_symbols.txt');
+    });
 });

--- a/src/attach/attach.tsx
+++ b/src/attach/attach.tsx
@@ -330,7 +330,7 @@ export class Attach extends React.PureComponent<AttachProps> {
         if (maxFilenameLength && filename.length > maxFilenameLength) {
             const lengthOfPart: number = Math.round(maxFilenameLength / 2) - 1;
 
-            return `${filename.substr(0, lengthOfPart)}...${filename.substr(filename.length - lengthOfPart)}`;
+            return `${filename.substr(0, lengthOfPart)}…${filename.substr(filename.length - lengthOfPart)}`;
         }
 
         return filename;

--- a/src/attach/attach.tsx
+++ b/src/attach/attach.tsx
@@ -125,6 +125,11 @@ export type AttachProps = {
     progressBarPercent?: number;
 
     /**
+     * Число символов, после которого имя файла будет обрезаться
+     */
+    maxFilenameLength?: number;
+
+    /**
      * Размер компонента
      */
     size?: 's' | 'm' | 'l' | 'xl';
@@ -283,7 +288,7 @@ export class Attach extends React.PureComponent<AttachProps> {
 
         if (files && files.length > 0) {
             const content = (files.length === 1)
-                ? files[0].name
+                ? this.truncateFilename(files[0].name)
                 : (
                     <abbr
                         title={ files.map(file => file.name).join() }
@@ -318,6 +323,18 @@ export class Attach extends React.PureComponent<AttachProps> {
             </span>
         );
     }
+
+    private truncateFilename = (filename: string): string => {
+        const { maxFilenameLength } = this.props;
+
+        if (maxFilenameLength && filename.length > maxFilenameLength) {
+            const lengthOfPart: number = Math.round(maxFilenameLength / 2) - 1;
+
+            return `${filename.substr(0, lengthOfPart)}...${filename.substr(filename.length - lengthOfPart)}`;
+        }
+
+        return filename;
+    };
 
     private handleInputChange = (event) => {
         this.performChange(Array.from(event.target.files));


### PR DESCRIPTION
Возможность обрезать имя файла, если оно слишком длинное.

## Мотивация и контекст
Появилась необходимость обрезать имя файла, т.к. оно может слишком сильно растягивать верстку.
