### PR TITLE
fix(*): use React.ReactNode

### DIFF
--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -108,7 +108,7 @@ export type ButtonProps = DeepReadonly<{
     /**
      * Дочерние элементы `Button`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Идентификатор для систем автоматизированного тестирования

--- a/src/collapse/collapse.tsx
+++ b/src/collapse/collapse.tsx
@@ -31,7 +31,7 @@ export type CollapseProps = DeepReadonly<{
     /**
      * Дочерние элементы `Collapse`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/dropdown/dropdown.tsx
+++ b/src/dropdown/dropdown.tsx
@@ -63,7 +63,7 @@ export type DropdownProps = DeepReadonly<{
     /**
      * Дочерние элементы `Dropdown`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/form-field/form-field.tsx
+++ b/src/form-field/form-field.tsx
@@ -12,7 +12,7 @@ export type FormFieldProps = DeepReadonly<{
     /**
      * Дочерние элементы `FormField`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Дополнительный класс

--- a/src/form/form.tsx
+++ b/src/form/form.tsx
@@ -52,7 +52,7 @@ export type FormProps = DeepReadonly<{
     /**
      * Дочерние элементы формы
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/heading/heading.tsx
+++ b/src/heading/heading.tsx
@@ -20,7 +20,7 @@ export type HeadingProps = DeepReadonly<{
     /**
      * Дочерние элементы `Heading`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Размер, определяющий какой тег заголовка будет использоваться

--- a/src/input-group/input-group.tsx
+++ b/src/input-group/input-group.tsx
@@ -17,7 +17,7 @@ export type InputGroupProps = DeepReadonly<{
     /**
      * Дочерние элементы `InputGroup`, как правило, компоненты `Input`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/label/label.tsx
+++ b/src/label/label.tsx
@@ -16,7 +16,7 @@ export type LabelProps = DeepReadonly<{
     /**
      * Дочерние элементы `Label`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/link/link.tsx
+++ b/src/link/link.tsx
@@ -72,7 +72,7 @@ export type LinkProps = DeepReadonly<{
     /**
      * Дочерние элементы `Link`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/menu-item/menu-item.tsx
+++ b/src/menu-item/menu-item.tsx
@@ -70,7 +70,7 @@ export type MenuItemProps = DeepReadonly<{
     /**
      * Дочерние элементы `MenuItem`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/notification/notification.tsx
+++ b/src/notification/notification.tsx
@@ -47,7 +47,7 @@ export type NotificationProps = DeepReadonly<{
     /**
      * Дочерние элементы `Notification`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/paragraph/paragraph.tsx
+++ b/src/paragraph/paragraph.tsx
@@ -22,7 +22,7 @@ export type ParagraphProps = DeepReadonly<{
     /**
      * Дочерние элементы `Paragraph`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/popup-container-provider/popup-container-provider.tsx
+++ b/src/popup-container-provider/popup-container-provider.tsx
@@ -12,7 +12,7 @@ export type PopupContainerProviderProps = DeepReadonly<{
     /**
      * Дочерние элементы контейнера
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Дополнительный класс

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -66,7 +66,7 @@ export type PopupProps = DeepReadonly<{
     /**
      * Дочерние элементы `Popup`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тип попапа

--- a/src/radio-group/radio-group.tsx
+++ b/src/radio-group/radio-group.tsx
@@ -50,7 +50,7 @@ export type RadioGroupProps = DeepReadonly<{
     /**
      * Дочерние элементы `RadioGroup`, как правило, компоненты `Radio`
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Тема компонента

--- a/src/sidebar/sidebar.tsx
+++ b/src/sidebar/sidebar.tsx
@@ -78,7 +78,7 @@ export type SidebarProps = DeepReadonly<{
     /**
      * Дочерние компоненты
      */
-    children?: ReadonlyArray<React.ReactNode> | React.ReactNode;
+    children?: React.ReactNode;
 
     /**
      * Признак для отрисовки элемента закрытия


### PR DESCRIPTION
children тип заменил на React.ReactNode и проблема ушла

А вообще https://github.com/alfa-laboratory/library-utils/blob/master/typings/stringify-component-definition.js#L88

Вот тут все происходит. В проптайпах было явно вот так написано

children: Type.arrayOf(Type.node),
children: Type.oneOfType([Type.arrayOf(Type.node), Type.node]),