### PR TITLE
chore(*): export Themed class

### DIFF
--- a/src/amount/amount.tsx
+++ b/src/amount/amount.tsx
@@ -161,4 +161,6 @@ export class Amount extends React.Component<AmountProps> {
     }
 }
 
-export default withTheme(Amount);
+class ThemedAmount extends Amount {}
+(ThemedAmount as any) = withTheme(Amount);
+export default ThemedAmount;

--- a/src/attach/attach.tsx
+++ b/src/attach/attach.tsx
@@ -409,4 +409,6 @@ export class Attach extends React.PureComponent<AttachProps> {
     }
 }
 
-export default withTheme(Attach);
+class ThemedAttach extends Attach {}
+(ThemedAttach as any) = withTheme(Attach);
+export default ThemedAttach;

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -403,4 +403,6 @@ export class Button extends React.PureComponent<ButtonProps> {
     }
 }
 
-export default withTheme(Button);
+class ThemedButton extends Button {}
+(ThemedButton as any) = withTheme(Button);
+export default ThemedButton;

--- a/src/calendar-input/calendar-input.tsx
+++ b/src/calendar-input/calendar-input.tsx
@@ -755,4 +755,6 @@ export class CalendarInput extends React.Component<CalendarInputProps> {
     }
 }
 
-export default withTheme(CalendarInput);
+class ThemedCalendarInput extends CalendarInput {}
+(ThemedCalendarInput as any) = withTheme(CalendarInput);
+export default ThemedCalendarInput;

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -906,4 +906,6 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     }
 }
 
-export default withTheme(Calendar);
+class ThemedCalendar extends Calendar {}
+(ThemedCalendar as any) = withTheme(Calendar);
+export default ThemedCalendar;

--- a/src/card-input/card-input.tsx
+++ b/src/card-input/card-input.tsx
@@ -67,4 +67,6 @@ export class CardInput extends React.PureComponent<CardInputProps> {
     }
 }
 
-export default withTheme(CardInput);
+class ThemedCardInput extends CardInput {}
+(ThemedCardInput as any) = withTheme(CardInput);
+export default ThemedCardInput;

--- a/src/checkbox-group/checkbox-group.tsx
+++ b/src/checkbox-group/checkbox-group.tsx
@@ -227,4 +227,6 @@ export class CheckBoxGroup extends React.PureComponent<CheckBoxGroupProps> {
     }
 }
 
-export default withTheme(CheckBoxGroup);
+class ThemedCheckBoxGroup extends CheckBoxGroup {}
+(ThemedCheckBoxGroup as any) = withTheme(CheckBoxGroup);
+export default ThemedCheckBoxGroup;

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -337,4 +337,6 @@ export class CheckBox extends React.PureComponent<CheckboxProps> {
     }
 }
 
-export default withTheme(CheckBox);
+class ThemedCheckBox extends CheckBox {}
+(ThemedCheckBox as any) = withTheme(CheckBox);
+export default ThemedCheckBox;

--- a/src/collapse/collapse.tsx
+++ b/src/collapse/collapse.tsx
@@ -164,4 +164,6 @@ export class Collapse extends React.PureComponent<CollapseProps> {
     }
 }
 
-export default withTheme(Collapse);
+class ThemedCollapse extends Collapse {}
+(ThemedCollapse as any) = withTheme(Collapse);
+export default ThemedCollapse;

--- a/src/dropdown/dropdown.tsx
+++ b/src/dropdown/dropdown.tsx
@@ -298,4 +298,6 @@ export class Dropdown extends React.PureComponent<DropdownProps> {
     }
 }
 
-export default withTheme(Dropdown);
+class ThemedDropdown extends Dropdown {}
+(ThemedDropdown as any) = withTheme(Dropdown);
+export default ThemedDropdown;

--- a/src/dropzone/dropzone.tsx
+++ b/src/dropzone/dropzone.tsx
@@ -169,4 +169,6 @@ export class Dropzone extends React.PureComponent<DropzoneProps> {
     }
 }
 
-export default withTheme(Dropzone);
+class ThemedDropzone extends Dropzone {}
+(ThemedDropzone as any) = withTheme(Dropzone);
+export default ThemedDropzone;

--- a/src/email-input/email-input.tsx
+++ b/src/email-input/email-input.tsx
@@ -59,4 +59,6 @@ export class EmailInput extends React.PureComponent<InputProps> {
     }
 }
 
-export default withTheme(EmailInput);
+class ThemedEmailInput extends EmailInput {}
+(ThemedEmailInput as any) = withTheme(EmailInput);
+export default ThemedEmailInput;

--- a/src/flag-icon/flag-icon.tsx
+++ b/src/flag-icon/flag-icon.tsx
@@ -79,4 +79,6 @@ export class FlagIcon extends React.PureComponent<FlagIconProps> {
     }
 }
 
-export default withTheme(FlagIcon);
+class ThemedFlagIcon extends FlagIcon {}
+(ThemedFlagIcon as any) = withTheme(FlagIcon);
+export default ThemedFlagIcon;

--- a/src/form-field/form-field.tsx
+++ b/src/form-field/form-field.tsx
@@ -64,4 +64,6 @@ export class FormField extends React.PureComponent<FormFieldProps> {
     }
 }
 
-export default withTheme(FormField);
+class ThemedFormField extends FormField {}
+(ThemedFormField as any) = withTheme(FormField);
+export default ThemedFormField;

--- a/src/form/form.tsx
+++ b/src/form/form.tsx
@@ -138,4 +138,6 @@ export class Form extends React.PureComponent<FormProps> {
     }
 }
 
-export default withTheme(Form);
+class ThemedForm extends Form {}
+(ThemedForm as any) = withTheme(Form);
+export default ThemedForm;

--- a/src/heading/heading.tsx
+++ b/src/heading/heading.tsx
@@ -82,4 +82,6 @@ export class Heading extends React.PureComponent<HeadingProps> {
     }
 }
 
-export default withTheme(Heading);
+class ThemedHeading extends Heading {}
+(ThemedHeading as any) = withTheme(Heading);
+export default ThemedHeading;

--- a/src/icon-button/icon-button.tsx
+++ b/src/icon-button/icon-button.tsx
@@ -16,4 +16,6 @@ export class IconButton extends Button {
     cn = createCn('icon-button');
 }
 
-export default withTheme(IconButton);
+class ThemedIconButton extends IconButton {}
+(ThemedIconButton as any) = withTheme(IconButton);
+export default ThemedIconButton;

--- a/src/icon/action/action-photo-or-file/action-photo-or-file.tsx
+++ b/src/icon/action/action-photo-or-file/action-photo-or-file.tsx
@@ -18,4 +18,6 @@ class IconActionPhotoOrFile extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconActionPhotoOrFile);
+class ThemedIconActionPhotoOrFile extends IconActionPhotoOrFile {}
+(ThemedIconActionPhotoOrFile as any) = withTheme(IconActionPhotoOrFile);
+export default ThemedIconActionPhotoOrFile;

--- a/src/icon/action/add-filled/add-filled.tsx
+++ b/src/icon/action/add-filled/add-filled.tsx
@@ -18,4 +18,6 @@ class IconAddFilled extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAddFilled);
+class ThemedIconAddFilled extends IconAddFilled {}
+(ThemedIconAddFilled as any) = withTheme(IconAddFilled);
+export default ThemedIconAddFilled;

--- a/src/icon/action/add/add.tsx
+++ b/src/icon/action/add/add.tsx
@@ -18,4 +18,6 @@ class IconAdd extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAdd);
+class ThemedIconAdd extends IconAdd {}
+(ThemedIconAdd as any) = withTheme(IconAdd);
+export default ThemedIconAdd;

--- a/src/icon/action/analytics/analytics.tsx
+++ b/src/icon/action/analytics/analytics.tsx
@@ -18,4 +18,6 @@ class IconAnalytics extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAnalytics);
+class ThemedIconAnalytics extends IconAnalytics {}
+(ThemedIconAnalytics as any) = withTheme(IconAnalytics);
+export default ThemedIconAnalytics;

--- a/src/icon/action/android-document/android-document.tsx
+++ b/src/icon/action/android-document/android-document.tsx
@@ -18,4 +18,6 @@ class IconAndroidDocument extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAndroidDocument);
+class ThemedIconAndroidDocument extends IconAndroidDocument {}
+(ThemedIconAndroidDocument as any) = withTheme(IconAndroidDocument);
+export default ThemedIconAndroidDocument;

--- a/src/icon/action/android-flash/android-flash.tsx
+++ b/src/icon/action/android-flash/android-flash.tsx
@@ -18,4 +18,6 @@ class IconAndroidFlash extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAndroidFlash);
+class ThemedIconAndroidFlash extends IconAndroidFlash {}
+(ThemedIconAndroidFlash as any) = withTheme(IconAndroidFlash);
+export default ThemedIconAndroidFlash;

--- a/src/icon/action/android-photo/android-photo.tsx
+++ b/src/icon/action/android-photo/android-photo.tsx
@@ -18,4 +18,6 @@ class IconAndroidPhoto extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAndroidPhoto);
+class ThemedIconAndroidPhoto extends IconAndroidPhoto {}
+(ThemedIconAndroidPhoto as any) = withTheme(IconAndroidPhoto);
+export default ThemedIconAndroidPhoto;

--- a/src/icon/action/arrow-back-bold/arrow-back-bold.tsx
+++ b/src/icon/action/arrow-back-bold/arrow-back-bold.tsx
@@ -18,4 +18,6 @@ class IconArrowBackBold extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowBackBold);
+class ThemedIconArrowBackBold extends IconArrowBackBold {}
+(ThemedIconArrowBackBold as any) = withTheme(IconArrowBackBold);
+export default ThemedIconArrowBackBold;

--- a/src/icon/action/arrow-back/arrow-back.tsx
+++ b/src/icon/action/arrow-back/arrow-back.tsx
@@ -18,4 +18,6 @@ class IconArrowBack extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowBack);
+class ThemedIconArrowBack extends IconArrowBack {}
+(ThemedIconArrowBack as any) = withTheme(IconArrowBack);
+export default ThemedIconArrowBack;

--- a/src/icon/action/attachment/attachment.tsx
+++ b/src/icon/action/attachment/attachment.tsx
@@ -18,4 +18,6 @@ class IconAttachment extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAttachment);
+class ThemedIconAttachment extends IconAttachment {}
+(ThemedIconAttachment as any) = withTheme(IconAttachment);
+export default ThemedIconAttachment;

--- a/src/icon/action/back/back.tsx
+++ b/src/icon/action/back/back.tsx
@@ -18,4 +18,6 @@ class IconBack extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBack);
+class ThemedIconBack extends IconBack {}
+(ThemedIconBack as any) = withTheme(IconBack);
+export default ThemedIconBack;

--- a/src/icon/action/call/call.tsx
+++ b/src/icon/action/call/call.tsx
@@ -18,4 +18,6 @@ class IconCall extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCall);
+class ThemedIconCall extends IconCall {}
+(ThemedIconCall as any) = withTheme(IconCall);
+export default ThemedIconCall;

--- a/src/icon/action/camera/camera.tsx
+++ b/src/icon/action/camera/camera.tsx
@@ -18,4 +18,6 @@ class IconCamera extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCamera);
+class ThemedIconCamera extends IconCamera {}
+(ThemedIconCamera as any) = withTheme(IconCamera);
+export default ThemedIconCamera;

--- a/src/icon/action/card-pin-change/card-pin-change.tsx
+++ b/src/icon/action/card-pin-change/card-pin-change.tsx
@@ -18,4 +18,6 @@ class IconCardPinChange extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardPinChange);
+class ThemedIconCardPinChange extends IconCardPinChange {}
+(ThemedIconCardPinChange as any) = withTheme(IconCardPinChange);
+export default ThemedIconCardPinChange;

--- a/src/icon/action/chat-message-error/chat-message-error.tsx
+++ b/src/icon/action/chat-message-error/chat-message-error.tsx
@@ -18,4 +18,6 @@ class IconChatMessageError extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconChatMessageError);
+class ThemedIconChatMessageError extends IconChatMessageError {}
+(ThemedIconChatMessageError as any) = withTheme(IconChatMessageError);
+export default ThemedIconChatMessageError;

--- a/src/icon/action/chat-send/chat-send.tsx
+++ b/src/icon/action/chat-send/chat-send.tsx
@@ -18,4 +18,6 @@ class IconChatSend extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconChatSend);
+class ThemedIconChatSend extends IconChatSend {}
+(ThemedIconChatSend as any) = withTheme(IconChatSend);
+export default ThemedIconChatSend;

--- a/src/icon/action/chat/chat.tsx
+++ b/src/icon/action/chat/chat.tsx
@@ -18,4 +18,6 @@ class IconChat extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconChat);
+class ThemedIconChat extends IconChat {}
+(ThemedIconChat as any) = withTheme(IconChat);
+export default ThemedIconChat;

--- a/src/icon/action/contactless/contactless.tsx
+++ b/src/icon/action/contactless/contactless.tsx
@@ -18,4 +18,6 @@ class IconContactless extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconContactless);
+class ThemedIconContactless extends IconContactless {}
+(ThemedIconContactless as any) = withTheme(IconContactless);
+export default ThemedIconContactless;

--- a/src/icon/action/convert-rub-to-usd/convert-rub-to-usd.tsx
+++ b/src/icon/action/convert-rub-to-usd/convert-rub-to-usd.tsx
@@ -18,4 +18,6 @@ class IconConvertRubToUsd extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconConvertRubToUsd);
+class ThemedIconConvertRubToUsd extends IconConvertRubToUsd {}
+(ThemedIconConvertRubToUsd as any) = withTheme(IconConvertRubToUsd);
+export default ThemedIconConvertRubToUsd;

--- a/src/icon/action/copy/copy.tsx
+++ b/src/icon/action/copy/copy.tsx
@@ -18,4 +18,6 @@ class IconCopy extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCopy);
+class ThemedIconCopy extends IconCopy {}
+(ThemedIconCopy as any) = withTheme(IconCopy);
+export default ThemedIconCopy;

--- a/src/icon/action/delete/delete.tsx
+++ b/src/icon/action/delete/delete.tsx
@@ -18,4 +18,6 @@ class IconDelete extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDelete);
+class ThemedIconDelete extends IconDelete {}
+(ThemedIconDelete as any) = withTheme(IconDelete);
+export default ThemedIconDelete;

--- a/src/icon/action/dislike-filled/dislike-filled.tsx
+++ b/src/icon/action/dislike-filled/dislike-filled.tsx
@@ -18,4 +18,6 @@ class IconDislikeFilled extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDislikeFilled);
+class ThemedIconDislikeFilled extends IconDislikeFilled {}
+(ThemedIconDislikeFilled as any) = withTheme(IconDislikeFilled);
+export default ThemedIconDislikeFilled;

--- a/src/icon/action/dislike/dislike.tsx
+++ b/src/icon/action/dislike/dislike.tsx
@@ -18,4 +18,6 @@ class IconDislike extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDislike);
+class ThemedIconDislike extends IconDislike {}
+(ThemedIconDislike as any) = withTheme(IconDislike);
+export default ThemedIconDislike;

--- a/src/icon/action/dots/dots.tsx
+++ b/src/icon/action/dots/dots.tsx
@@ -18,4 +18,6 @@ class IconDots extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDots);
+class ThemedIconDots extends IconDots {}
+(ThemedIconDots as any) = withTheme(IconDots);
+export default ThemedIconDots;

--- a/src/icon/action/download/download.tsx
+++ b/src/icon/action/download/download.tsx
@@ -18,4 +18,6 @@ class IconDownload extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDownload);
+class ThemedIconDownload extends IconDownload {}
+(ThemedIconDownload as any) = withTheme(IconDownload);
+export default ThemedIconDownload;

--- a/src/icon/action/edit/edit.tsx
+++ b/src/icon/action/edit/edit.tsx
@@ -18,4 +18,6 @@ class IconEdit extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconEdit);
+class ThemedIconEdit extends IconEdit {}
+(ThemedIconEdit as any) = withTheme(IconEdit);
+export default ThemedIconEdit;

--- a/src/icon/action/email/email.tsx
+++ b/src/icon/action/email/email.tsx
@@ -18,4 +18,6 @@ class IconEmail extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconEmail);
+class ThemedIconEmail extends IconEmail {}
+(ThemedIconEmail as any) = withTheme(IconEmail);
+export default ThemedIconEmail;

--- a/src/icon/action/erase/erase.tsx
+++ b/src/icon/action/erase/erase.tsx
@@ -18,4 +18,6 @@ class IconErase extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconErase);
+class ThemedIconErase extends IconErase {}
+(ThemedIconErase as any) = withTheme(IconErase);
+export default ThemedIconErase;

--- a/src/icon/action/filter/filter.tsx
+++ b/src/icon/action/filter/filter.tsx
@@ -18,4 +18,6 @@ class IconFilter extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFilter);
+class ThemedIconFilter extends IconFilter {}
+(ThemedIconFilter as any) = withTheme(IconFilter);
+export default ThemedIconFilter;

--- a/src/icon/action/flash/flash.tsx
+++ b/src/icon/action/flash/flash.tsx
@@ -18,4 +18,6 @@ class IconFlash extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFlash);
+class ThemedIconFlash extends IconFlash {}
+(ThemedIconFlash as any) = withTheme(IconFlash);
+export default ThemedIconFlash;

--- a/src/icon/action/gallery-in-camera/gallery-in-camera.tsx
+++ b/src/icon/action/gallery-in-camera/gallery-in-camera.tsx
@@ -18,4 +18,6 @@ class IconGalleryInCamera extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconGalleryInCamera);
+class ThemedIconGalleryInCamera extends IconGalleryInCamera {}
+(ThemedIconGalleryInCamera as any) = withTheme(IconGalleryInCamera);
+export default ThemedIconGalleryInCamera;

--- a/src/icon/action/like-filled/like-filled.tsx
+++ b/src/icon/action/like-filled/like-filled.tsx
@@ -18,4 +18,6 @@ class IconLikeFilled extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconLikeFilled);
+class ThemedIconLikeFilled extends IconLikeFilled {}
+(ThemedIconLikeFilled as any) = withTheme(IconLikeFilled);
+export default ThemedIconLikeFilled;

--- a/src/icon/action/like/like.tsx
+++ b/src/icon/action/like/like.tsx
@@ -18,4 +18,6 @@ class IconLike extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconLike);
+class ThemedIconLike extends IconLike {}
+(ThemedIconLike as any) = withTheme(IconLike);
+export default ThemedIconLike;

--- a/src/icon/action/lock-filled/lock-filled.tsx
+++ b/src/icon/action/lock-filled/lock-filled.tsx
@@ -18,4 +18,6 @@ class IconLockFilled extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconLockFilled);
+class ThemedIconLockFilled extends IconLockFilled {}
+(ThemedIconLockFilled as any) = withTheme(IconLockFilled);
+export default ThemedIconLockFilled;

--- a/src/icon/action/lock/lock.tsx
+++ b/src/icon/action/lock/lock.tsx
@@ -18,4 +18,6 @@ class IconLock extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconLock);
+class ThemedIconLock extends IconLock {}
+(ThemedIconLock as any) = withTheme(IconLock);
+export default ThemedIconLock;

--- a/src/icon/action/logout/logout.tsx
+++ b/src/icon/action/logout/logout.tsx
@@ -18,4 +18,6 @@ class IconLogout extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconLogout);
+class ThemedIconLogout extends IconLogout {}
+(ThemedIconLogout as any) = withTheme(IconLogout);
+export default ThemedIconLogout;

--- a/src/icon/action/more/more.tsx
+++ b/src/icon/action/more/more.tsx
@@ -18,4 +18,6 @@ class IconMore extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMore);
+class ThemedIconMore extends IconMore {}
+(ThemedIconMore as any) = withTheme(IconMore);
+export default ThemedIconMore;

--- a/src/icon/action/navigation-chat/navigation-chat.tsx
+++ b/src/icon/action/navigation-chat/navigation-chat.tsx
@@ -18,4 +18,6 @@ class IconNavigationChat extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNavigationChat);
+class ThemedIconNavigationChat extends IconNavigationChat {}
+(ThemedIconNavigationChat as any) = withTheme(IconNavigationChat);
+export default ThemedIconNavigationChat;

--- a/src/icon/action/navigation-history/navigation-history.tsx
+++ b/src/icon/action/navigation-history/navigation-history.tsx
@@ -18,4 +18,6 @@ class IconNavigationHistory extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNavigationHistory);
+class ThemedIconNavigationHistory extends IconNavigationHistory {}
+(ThemedIconNavigationHistory as any) = withTheme(IconNavigationHistory);
+export default ThemedIconNavigationHistory;

--- a/src/icon/action/navigation-home/navigation-home.tsx
+++ b/src/icon/action/navigation-home/navigation-home.tsx
@@ -18,4 +18,6 @@ class IconNavigationHome extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNavigationHome);
+class ThemedIconNavigationHome extends IconNavigationHome {}
+(ThemedIconNavigationHome as any) = withTheme(IconNavigationHome);
+export default ThemedIconNavigationHome;

--- a/src/icon/action/navigation-marketplace/navigation-marketplace.tsx
+++ b/src/icon/action/navigation-marketplace/navigation-marketplace.tsx
@@ -18,4 +18,6 @@ class IconNavigationMarketplace extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNavigationMarketplace);
+class ThemedIconNavigationMarketplace extends IconNavigationMarketplace {}
+(ThemedIconNavigationMarketplace as any) = withTheme(IconNavigationMarketplace);
+export default ThemedIconNavigationMarketplace;

--- a/src/icon/action/navigation-payment/navigation-payment.tsx
+++ b/src/icon/action/navigation-payment/navigation-payment.tsx
@@ -18,4 +18,6 @@ class IconNavigationPayment extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNavigationPayment);
+class ThemedIconNavigationPayment extends IconNavigationPayment {}
+(ThemedIconNavigationPayment as any) = withTheme(IconNavigationPayment);
+export default ThemedIconNavigationPayment;

--- a/src/icon/action/next/next.tsx
+++ b/src/icon/action/next/next.tsx
@@ -18,4 +18,6 @@ class IconNext extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNext);
+class ThemedIconNext extends IconNext {}
+(ThemedIconNext as any) = withTheme(IconNext);
+export default ThemedIconNext;

--- a/src/icon/action/password-change/password-change.tsx
+++ b/src/icon/action/password-change/password-change.tsx
@@ -18,4 +18,6 @@ class IconPasswordChange extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPasswordChange);
+class ThemedIconPasswordChange extends IconPasswordChange {}
+(ThemedIconPasswordChange as any) = withTheme(IconPasswordChange);
+export default ThemedIconPasswordChange;

--- a/src/icon/action/password-hide/password-hide.tsx
+++ b/src/icon/action/password-hide/password-hide.tsx
@@ -18,4 +18,6 @@ class IconPasswordHide extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPasswordHide);
+class ThemedIconPasswordHide extends IconPasswordHide {}
+(ThemedIconPasswordHide as any) = withTheme(IconPasswordHide);
+export default ThemedIconPasswordHide;

--- a/src/icon/action/password-show/password-show.tsx
+++ b/src/icon/action/password-show/password-show.tsx
@@ -18,4 +18,6 @@ class IconPasswordShow extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPasswordShow);
+class ThemedIconPasswordShow extends IconPasswordShow {}
+(ThemedIconPasswordShow as any) = withTheme(IconPasswordShow);
+export default ThemedIconPasswordShow;

--- a/src/icon/action/pause/pause.tsx
+++ b/src/icon/action/pause/pause.tsx
@@ -18,4 +18,6 @@ class IconPause extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPause);
+class ThemedIconPause extends IconPause {}
+(ThemedIconPause as any) = withTheme(IconPause);
+export default ThemedIconPause;

--- a/src/icon/action/photo-card/photo-card.tsx
+++ b/src/icon/action/photo-card/photo-card.tsx
@@ -18,4 +18,6 @@ class IconPhotoCard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPhotoCard);
+class ThemedIconPhotoCard extends IconPhotoCard {}
+(ThemedIconPhotoCard as any) = withTheme(IconPhotoCard);
+export default ThemedIconPhotoCard;

--- a/src/icon/action/pin-unpin/pin-unpin.tsx
+++ b/src/icon/action/pin-unpin/pin-unpin.tsx
@@ -18,4 +18,6 @@ class IconPinUnpin extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPinUnpin);
+class ThemedIconPinUnpin extends IconPinUnpin {}
+(ThemedIconPinUnpin as any) = withTheme(IconPinUnpin);
+export default ThemedIconPinUnpin;

--- a/src/icon/action/pin/pin.tsx
+++ b/src/icon/action/pin/pin.tsx
@@ -18,4 +18,6 @@ class IconPin extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPin);
+class ThemedIconPin extends IconPin {}
+(ThemedIconPin as any) = withTheme(IconPin);
+export default ThemedIconPin;

--- a/src/icon/action/power-card/power-card.tsx
+++ b/src/icon/action/power-card/power-card.tsx
@@ -18,4 +18,6 @@ class IconPowerCard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPowerCard);
+class ThemedIconPowerCard extends IconPowerCard {}
+(ThemedIconPowerCard as any) = withTheme(IconPowerCard);
+export default ThemedIconPowerCard;

--- a/src/icon/action/power/power.tsx
+++ b/src/icon/action/power/power.tsx
@@ -18,4 +18,6 @@ class IconPower extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPower);
+class ThemedIconPower extends IconPower {}
+(ThemedIconPower as any) = withTheme(IconPower);
+export default ThemedIconPower;

--- a/src/icon/action/printer/printer.tsx
+++ b/src/icon/action/printer/printer.tsx
@@ -18,4 +18,6 @@ class IconPrinter extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPrinter);
+class ThemedIconPrinter extends IconPrinter {}
+(ThemedIconPrinter as any) = withTheme(IconPrinter);
+export default ThemedIconPrinter;

--- a/src/icon/action/repeat/repeat.tsx
+++ b/src/icon/action/repeat/repeat.tsx
@@ -18,4 +18,6 @@ class IconRepeat extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconRepeat);
+class ThemedIconRepeat extends IconRepeat {}
+(ThemedIconRepeat as any) = withTheme(IconRepeat);
+export default ThemedIconRepeat;

--- a/src/icon/action/reply/reply.tsx
+++ b/src/icon/action/reply/reply.tsx
@@ -18,4 +18,6 @@ class IconReply extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconReply);
+class ThemedIconReply extends IconReply {}
+(ThemedIconReply as any) = withTheme(IconReply);
+export default ThemedIconReply;

--- a/src/icon/action/search/search.tsx
+++ b/src/icon/action/search/search.tsx
@@ -18,4 +18,6 @@ class IconSearch extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSearch);
+class ThemedIconSearch extends IconSearch {}
+(ThemedIconSearch as any) = withTheme(IconSearch);
+export default ThemedIconSearch;

--- a/src/icon/action/selfemloyed-reg/selfemloyed-reg.tsx
+++ b/src/icon/action/selfemloyed-reg/selfemloyed-reg.tsx
@@ -18,4 +18,6 @@ class IconSelfemloyedReg extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSelfemloyedReg);
+class ThemedIconSelfemloyedReg extends IconSelfemloyedReg {}
+(ThemedIconSelfemloyedReg as any) = withTheme(IconSelfemloyedReg);
+export default ThemedIconSelfemloyedReg;

--- a/src/icon/action/sent-done/sent-done.tsx
+++ b/src/icon/action/sent-done/sent-done.tsx
@@ -18,4 +18,6 @@ class IconSentDone extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSentDone);
+class ThemedIconSentDone extends IconSentDone {}
+(ThemedIconSentDone as any) = withTheme(IconSentDone);
+export default ThemedIconSentDone;

--- a/src/icon/action/settings/settings.tsx
+++ b/src/icon/action/settings/settings.tsx
@@ -18,4 +18,6 @@ class IconSettings extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSettings);
+class ThemedIconSettings extends IconSettings {}
+(ThemedIconSettings as any) = withTheme(IconSettings);
+export default ThemedIconSettings;

--- a/src/icon/action/share-android/share-android.tsx
+++ b/src/icon/action/share-android/share-android.tsx
@@ -18,4 +18,6 @@ class IconShareAndroid extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconShareAndroid);
+class ThemedIconShareAndroid extends IconShareAndroid {}
+(ThemedIconShareAndroid as any) = withTheme(IconShareAndroid);
+export default ThemedIconShareAndroid;

--- a/src/icon/action/share-ios/share-ios.tsx
+++ b/src/icon/action/share-ios/share-ios.tsx
@@ -18,4 +18,6 @@ class IconShareIos extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconShareIos);
+class ThemedIconShareIos extends IconShareIos {}
+(ThemedIconShareIos as any) = withTheme(IconShareIos);
+export default ThemedIconShareIos;

--- a/src/icon/action/sign/sign.tsx
+++ b/src/icon/action/sign/sign.tsx
@@ -18,4 +18,6 @@ class IconSign extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSign);
+class ThemedIconSign extends IconSign {}
+(ThemedIconSign as any) = withTheme(IconSign);
+export default ThemedIconSign;

--- a/src/icon/action/unlock/unlock.tsx
+++ b/src/icon/action/unlock/unlock.tsx
@@ -18,4 +18,6 @@ class IconUnlock extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconUnlock);
+class ThemedIconUnlock extends IconUnlock {}
+(ThemedIconUnlock as any) = withTheme(IconUnlock);
+export default ThemedIconUnlock;

--- a/src/icon/banking/account-add/account-add.tsx
+++ b/src/icon/banking/account-add/account-add.tsx
@@ -18,4 +18,6 @@ class IconAccountAdd extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAccountAdd);
+class ThemedIconAccountAdd extends IconAccountAdd {}
+(ThemedIconAccountAdd as any) = withTheme(IconAccountAdd);
+export default ThemedIconAccountAdd;

--- a/src/icon/banking/account-default/account-default.tsx
+++ b/src/icon/banking/account-default/account-default.tsx
@@ -18,4 +18,6 @@ class IconAccountDefault extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAccountDefault);
+class ThemedIconAccountDefault extends IconAccountDefault {}
+(ThemedIconAccountDefault as any) = withTheme(IconAccountDefault);
+export default ThemedIconAccountDefault;

--- a/src/icon/banking/account-shared/account-shared.tsx
+++ b/src/icon/banking/account-shared/account-shared.tsx
@@ -18,4 +18,6 @@ class IconAccountShared extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAccountShared);
+class ThemedIconAccountShared extends IconAccountShared {}
+(ThemedIconAccountShared as any) = withTheme(IconAccountShared);
+export default ThemedIconAccountShared;

--- a/src/icon/banking/attention-bold/attention-bold.tsx
+++ b/src/icon/banking/attention-bold/attention-bold.tsx
@@ -18,4 +18,6 @@ class IconAttentionBold extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAttentionBold);
+class ThemedIconAttentionBold extends IconAttentionBold {}
+(ThemedIconAttentionBold as any) = withTheme(IconAttentionBold);
+export default ThemedIconAttentionBold;

--- a/src/icon/banking/balance-transfer/balance-transfer.tsx
+++ b/src/icon/banking/balance-transfer/balance-transfer.tsx
@@ -18,4 +18,6 @@ class IconBalanceTransfer extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBalanceTransfer);
+class ThemedIconBalanceTransfer extends IconBalanceTransfer {}
+(ThemedIconBalanceTransfer as any) = withTheme(IconBalanceTransfer);
+export default ThemedIconBalanceTransfer;

--- a/src/icon/banking/card-accounts-list/card-accounts-list.tsx
+++ b/src/icon/banking/card-accounts-list/card-accounts-list.tsx
@@ -18,4 +18,6 @@ class IconCardAccountsList extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardAccountsList);
+class ThemedIconCardAccountsList extends IconCardAccountsList {}
+(ThemedIconCardAccountsList as any) = withTheme(IconCardAccountsList);
+export default ThemedIconCardAccountsList;

--- a/src/icon/banking/card-activate/card-activate.tsx
+++ b/src/icon/banking/card-activate/card-activate.tsx
@@ -18,4 +18,6 @@ class IconCardActivate extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardActivate);
+class ThemedIconCardActivate extends IconCardActivate {}
+(ThemedIconCardActivate as any) = withTheme(IconCardActivate);
+export default ThemedIconCardActivate;

--- a/src/icon/banking/card-activation/card-activation.tsx
+++ b/src/icon/banking/card-activation/card-activation.tsx
@@ -18,4 +18,6 @@ class IconCardActivation extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardActivation);
+class ThemedIconCardActivation extends IconCardActivation {}
+(ThemedIconCardActivation as any) = withTheme(IconCardActivation);
+export default ThemedIconCardActivation;

--- a/src/icon/banking/card-add/card-add.tsx
+++ b/src/icon/banking/card-add/card-add.tsx
@@ -18,4 +18,6 @@ class IconCardAdd extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardAdd);
+class ThemedIconCardAdd extends IconCardAdd {}
+(ThemedIconCardAdd as any) = withTheme(IconCardAdd);
+export default ThemedIconCardAdd;

--- a/src/icon/banking/card-close/card-close.tsx
+++ b/src/icon/banking/card-close/card-close.tsx
@@ -18,4 +18,6 @@ class IconCardClose extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardClose);
+class ThemedIconCardClose extends IconCardClose {}
+(ThemedIconCardClose as any) = withTheme(IconCardClose);
+export default ThemedIconCardClose;

--- a/src/icon/banking/card-expences/card-expences.tsx
+++ b/src/icon/banking/card-expences/card-expences.tsx
@@ -18,4 +18,6 @@ class IconCardExpences extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardExpences);
+class ThemedIconCardExpences extends IconCardExpences {}
+(ThemedIconCardExpences as any) = withTheme(IconCardExpences);
+export default ThemedIconCardExpences;

--- a/src/icon/banking/card-list/card-list.tsx
+++ b/src/icon/banking/card-list/card-list.tsx
@@ -18,4 +18,6 @@ class IconCardList extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardList);
+class ThemedIconCardList extends IconCardList {}
+(ThemedIconCardList as any) = withTheme(IconCardList);
+export default ThemedIconCardList;

--- a/src/icon/banking/card-to-card/card-to-card.tsx
+++ b/src/icon/banking/card-to-card/card-to-card.tsx
@@ -18,4 +18,6 @@ class IconCardToCard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardToCard);
+class ThemedIconCardToCard extends IconCardToCard {}
+(ThemedIconCardToCard as any) = withTheme(IconCardToCard);
+export default ThemedIconCardToCard;

--- a/src/icon/banking/card-unknown/card-unknown.tsx
+++ b/src/icon/banking/card-unknown/card-unknown.tsx
@@ -18,4 +18,6 @@ class IconCardUnknown extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardUnknown);
+class ThemedIconCardUnknown extends IconCardUnknown {}
+(ThemedIconCardUnknown as any) = withTheme(IconCardUnknown);
+export default ThemedIconCardUnknown;

--- a/src/icon/banking/card/card.tsx
+++ b/src/icon/banking/card/card.tsx
@@ -18,4 +18,6 @@ class IconCard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCard);
+class ThemedIconCard extends IconCard {}
+(ThemedIconCard as any) = withTheme(IconCard);
+export default ThemedIconCard;

--- a/src/icon/banking/cash/cash.tsx
+++ b/src/icon/banking/cash/cash.tsx
@@ -18,4 +18,6 @@ class IconCash extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCash);
+class ThemedIconCash extends IconCash {}
+(ThemedIconCash as any) = withTheme(IconCash);
+export default ThemedIconCash;

--- a/src/icon/banking/convert/convert.tsx
+++ b/src/icon/banking/convert/convert.tsx
@@ -18,4 +18,6 @@ class IconConvert extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconConvert);
+class ThemedIconConvert extends IconConvert {}
+(ThemedIconConvert as any) = withTheme(IconConvert);
+export default ThemedIconConvert;

--- a/src/icon/banking/costs-card/costs-card.tsx
+++ b/src/icon/banking/costs-card/costs-card.tsx
@@ -18,4 +18,6 @@ class IconCostsCard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCostsCard);
+class ThemedIconCostsCard extends IconCostsCard {}
+(ThemedIconCostsCard as any) = withTheme(IconCostsCard);
+export default ThemedIconCostsCard;

--- a/src/icon/banking/costs/costs.tsx
+++ b/src/icon/banking/costs/costs.tsx
@@ -18,4 +18,6 @@ class IconCosts extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCosts);
+class ThemedIconCosts extends IconCosts {}
+(ThemedIconCosts as any) = withTheme(IconCosts);
+export default ThemedIconCosts;

--- a/src/icon/banking/credit-card/credit-card.tsx
+++ b/src/icon/banking/credit-card/credit-card.tsx
@@ -18,4 +18,6 @@ class IconCreditCard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCreditCard);
+class ThemedIconCreditCard extends IconCreditCard {}
+(ThemedIconCreditCard as any) = withTheme(IconCreditCard);
+export default ThemedIconCreditCard;

--- a/src/icon/banking/credit/credit.tsx
+++ b/src/icon/banking/credit/credit.tsx
@@ -18,4 +18,6 @@ class IconCredit extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCredit);
+class ThemedIconCredit extends IconCredit {}
+(ThemedIconCredit as any) = withTheme(IconCredit);
+export default ThemedIconCredit;

--- a/src/icon/banking/crown-premium/crown-premium.tsx
+++ b/src/icon/banking/crown-premium/crown-premium.tsx
@@ -18,4 +18,6 @@ class IconCrownPremium extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCrownPremium);
+class ThemedIconCrownPremium extends IconCrownPremium {}
+(ThemedIconCrownPremium as any) = withTheme(IconCrownPremium);
+export default ThemedIconCrownPremium;

--- a/src/icon/banking/crown/crown.tsx
+++ b/src/icon/banking/crown/crown.tsx
@@ -18,4 +18,6 @@ class IconCrown extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCrown);
+class ThemedIconCrown extends IconCrown {}
+(ThemedIconCrown as any) = withTheme(IconCrown);
+export default ThemedIconCrown;

--- a/src/icon/banking/cvv/cvv.tsx
+++ b/src/icon/banking/cvv/cvv.tsx
@@ -18,4 +18,6 @@ class IconCvv extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCvv);
+class ThemedIconCvv extends IconCvv {}
+(ThemedIconCvv as any) = withTheme(IconCvv);
+export default ThemedIconCvv;

--- a/src/icon/banking/deposit/deposit.tsx
+++ b/src/icon/banking/deposit/deposit.tsx
@@ -18,4 +18,6 @@ class IconDeposit extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDeposit);
+class ThemedIconDeposit extends IconDeposit {}
+(ThemedIconDeposit as any) = withTheme(IconDeposit);
+export default ThemedIconDeposit;

--- a/src/icon/banking/expences-planner/expences-planner.tsx
+++ b/src/icon/banking/expences-planner/expences-planner.tsx
@@ -18,4 +18,6 @@ class IconExpencesPlanner extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconExpencesPlanner);
+class ThemedIconExpencesPlanner extends IconExpencesPlanner {}
+(ThemedIconExpencesPlanner as any) = withTheme(IconExpencesPlanner);
+export default ThemedIconExpencesPlanner;

--- a/src/icon/banking/expences/expences.tsx
+++ b/src/icon/banking/expences/expences.tsx
@@ -18,4 +18,6 @@ class IconExpences extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconExpences);
+class ThemedIconExpences extends IconExpences {}
+(ThemedIconExpences as any) = withTheme(IconExpences);
+export default ThemedIconExpences;

--- a/src/icon/banking/goals/goals.tsx
+++ b/src/icon/banking/goals/goals.tsx
@@ -18,4 +18,6 @@ class IconGoals extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconGoals);
+class ThemedIconGoals extends IconGoals {}
+(ThemedIconGoals as any) = withTheme(IconGoals);
+export default ThemedIconGoals;

--- a/src/icon/banking/income/income.tsx
+++ b/src/icon/banking/income/income.tsx
@@ -18,4 +18,6 @@ class IconIncome extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconIncome);
+class ThemedIconIncome extends IconIncome {}
+(ThemedIconIncome as any) = withTheme(IconIncome);
+export default ThemedIconIncome;

--- a/src/icon/banking/insurance/insurance.tsx
+++ b/src/icon/banking/insurance/insurance.tsx
@@ -18,4 +18,6 @@ class IconInsurance extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconInsurance);
+class ThemedIconInsurance extends IconInsurance {}
+(ThemedIconInsurance as any) = withTheme(IconInsurance);
+export default ThemedIconInsurance;

--- a/src/icon/banking/investments/investments.tsx
+++ b/src/icon/banking/investments/investments.tsx
@@ -18,4 +18,6 @@ class IconInvestments extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconInvestments);
+class ThemedIconInvestments extends IconInvestments {}
+(ThemedIconInvestments as any) = withTheme(IconInvestments);
+export default ThemedIconInvestments;

--- a/src/icon/banking/invoice-for-payment/invoice-for-payment.tsx
+++ b/src/icon/banking/invoice-for-payment/invoice-for-payment.tsx
@@ -18,4 +18,6 @@ class IconInvoiceForPayment extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconInvoiceForPayment);
+class ThemedIconInvoiceForPayment extends IconInvoiceForPayment {}
+(ThemedIconInvoiceForPayment as any) = withTheme(IconInvoiceForPayment);
+export default ThemedIconInvoiceForPayment;

--- a/src/icon/banking/limits/limits.tsx
+++ b/src/icon/banking/limits/limits.tsx
@@ -18,4 +18,6 @@ class IconLimits extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconLimits);
+class ThemedIconLimits extends IconLimits {}
+(ThemedIconLimits as any) = withTheme(IconLimits);
+export default ThemedIconLimits;

--- a/src/icon/banking/marketplace/marketplace.tsx
+++ b/src/icon/banking/marketplace/marketplace.tsx
@@ -18,4 +18,6 @@ class IconMarketplace extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMarketplace);
+class ThemedIconMarketplace extends IconMarketplace {}
+(ThemedIconMarketplace as any) = withTheme(IconMarketplace);
+export default ThemedIconMarketplace;

--- a/src/icon/banking/offer-fill/offer-fill.tsx
+++ b/src/icon/banking/offer-fill/offer-fill.tsx
@@ -18,4 +18,6 @@ class IconOfferFill extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconOfferFill);
+class ThemedIconOfferFill extends IconOfferFill {}
+(ThemedIconOfferFill as any) = withTheme(IconOfferFill);
+export default ThemedIconOfferFill;

--- a/src/icon/banking/offer/offer.tsx
+++ b/src/icon/banking/offer/offer.tsx
@@ -18,4 +18,6 @@ class IconOffer extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconOffer);
+class ThemedIconOffer extends IconOffer {}
+(ThemedIconOffer as any) = withTheme(IconOffer);
+export default ThemedIconOffer;

--- a/src/icon/banking/outcome/outcome.tsx
+++ b/src/icon/banking/outcome/outcome.tsx
@@ -18,4 +18,6 @@ class IconOutcome extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconOutcome);
+class ThemedIconOutcome extends IconOutcome {}
+(ThemedIconOutcome as any) = withTheme(IconOutcome);
+export default ThemedIconOutcome;

--- a/src/icon/banking/overdraft/overdraft.tsx
+++ b/src/icon/banking/overdraft/overdraft.tsx
@@ -18,4 +18,6 @@ class IconOverdraft extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconOverdraft);
+class ThemedIconOverdraft extends IconOverdraft {}
+(ThemedIconOverdraft as any) = withTheme(IconOverdraft);
+export default ThemedIconOverdraft;

--- a/src/icon/banking/pay-back/pay-back.tsx
+++ b/src/icon/banking/pay-back/pay-back.tsx
@@ -18,4 +18,6 @@ class IconPayBack extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPayBack);
+class ThemedIconPayBack extends IconPayBack {}
+(ThemedIconPayBack as any) = withTheme(IconPayBack);
+export default ThemedIconPayBack;

--- a/src/icon/banking/payment-by-photo/payment-by-photo.tsx
+++ b/src/icon/banking/payment-by-photo/payment-by-photo.tsx
@@ -18,4 +18,6 @@ class IconPaymentByPhoto extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentByPhoto);
+class ThemedIconPaymentByPhoto extends IconPaymentByPhoto {}
+(ThemedIconPaymentByPhoto as any) = withTheme(IconPaymentByPhoto);
+export default ThemedIconPaymentByPhoto;

--- a/src/icon/banking/payment-error/payment-error.tsx
+++ b/src/icon/banking/payment-error/payment-error.tsx
@@ -18,4 +18,6 @@ class IconPaymentError extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentError);
+class ThemedIconPaymentError extends IconPaymentError {}
+(ThemedIconPaymentError as any) = withTheme(IconPaymentError);
+export default ThemedIconPaymentError;

--- a/src/icon/banking/payment-outbox/payment-outbox.tsx
+++ b/src/icon/banking/payment-outbox/payment-outbox.tsx
@@ -18,4 +18,6 @@ class IconPaymentOutbox extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentOutbox);
+class ThemedIconPaymentOutbox extends IconPaymentOutbox {}
+(ThemedIconPaymentOutbox as any) = withTheme(IconPaymentOutbox);
+export default ThemedIconPaymentOutbox;

--- a/src/icon/banking/payment-plus/payment-plus.tsx
+++ b/src/icon/banking/payment-plus/payment-plus.tsx
@@ -18,4 +18,6 @@ class IconPaymentPlus extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentPlus);
+class ThemedIconPaymentPlus extends IconPaymentPlus {}
+(ThemedIconPaymentPlus as any) = withTheme(IconPaymentPlus);
+export default ThemedIconPaymentPlus;

--- a/src/icon/banking/payment-rounded-plus-big/payment-rounded-plus-big.tsx
+++ b/src/icon/banking/payment-rounded-plus-big/payment-rounded-plus-big.tsx
@@ -18,4 +18,6 @@ class IconPaymentRoundedPlusBig extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentRoundedPlusBig);
+class ThemedIconPaymentRoundedPlusBig extends IconPaymentRoundedPlusBig {}
+(ThemedIconPaymentRoundedPlusBig as any) = withTheme(IconPaymentRoundedPlusBig);
+export default ThemedIconPaymentRoundedPlusBig;

--- a/src/icon/banking/payment-rounded-plus/payment-rounded-plus.tsx
+++ b/src/icon/banking/payment-rounded-plus/payment-rounded-plus.tsx
@@ -18,4 +18,6 @@ class IconPaymentRoundedPlus extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentRoundedPlus);
+class ThemedIconPaymentRoundedPlus extends IconPaymentRoundedPlus {}
+(ThemedIconPaymentRoundedPlus as any) = withTheme(IconPaymentRoundedPlus);
+export default ThemedIconPaymentRoundedPlus;

--- a/src/icon/banking/payment-to-company/payment-to-company.tsx
+++ b/src/icon/banking/payment-to-company/payment-to-company.tsx
@@ -18,4 +18,6 @@ class IconPaymentToCompany extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentToCompany);
+class ThemedIconPaymentToCompany extends IconPaymentToCompany {}
+(ThemedIconPaymentToCompany as any) = withTheme(IconPaymentToCompany);
+export default ThemedIconPaymentToCompany;

--- a/src/icon/banking/payment-to-person/payment-to-person.tsx
+++ b/src/icon/banking/payment-to-person/payment-to-person.tsx
@@ -18,4 +18,6 @@ class IconPaymentToPerson extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentToPerson);
+class ThemedIconPaymentToPerson extends IconPaymentToPerson {}
+(ThemedIconPaymentToPerson as any) = withTheme(IconPaymentToPerson);
+export default ThemedIconPaymentToPerson;

--- a/src/icon/banking/payment-to-self/payment-to-self.tsx
+++ b/src/icon/banking/payment-to-self/payment-to-self.tsx
@@ -18,4 +18,6 @@ class IconPaymentToSelf extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentToSelf);
+class ThemedIconPaymentToSelf extends IconPaymentToSelf {}
+(ThemedIconPaymentToSelf as any) = withTheme(IconPaymentToSelf);
+export default ThemedIconPaymentToSelf;

--- a/src/icon/banking/payment-to-state/payment-to-state.tsx
+++ b/src/icon/banking/payment-to-state/payment-to-state.tsx
@@ -18,4 +18,6 @@ class IconPaymentToState extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPaymentToState);
+class ThemedIconPaymentToState extends IconPaymentToState {}
+(ThemedIconPaymentToState as any) = withTheme(IconPaymentToState);
+export default ThemedIconPaymentToState;

--- a/src/icon/banking/percent/percent.tsx
+++ b/src/icon/banking/percent/percent.tsx
@@ -18,4 +18,6 @@ class IconPercent extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPercent);
+class ThemedIconPercent extends IconPercent {}
+(ThemedIconPercent as any) = withTheme(IconPercent);
+export default ThemedIconPercent;

--- a/src/icon/banking/plan-expenses/plan-expenses.tsx
+++ b/src/icon/banking/plan-expenses/plan-expenses.tsx
@@ -18,4 +18,6 @@ class IconPlanExpenses extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPlanExpenses);
+class ThemedIconPlanExpenses extends IconPlanExpenses {}
+(ThemedIconPlanExpenses as any) = withTheme(IconPlanExpenses);
+export default ThemedIconPlanExpenses;

--- a/src/icon/banking/ready-to-send/ready-to-send.tsx
+++ b/src/icon/banking/ready-to-send/ready-to-send.tsx
@@ -18,4 +18,6 @@ class IconReadyToSend extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconReadyToSend);
+class ThemedIconReadyToSend extends IconReadyToSend {}
+(ThemedIconReadyToSend as any) = withTheme(IconReadyToSend);
+export default ThemedIconReadyToSend;

--- a/src/icon/banking/request-money/request-money.tsx
+++ b/src/icon/banking/request-money/request-money.tsx
@@ -18,4 +18,6 @@ class IconRequestMoney extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconRequestMoney);
+class ThemedIconRequestMoney extends IconRequestMoney {}
+(ThemedIconRequestMoney as any) = withTheme(IconRequestMoney);
+export default ThemedIconRequestMoney;

--- a/src/icon/banking/sent/sent.tsx
+++ b/src/icon/banking/sent/sent.tsx
@@ -18,4 +18,6 @@ class IconSent extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSent);
+class ThemedIconSent extends IconSent {}
+(ThemedIconSent as any) = withTheme(IconSent);
+export default ThemedIconSent;

--- a/src/icon/banking/subscrption/subscrption.tsx
+++ b/src/icon/banking/subscrption/subscrption.tsx
@@ -18,4 +18,6 @@ class IconSubscrption extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSubscrption);
+class ThemedIconSubscrption extends IconSubscrption {}
+(ThemedIconSubscrption as any) = withTheme(IconSubscrption);
+export default ThemedIconSubscrption;

--- a/src/icon/banking/transfer-any-bank-credit/transfer-any-bank-credit.tsx
+++ b/src/icon/banking/transfer-any-bank-credit/transfer-any-bank-credit.tsx
@@ -18,4 +18,6 @@ class IconTransferAnyBankCredit extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferAnyBankCredit);
+class ThemedIconTransferAnyBankCredit extends IconTransferAnyBankCredit {}
+(ThemedIconTransferAnyBankCredit as any) = withTheme(IconTransferAnyBankCredit);
+export default ThemedIconTransferAnyBankCredit;

--- a/src/icon/banking/transfer-any-bank/transfer-any-bank.tsx
+++ b/src/icon/banking/transfer-any-bank/transfer-any-bank.tsx
@@ -18,4 +18,6 @@ class IconTransferAnyBank extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferAnyBank);
+class ThemedIconTransferAnyBank extends IconTransferAnyBank {}
+(ThemedIconTransferAnyBank as any) = withTheme(IconTransferAnyBank);
+export default ThemedIconTransferAnyBank;

--- a/src/icon/banking/transfer-between-accounts/transfer-between-accounts.tsx
+++ b/src/icon/banking/transfer-between-accounts/transfer-between-accounts.tsx
@@ -18,4 +18,6 @@ class IconTransferBetweenAccounts extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferBetweenAccounts);
+class ThemedIconTransferBetweenAccounts extends IconTransferBetweenAccounts {}
+(ThemedIconTransferBetweenAccounts as any) = withTheme(IconTransferBetweenAccounts);
+export default ThemedIconTransferBetweenAccounts;

--- a/src/icon/banking/transfer-by-phone-android/transfer-by-phone-android.tsx
+++ b/src/icon/banking/transfer-by-phone-android/transfer-by-phone-android.tsx
@@ -18,4 +18,6 @@ class IconTransferByPhoneAndroid extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferByPhoneAndroid);
+class ThemedIconTransferByPhoneAndroid extends IconTransferByPhoneAndroid {}
+(ThemedIconTransferByPhoneAndroid as any) = withTheme(IconTransferByPhoneAndroid);
+export default ThemedIconTransferByPhoneAndroid;

--- a/src/icon/banking/transfer-by-phone-ios/transfer-by-phone-ios.tsx
+++ b/src/icon/banking/transfer-by-phone-ios/transfer-by-phone-ios.tsx
@@ -18,4 +18,6 @@ class IconTransferByPhoneIos extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferByPhoneIos);
+class ThemedIconTransferByPhoneIos extends IconTransferByPhoneIos {}
+(ThemedIconTransferByPhoneIos as any) = withTheme(IconTransferByPhoneIos);
+export default ThemedIconTransferByPhoneIos;

--- a/src/icon/banking/transfer-by-phone/transfer-by-phone.tsx
+++ b/src/icon/banking/transfer-by-phone/transfer-by-phone.tsx
@@ -18,4 +18,6 @@ class IconTransferByPhone extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferByPhone);
+class ThemedIconTransferByPhone extends IconTransferByPhone {}
+(ThemedIconTransferByPhone as any) = withTheme(IconTransferByPhone);
+export default ThemedIconTransferByPhone;

--- a/src/icon/banking/transfer-card/transfer-card.tsx
+++ b/src/icon/banking/transfer-card/transfer-card.tsx
@@ -18,4 +18,6 @@ class IconTransferCard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferCard);
+class ThemedIconTransferCard extends IconTransferCard {}
+(ThemedIconTransferCard as any) = withTheme(IconTransferCard);
+export default ThemedIconTransferCard;

--- a/src/icon/banking/transfer-external/transfer-external.tsx
+++ b/src/icon/banking/transfer-external/transfer-external.tsx
@@ -18,4 +18,6 @@ class IconTransferExternal extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferExternal);
+class ThemedIconTransferExternal extends IconTransferExternal {}
+(ThemedIconTransferExternal as any) = withTheme(IconTransferExternal);
+export default ThemedIconTransferExternal;

--- a/src/icon/banking/transfer-in/transfer-in.tsx
+++ b/src/icon/banking/transfer-in/transfer-in.tsx
@@ -18,4 +18,6 @@ class IconTransferIn extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferIn);
+class ThemedIconTransferIn extends IconTransferIn {}
+(ThemedIconTransferIn as any) = withTheme(IconTransferIn);
+export default ThemedIconTransferIn;

--- a/src/icon/banking/transfer-internal/transfer-internal.tsx
+++ b/src/icon/banking/transfer-internal/transfer-internal.tsx
@@ -18,4 +18,6 @@ class IconTransferInternal extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferInternal);
+class ThemedIconTransferInternal extends IconTransferInternal {}
+(ThemedIconTransferInternal as any) = withTheme(IconTransferInternal);
+export default ThemedIconTransferInternal;

--- a/src/icon/banking/transfer-out/transfer-out.tsx
+++ b/src/icon/banking/transfer-out/transfer-out.tsx
@@ -18,4 +18,6 @@ class IconTransferOut extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferOut);
+class ThemedIconTransferOut extends IconTransferOut {}
+(ThemedIconTransferOut as any) = withTheme(IconTransferOut);
+export default ThemedIconTransferOut;

--- a/src/icon/banking/transfer-outer/transfer-outer.tsx
+++ b/src/icon/banking/transfer-outer/transfer-outer.tsx
@@ -18,4 +18,6 @@ class IconTransferOuter extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferOuter);
+class ThemedIconTransferOuter extends IconTransferOuter {}
+(ThemedIconTransferOuter as any) = withTheme(IconTransferOuter);
+export default ThemedIconTransferOuter;

--- a/src/icon/banking/transfer-self/transfer-self.tsx
+++ b/src/icon/banking/transfer-self/transfer-self.tsx
@@ -18,4 +18,6 @@ class IconTransferSelf extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferSelf);
+class ThemedIconTransferSelf extends IconTransferSelf {}
+(ThemedIconTransferSelf as any) = withTheme(IconTransferSelf);
+export default ThemedIconTransferSelf;

--- a/src/icon/banking/transfer-to-card/transfer-to-card.tsx
+++ b/src/icon/banking/transfer-to-card/transfer-to-card.tsx
@@ -18,4 +18,6 @@ class IconTransferToCard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTransferToCard);
+class ThemedIconTransferToCard extends IconTransferToCard {}
+(ThemedIconTransferToCard as any) = withTheme(IconTransferToCard);
+export default ThemedIconTransferToCard;

--- a/src/icon/banking/user-add/user-add.tsx
+++ b/src/icon/banking/user-add/user-add.tsx
@@ -18,4 +18,6 @@ class IconUserAdd extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconUserAdd);
+class ThemedIconUserAdd extends IconUserAdd {}
+(ThemedIconUserAdd as any) = withTheme(IconUserAdd);
+export default ThemedIconUserAdd;

--- a/src/icon/banking/wallet/wallet.tsx
+++ b/src/icon/banking/wallet/wallet.tsx
@@ -18,4 +18,6 @@ class IconWallet extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconWallet);
+class ThemedIconWallet extends IconWallet {}
+(ThemedIconWallet as any) = withTheme(IconWallet);
+export default ThemedIconWallet;

--- a/src/icon/brand/bank-10223/bank-10223.tsx
+++ b/src/icon/brand/bank-10223/bank-10223.tsx
@@ -18,4 +18,6 @@ class IconBank10223 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank10223);
+class ThemedIconBank10223 extends IconBank10223 {}
+(ThemedIconBank10223 as any) = withTheme(IconBank10223);
+export default ThemedIconBank10223;

--- a/src/icon/brand/bank-1309/bank-1309.tsx
+++ b/src/icon/brand/bank-1309/bank-1309.tsx
@@ -18,4 +18,6 @@ class IconBank1309 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank1309);
+class ThemedIconBank1309 extends IconBank1309 {}
+(ThemedIconBank1309 as any) = withTheme(IconBank1309);
+export default ThemedIconBank1309;

--- a/src/icon/brand/bank-1415/bank-1415.tsx
+++ b/src/icon/brand/bank-1415/bank-1415.tsx
@@ -18,4 +18,6 @@ class IconBank1415 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank1415);
+class ThemedIconBank1415 extends IconBank1415 {}
+(ThemedIconBank1415 as any) = withTheme(IconBank1415);
+export default ThemedIconBank1415;

--- a/src/icon/brand/bank-1490/bank-1490.tsx
+++ b/src/icon/brand/bank-1490/bank-1490.tsx
@@ -18,4 +18,6 @@ class IconBank1490 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank1490);
+class ThemedIconBank1490 extends IconBank1490 {}
+(ThemedIconBank1490 as any) = withTheme(IconBank1490);
+export default ThemedIconBank1490;

--- a/src/icon/brand/bank-1516/bank-1516.tsx
+++ b/src/icon/brand/bank-1516/bank-1516.tsx
@@ -18,4 +18,6 @@ class IconBank1516 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank1516);
+class ThemedIconBank1516 extends IconBank1516 {}
+(ThemedIconBank1516 as any) = withTheme(IconBank1516);
+export default ThemedIconBank1516;

--- a/src/icon/brand/bank-2377/bank-2377.tsx
+++ b/src/icon/brand/bank-2377/bank-2377.tsx
@@ -18,4 +18,6 @@ class IconBank2377 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank2377);
+class ThemedIconBank2377 extends IconBank2377 {}
+(ThemedIconBank2377 as any) = withTheme(IconBank2377);
+export default ThemedIconBank2377;

--- a/src/icon/brand/bank-244/bank-244.tsx
+++ b/src/icon/brand/bank-244/bank-244.tsx
@@ -18,4 +18,6 @@ class IconBank244 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank244);
+class ThemedIconBank244 extends IconBank244 {}
+(ThemedIconBank244 as any) = withTheme(IconBank244);
+export default ThemedIconBank244;

--- a/src/icon/brand/bank-2449/bank-2449.tsx
+++ b/src/icon/brand/bank-2449/bank-2449.tsx
@@ -18,4 +18,6 @@ class IconBank2449 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank2449);
+class ThemedIconBank2449 extends IconBank2449 {}
+(ThemedIconBank2449 as any) = withTheme(IconBank2449);
+export default ThemedIconBank2449;

--- a/src/icon/brand/bank-256/bank-256.tsx
+++ b/src/icon/brand/bank-256/bank-256.tsx
@@ -18,4 +18,6 @@ class IconBank256 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank256);
+class ThemedIconBank256 extends IconBank256 {}
+(ThemedIconBank256 as any) = withTheme(IconBank256);
+export default ThemedIconBank256;

--- a/src/icon/brand/bank-285/bank-285.tsx
+++ b/src/icon/brand/bank-285/bank-285.tsx
@@ -18,4 +18,6 @@ class IconBank285 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank285);
+class ThemedIconBank285 extends IconBank285 {}
+(ThemedIconBank285 as any) = withTheme(IconBank285);
+export default ThemedIconBank285;

--- a/src/icon/brand/bank-3001/bank-3001.tsx
+++ b/src/icon/brand/bank-3001/bank-3001.tsx
@@ -18,4 +18,6 @@ class IconBank3001 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank3001);
+class ThemedIconBank3001 extends IconBank3001 {}
+(ThemedIconBank3001 as any) = withTheme(IconBank3001);
+export default ThemedIconBank3001;

--- a/src/icon/brand/bank-3308/bank-3308.tsx
+++ b/src/icon/brand/bank-3308/bank-3308.tsx
@@ -18,4 +18,6 @@ class IconBank3308 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank3308);
+class ThemedIconBank3308 extends IconBank3308 {}
+(ThemedIconBank3308 as any) = withTheme(IconBank3308);
+export default ThemedIconBank3308;

--- a/src/icon/brand/bank-351/bank-351.tsx
+++ b/src/icon/brand/bank-351/bank-351.tsx
@@ -18,4 +18,6 @@ class IconBank351 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank351);
+class ThemedIconBank351 extends IconBank351 {}
+(ThemedIconBank351 as any) = withTheme(IconBank351);
+export default ThemedIconBank351;

--- a/src/icon/brand/bank-404/bank-404.tsx
+++ b/src/icon/brand/bank-404/bank-404.tsx
@@ -18,4 +18,6 @@ class IconBank404 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank404);
+class ThemedIconBank404 extends IconBank404 {}
+(ThemedIconBank404 as any) = withTheme(IconBank404);
+export default ThemedIconBank404;

--- a/src/icon/brand/bank-4267/bank-4267.tsx
+++ b/src/icon/brand/bank-4267/bank-4267.tsx
@@ -18,4 +18,6 @@ class IconBank4267 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank4267);
+class ThemedIconBank4267 extends IconBank4267 {}
+(ThemedIconBank4267 as any) = withTheme(IconBank4267);
+export default ThemedIconBank4267;

--- a/src/icon/brand/bank-439/bank-439.tsx
+++ b/src/icon/brand/bank-439/bank-439.tsx
@@ -18,4 +18,6 @@ class IconBank439 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank439);
+class ThemedIconBank439 extends IconBank439 {}
+(ThemedIconBank439 as any) = withTheme(IconBank439);
+export default ThemedIconBank439;

--- a/src/icon/brand/bank-4924/bank-4924.tsx
+++ b/src/icon/brand/bank-4924/bank-4924.tsx
@@ -18,4 +18,6 @@ class IconBank4924 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank4924);
+class ThemedIconBank4924 extends IconBank4924 {}
+(ThemedIconBank4924 as any) = withTheme(IconBank4924);
+export default ThemedIconBank4924;

--- a/src/icon/brand/bank-5030/bank-5030.tsx
+++ b/src/icon/brand/bank-5030/bank-5030.tsx
@@ -18,4 +18,6 @@ class IconBank5030 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank5030);
+class ThemedIconBank5030 extends IconBank5030 {}
+(ThemedIconBank5030 as any) = withTheme(IconBank5030);
+export default ThemedIconBank5030;

--- a/src/icon/brand/bank-5475/bank-5475.tsx
+++ b/src/icon/brand/bank-5475/bank-5475.tsx
@@ -18,4 +18,6 @@ class IconBank5475 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank5475);
+class ThemedIconBank5475 extends IconBank5475 {}
+(ThemedIconBank5475 as any) = withTheme(IconBank5475);
+export default ThemedIconBank5475;

--- a/src/icon/brand/bank-6415/bank-6415.tsx
+++ b/src/icon/brand/bank-6415/bank-6415.tsx
@@ -18,4 +18,6 @@ class IconBank6415 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank6415);
+class ThemedIconBank6415 extends IconBank6415 {}
+(ThemedIconBank6415 as any) = withTheme(IconBank6415);
+export default ThemedIconBank6415;

--- a/src/icon/brand/bank-7311/bank-7311.tsx
+++ b/src/icon/brand/bank-7311/bank-7311.tsx
@@ -18,4 +18,6 @@ class IconBank7311 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank7311);
+class ThemedIconBank7311 extends IconBank7311 {}
+(ThemedIconBank7311 as any) = withTheme(IconBank7311);
+export default ThemedIconBank7311;

--- a/src/icon/brand/bank-7686/bank-7686.tsx
+++ b/src/icon/brand/bank-7686/bank-7686.tsx
@@ -18,4 +18,6 @@ class IconBank7686 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank7686);
+class ThemedIconBank7686 extends IconBank7686 {}
+(ThemedIconBank7686 as any) = withTheme(IconBank7686);
+export default ThemedIconBank7686;

--- a/src/icon/brand/bank-7687/bank-7687.tsx
+++ b/src/icon/brand/bank-7687/bank-7687.tsx
@@ -18,4 +18,6 @@ class IconBank7687 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank7687);
+class ThemedIconBank7687 extends IconBank7687 {}
+(ThemedIconBank7687 as any) = withTheme(IconBank7687);
+export default ThemedIconBank7687;

--- a/src/icon/brand/bank-8967/bank-8967.tsx
+++ b/src/icon/brand/bank-8967/bank-8967.tsx
@@ -18,4 +18,6 @@ class IconBank8967 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank8967);
+class ThemedIconBank8967 extends IconBank8967 {}
+(ThemedIconBank8967 as any) = withTheme(IconBank8967);
+export default ThemedIconBank8967;

--- a/src/icon/brand/bank-9908/bank-9908.tsx
+++ b/src/icon/brand/bank-9908/bank-9908.tsx
@@ -18,4 +18,6 @@ class IconBank9908 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBank9908);
+class ThemedIconBank9908 extends IconBank9908 {}
+(ThemedIconBank9908 as any) = withTheme(IconBank9908);
+export default ThemedIconBank9908;

--- a/src/icon/brand/bank-alfa/bank-alfa.tsx
+++ b/src/icon/brand/bank-alfa/bank-alfa.tsx
@@ -18,4 +18,6 @@ class IconBankAlfa extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankAlfa);
+class ThemedIconBankAlfa extends IconBankAlfa {}
+(ThemedIconBankAlfa as any) = withTheme(IconBankAlfa);
+export default ThemedIconBankAlfa;

--- a/src/icon/brand/bank-baltiyskiy/bank-baltiyskiy.tsx
+++ b/src/icon/brand/bank-baltiyskiy/bank-baltiyskiy.tsx
@@ -18,4 +18,6 @@ class IconBankBaltiyskiy extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankBaltiyskiy);
+class ThemedIconBankBaltiyskiy extends IconBankBaltiyskiy {}
+(ThemedIconBankBaltiyskiy as any) = withTheme(IconBankBaltiyskiy);
+export default ThemedIconBankBaltiyskiy;

--- a/src/icon/brand/bank-binbank/bank-binbank.tsx
+++ b/src/icon/brand/bank-binbank/bank-binbank.tsx
@@ -18,4 +18,6 @@ class IconBankBinbank extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankBinbank);
+class ThemedIconBankBinbank extends IconBankBinbank {}
+(ThemedIconBankBinbank as any) = withTheme(IconBankBinbank);
+export default ThemedIconBankBinbank;

--- a/src/icon/brand/bank-europe/bank-europe.tsx
+++ b/src/icon/brand/bank-europe/bank-europe.tsx
@@ -18,4 +18,6 @@ class IconBankEurope extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankEurope);
+class ThemedIconBankEurope extends IconBankEurope {}
+(ThemedIconBankEurope as any) = withTheme(IconBankEurope);
+export default ThemedIconBankEurope;

--- a/src/icon/brand/bank-gazprombank/bank-gazprombank.tsx
+++ b/src/icon/brand/bank-gazprombank/bank-gazprombank.tsx
@@ -18,4 +18,6 @@ class IconBankGazprombank extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankGazprombank);
+class ThemedIconBankGazprombank extends IconBankGazprombank {}
+(ThemedIconBankGazprombank as any) = withTheme(IconBankGazprombank);
+export default ThemedIconBankGazprombank;

--- a/src/icon/brand/bank-home-credit/bank-home-credit.tsx
+++ b/src/icon/brand/bank-home-credit/bank-home-credit.tsx
@@ -18,4 +18,6 @@ class IconBankHomeCredit extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankHomeCredit);
+class ThemedIconBankHomeCredit extends IconBankHomeCredit {}
+(ThemedIconBankHomeCredit as any) = withTheme(IconBankHomeCredit);
+export default ThemedIconBankHomeCredit;

--- a/src/icon/brand/bank-mdm/bank-mdm.tsx
+++ b/src/icon/brand/bank-mdm/bank-mdm.tsx
@@ -18,4 +18,6 @@ class IconBankMdm extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankMdm);
+class ThemedIconBankMdm extends IconBankMdm {}
+(ThemedIconBankMdm as any) = withTheme(IconBankMdm);
+export default ThemedIconBankMdm;

--- a/src/icon/brand/bank-mkb/bank-mkb.tsx
+++ b/src/icon/brand/bank-mkb/bank-mkb.tsx
@@ -18,4 +18,6 @@ class IconBankMkb extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankMkb);
+class ThemedIconBankMkb extends IconBankMkb {}
+(ThemedIconBankMkb as any) = withTheme(IconBankMkb);
+export default ThemedIconBankMkb;

--- a/src/icon/brand/bank-moscow/bank-moscow.tsx
+++ b/src/icon/brand/bank-moscow/bank-moscow.tsx
@@ -18,4 +18,6 @@ class IconBankMoscow extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankMoscow);
+class ThemedIconBankMoscow extends IconBankMoscow {}
+(ThemedIconBankMoscow as any) = withTheme(IconBankMoscow);
+export default ThemedIconBankMoscow;

--- a/src/icon/brand/bank-mts/bank-mts.tsx
+++ b/src/icon/brand/bank-mts/bank-mts.tsx
@@ -18,4 +18,6 @@ class IconBankMts extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankMts);
+class ThemedIconBankMts extends IconBankMts {}
+(ThemedIconBankMts as any) = withTheme(IconBankMts);
+export default ThemedIconBankMts;

--- a/src/icon/brand/bank-nsipf-1/bank-nsipf-1.tsx
+++ b/src/icon/brand/bank-nsipf-1/bank-nsipf-1.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf1 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf1);
+class ThemedIconBankNsipf1 extends IconBankNsipf1 {}
+(ThemedIconBankNsipf1 as any) = withTheme(IconBankNsipf1);
+export default ThemedIconBankNsipf1;

--- a/src/icon/brand/bank-nsipf-1000/bank-nsipf-1000.tsx
+++ b/src/icon/brand/bank-nsipf-1000/bank-nsipf-1000.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf1000 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf1000);
+class ThemedIconBankNsipf1000 extends IconBankNsipf1000 {}
+(ThemedIconBankNsipf1000 as any) = withTheme(IconBankNsipf1000);
+export default ThemedIconBankNsipf1000;

--- a/src/icon/brand/bank-nsipf-128/bank-nsipf-128.tsx
+++ b/src/icon/brand/bank-nsipf-128/bank-nsipf-128.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf128 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf128);
+class ThemedIconBankNsipf128 extends IconBankNsipf128 {}
+(ThemedIconBankNsipf128 as any) = withTheme(IconBankNsipf128);
+export default ThemedIconBankNsipf128;

--- a/src/icon/brand/bank-nsipf-1326/bank-nsipf-1326.tsx
+++ b/src/icon/brand/bank-nsipf-1326/bank-nsipf-1326.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf1326 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf1326);
+class ThemedIconBankNsipf1326 extends IconBankNsipf1326 {}
+(ThemedIconBankNsipf1326 as any) = withTheme(IconBankNsipf1326);
+export default ThemedIconBankNsipf1326;

--- a/src/icon/brand/bank-nsipf-1439/bank-nsipf-1439.tsx
+++ b/src/icon/brand/bank-nsipf-1439/bank-nsipf-1439.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf1439 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf1439);
+class ThemedIconBankNsipf1439 extends IconBankNsipf1439 {}
+(ThemedIconBankNsipf1439 as any) = withTheme(IconBankNsipf1439);
+export default ThemedIconBankNsipf1439;

--- a/src/icon/brand/bank-nsipf-1481/bank-nsipf-1481.tsx
+++ b/src/icon/brand/bank-nsipf-1481/bank-nsipf-1481.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf1481 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf1481);
+class ThemedIconBankNsipf1481 extends IconBankNsipf1481 {}
+(ThemedIconBankNsipf1481 as any) = withTheme(IconBankNsipf1481);
+export default ThemedIconBankNsipf1481;

--- a/src/icon/brand/bank-nsipf-1792/bank-nsipf-1792.tsx
+++ b/src/icon/brand/bank-nsipf-1792/bank-nsipf-1792.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf1792 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf1792);
+class ThemedIconBankNsipf1792 extends IconBankNsipf1792 {}
+(ThemedIconBankNsipf1792 as any) = withTheme(IconBankNsipf1792);
+export default ThemedIconBankNsipf1792;

--- a/src/icon/brand/bank-nsipf-2209/bank-nsipf-2209.tsx
+++ b/src/icon/brand/bank-nsipf-2209/bank-nsipf-2209.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2209 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2209);
+class ThemedIconBankNsipf2209 extends IconBankNsipf2209 {}
+(ThemedIconBankNsipf2209 as any) = withTheme(IconBankNsipf2209);
+export default ThemedIconBankNsipf2209;

--- a/src/icon/brand/bank-nsipf-2241/bank-nsipf-2241.tsx
+++ b/src/icon/brand/bank-nsipf-2241/bank-nsipf-2241.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2241 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2241);
+class ThemedIconBankNsipf2241 extends IconBankNsipf2241 {}
+(ThemedIconBankNsipf2241 as any) = withTheme(IconBankNsipf2241);
+export default ThemedIconBankNsipf2241;

--- a/src/icon/brand/bank-nsipf-2268/bank-nsipf-2268.tsx
+++ b/src/icon/brand/bank-nsipf-2268/bank-nsipf-2268.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2268 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2268);
+class ThemedIconBankNsipf2268 extends IconBankNsipf2268 {}
+(ThemedIconBankNsipf2268 as any) = withTheme(IconBankNsipf2268);
+export default ThemedIconBankNsipf2268;

--- a/src/icon/brand/bank-nsipf-2275/bank-nsipf-2275.tsx
+++ b/src/icon/brand/bank-nsipf-2275/bank-nsipf-2275.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2275 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2275);
+class ThemedIconBankNsipf2275 extends IconBankNsipf2275 {}
+(ThemedIconBankNsipf2275 as any) = withTheme(IconBankNsipf2275);
+export default ThemedIconBankNsipf2275;

--- a/src/icon/brand/bank-nsipf-2289/bank-nsipf-2289.tsx
+++ b/src/icon/brand/bank-nsipf-2289/bank-nsipf-2289.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2289 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2289);
+class ThemedIconBankNsipf2289 extends IconBankNsipf2289 {}
+(ThemedIconBankNsipf2289 as any) = withTheme(IconBankNsipf2289);
+export default ThemedIconBankNsipf2289;

--- a/src/icon/brand/bank-nsipf-2361/bank-nsipf-2361.tsx
+++ b/src/icon/brand/bank-nsipf-2361/bank-nsipf-2361.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2361 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2361);
+class ThemedIconBankNsipf2361 extends IconBankNsipf2361 {}
+(ThemedIconBankNsipf2361 as any) = withTheme(IconBankNsipf2361);
+export default ThemedIconBankNsipf2361;

--- a/src/icon/brand/bank-nsipf-2524/bank-nsipf-2524.tsx
+++ b/src/icon/brand/bank-nsipf-2524/bank-nsipf-2524.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2524 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2524);
+class ThemedIconBankNsipf2524 extends IconBankNsipf2524 {}
+(ThemedIconBankNsipf2524 as any) = withTheme(IconBankNsipf2524);
+export default ThemedIconBankNsipf2524;

--- a/src/icon/brand/bank-nsipf-2673/bank-nsipf-2673.tsx
+++ b/src/icon/brand/bank-nsipf-2673/bank-nsipf-2673.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2673 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2673);
+class ThemedIconBankNsipf2673 extends IconBankNsipf2673 {}
+(ThemedIconBankNsipf2673 as any) = withTheme(IconBankNsipf2673);
+export default ThemedIconBankNsipf2673;

--- a/src/icon/brand/bank-nsipf-2748/bank-nsipf-2748.tsx
+++ b/src/icon/brand/bank-nsipf-2748/bank-nsipf-2748.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2748 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2748);
+class ThemedIconBankNsipf2748 extends IconBankNsipf2748 {}
+(ThemedIconBankNsipf2748 as any) = withTheme(IconBankNsipf2748);
+export default ThemedIconBankNsipf2748;

--- a/src/icon/brand/bank-nsipf-2766/bank-nsipf-2766.tsx
+++ b/src/icon/brand/bank-nsipf-2766/bank-nsipf-2766.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf2766 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf2766);
+class ThemedIconBankNsipf2766 extends IconBankNsipf2766 {}
+(ThemedIconBankNsipf2766 as any) = withTheme(IconBankNsipf2766);
+export default ThemedIconBankNsipf2766;

--- a/src/icon/brand/bank-nsipf-316/bank-nsipf-316.tsx
+++ b/src/icon/brand/bank-nsipf-316/bank-nsipf-316.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf316 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf316);
+class ThemedIconBankNsipf316 extends IconBankNsipf316 {}
+(ThemedIconBankNsipf316 as any) = withTheme(IconBankNsipf316);
+export default ThemedIconBankNsipf316;

--- a/src/icon/brand/bank-nsipf-323/bank-nsipf-323.tsx
+++ b/src/icon/brand/bank-nsipf-323/bank-nsipf-323.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf323 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf323);
+class ThemedIconBankNsipf323 extends IconBankNsipf323 {}
+(ThemedIconBankNsipf323 as any) = withTheme(IconBankNsipf323);
+export default ThemedIconBankNsipf323;

--- a/src/icon/brand/bank-nsipf-3251/bank-nsipf-3251.tsx
+++ b/src/icon/brand/bank-nsipf-3251/bank-nsipf-3251.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf3251 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf3251);
+class ThemedIconBankNsipf3251 extends IconBankNsipf3251 {}
+(ThemedIconBankNsipf3251 as any) = withTheme(IconBankNsipf3251);
+export default ThemedIconBankNsipf3251;

--- a/src/icon/brand/bank-nsipf-3279/bank-nsipf-3279.tsx
+++ b/src/icon/brand/bank-nsipf-3279/bank-nsipf-3279.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf3279 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf3279);
+class ThemedIconBankNsipf3279 extends IconBankNsipf3279 {}
+(ThemedIconBankNsipf3279 as any) = withTheme(IconBankNsipf3279);
+export default ThemedIconBankNsipf3279;

--- a/src/icon/brand/bank-nsipf-3292/bank-nsipf-3292.tsx
+++ b/src/icon/brand/bank-nsipf-3292/bank-nsipf-3292.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf3292 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf3292);
+class ThemedIconBankNsipf3292 extends IconBankNsipf3292 {}
+(ThemedIconBankNsipf3292 as any) = withTheme(IconBankNsipf3292);
+export default ThemedIconBankNsipf3292;

--- a/src/icon/brand/bank-nsipf-3311/bank-nsipf-3311.tsx
+++ b/src/icon/brand/bank-nsipf-3311/bank-nsipf-3311.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf3311 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf3311);
+class ThemedIconBankNsipf3311 extends IconBankNsipf3311 {}
+(ThemedIconBankNsipf3311 as any) = withTheme(IconBankNsipf3311);
+export default ThemedIconBankNsipf3311;

--- a/src/icon/brand/bank-nsipf-354/bank-nsipf-354.tsx
+++ b/src/icon/brand/bank-nsipf-354/bank-nsipf-354.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf354 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf354);
+class ThemedIconBankNsipf354 extends IconBankNsipf354 {}
+(ThemedIconBankNsipf354 as any) = withTheme(IconBankNsipf354);
+export default ThemedIconBankNsipf354;

--- a/src/icon/brand/bank-nsipf-429/bank-nsipf-429.tsx
+++ b/src/icon/brand/bank-nsipf-429/bank-nsipf-429.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf429 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf429);
+class ThemedIconBankNsipf429 extends IconBankNsipf429 {}
+(ThemedIconBankNsipf429 as any) = withTheme(IconBankNsipf429);
+export default ThemedIconBankNsipf429;

--- a/src/icon/brand/bank-nsipf-436/bank-nsipf-436.tsx
+++ b/src/icon/brand/bank-nsipf-436/bank-nsipf-436.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf436 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf436);
+class ThemedIconBankNsipf436 extends IconBankNsipf436 {}
+(ThemedIconBankNsipf436 as any) = withTheme(IconBankNsipf436);
+export default ThemedIconBankNsipf436;

--- a/src/icon/brand/bank-nsipf-705/bank-nsipf-705.tsx
+++ b/src/icon/brand/bank-nsipf-705/bank-nsipf-705.tsx
@@ -18,4 +18,6 @@ class IconBankNsipf705 extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankNsipf705);
+class ThemedIconBankNsipf705 extends IconBankNsipf705 {}
+(ThemedIconBankNsipf705 as any) = withTheme(IconBankNsipf705);
+export default ThemedIconBankNsipf705;

--- a/src/icon/brand/bank-otkritie/bank-otkritie.tsx
+++ b/src/icon/brand/bank-otkritie/bank-otkritie.tsx
@@ -18,4 +18,6 @@ class IconBankOtkritie extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankOtkritie);
+class ThemedIconBankOtkritie extends IconBankOtkritie {}
+(ThemedIconBankOtkritie as any) = withTheme(IconBankOtkritie);
+export default ThemedIconBankOtkritie;

--- a/src/icon/brand/bank-otp/bank-otp.tsx
+++ b/src/icon/brand/bank-otp/bank-otp.tsx
@@ -18,4 +18,6 @@ class IconBankOtp extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankOtp);
+class ThemedIconBankOtp extends IconBankOtp {}
+(ThemedIconBankOtp as any) = withTheme(IconBankOtp);
+export default ThemedIconBankOtp;

--- a/src/icon/brand/bank-psb/bank-psb.tsx
+++ b/src/icon/brand/bank-psb/bank-psb.tsx
@@ -18,4 +18,6 @@ class IconBankPsb extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankPsb);
+class ThemedIconBankPsb extends IconBankPsb {}
+(ThemedIconBankPsb as any) = withTheme(IconBankPsb);
+export default ThemedIconBankPsb;

--- a/src/icon/brand/bank-qiwi/bank-qiwi.tsx
+++ b/src/icon/brand/bank-qiwi/bank-qiwi.tsx
@@ -18,4 +18,6 @@ class IconBankQiwi extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankQiwi);
+class ThemedIconBankQiwi extends IconBankQiwi {}
+(ThemedIconBankQiwi as any) = withTheme(IconBankQiwi);
+export default ThemedIconBankQiwi;

--- a/src/icon/brand/bank-raiffeisen/bank-raiffeisen.tsx
+++ b/src/icon/brand/bank-raiffeisen/bank-raiffeisen.tsx
@@ -18,4 +18,6 @@ class IconBankRaiffeisen extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankRaiffeisen);
+class ThemedIconBankRaiffeisen extends IconBankRaiffeisen {}
+(ThemedIconBankRaiffeisen as any) = withTheme(IconBankRaiffeisen);
+export default ThemedIconBankRaiffeisen;

--- a/src/icon/brand/bank-russian-standard/bank-russian-standard.tsx
+++ b/src/icon/brand/bank-russian-standard/bank-russian-standard.tsx
@@ -18,4 +18,6 @@ class IconBankRussianStandard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankRussianStandard);
+class ThemedIconBankRussianStandard extends IconBankRussianStandard {}
+(ThemedIconBankRussianStandard as any) = withTheme(IconBankRussianStandard);
+export default ThemedIconBankRussianStandard;

--- a/src/icon/brand/bank-saint-petersburg/bank-saint-petersburg.tsx
+++ b/src/icon/brand/bank-saint-petersburg/bank-saint-petersburg.tsx
@@ -18,4 +18,6 @@ class IconBankSaintPetersburg extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankSaintPetersburg);
+class ThemedIconBankSaintPetersburg extends IconBankSaintPetersburg {}
+(ThemedIconBankSaintPetersburg as any) = withTheme(IconBankSaintPetersburg);
+export default ThemedIconBankSaintPetersburg;

--- a/src/icon/brand/bank-sber/bank-sber.tsx
+++ b/src/icon/brand/bank-sber/bank-sber.tsx
@@ -18,4 +18,6 @@ class IconBankSber extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankSber);
+class ThemedIconBankSber extends IconBankSber {}
+(ThemedIconBankSber as any) = withTheme(IconBankSber);
+export default ThemedIconBankSber;

--- a/src/icon/brand/bank-skb/bank-skb.tsx
+++ b/src/icon/brand/bank-skb/bank-skb.tsx
@@ -18,4 +18,6 @@ class IconBankSkb extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankSkb);
+class ThemedIconBankSkb extends IconBankSkb {}
+(ThemedIconBankSkb as any) = withTheme(IconBankSkb);
+export default ThemedIconBankSkb;

--- a/src/icon/brand/bank-societe-generale/bank-societe-generale.tsx
+++ b/src/icon/brand/bank-societe-generale/bank-societe-generale.tsx
@@ -18,4 +18,6 @@ class IconBankSocieteGenerale extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankSocieteGenerale);
+class ThemedIconBankSocieteGenerale extends IconBankSocieteGenerale {}
+(ThemedIconBankSocieteGenerale as any) = withTheme(IconBankSocieteGenerale);
+export default ThemedIconBankSocieteGenerale;

--- a/src/icon/brand/bank-tinkoff/bank-tinkoff.tsx
+++ b/src/icon/brand/bank-tinkoff/bank-tinkoff.tsx
@@ -18,4 +18,6 @@ class IconBankTinkoff extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankTinkoff);
+class ThemedIconBankTinkoff extends IconBankTinkoff {}
+(ThemedIconBankTinkoff as any) = withTheme(IconBankTinkoff);
+export default ThemedIconBankTinkoff;

--- a/src/icon/brand/bank-trust/bank-trust.tsx
+++ b/src/icon/brand/bank-trust/bank-trust.tsx
@@ -18,4 +18,6 @@ class IconBankTrust extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankTrust);
+class ThemedIconBankTrust extends IconBankTrust {}
+(ThemedIconBankTrust as any) = withTheme(IconBankTrust);
+export default ThemedIconBankTrust;

--- a/src/icon/brand/bank-unicredit/bank-unicredit.tsx
+++ b/src/icon/brand/bank-unicredit/bank-unicredit.tsx
@@ -18,4 +18,6 @@ class IconBankUnicredit extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankUnicredit);
+class ThemedIconBankUnicredit extends IconBankUnicredit {}
+(ThemedIconBankUnicredit as any) = withTheme(IconBankUnicredit);
+export default ThemedIconBankUnicredit;

--- a/src/icon/brand/bank-uralsib/bank-uralsib.tsx
+++ b/src/icon/brand/bank-uralsib/bank-uralsib.tsx
@@ -18,4 +18,6 @@ class IconBankUralsib extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankUralsib);
+class ThemedIconBankUralsib extends IconBankUralsib {}
+(ThemedIconBankUralsib as any) = withTheme(IconBankUralsib);
+export default ThemedIconBankUralsib;

--- a/src/icon/brand/bank-uralskiy/bank-uralskiy.tsx
+++ b/src/icon/brand/bank-uralskiy/bank-uralskiy.tsx
@@ -18,4 +18,6 @@ class IconBankUralskiy extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankUralskiy);
+class ThemedIconBankUralskiy extends IconBankUralskiy {}
+(ThemedIconBankUralskiy as any) = withTheme(IconBankUralskiy);
+export default ThemedIconBankUralskiy;

--- a/src/icon/brand/bank-vozrozhdenie/bank-vozrozhdenie.tsx
+++ b/src/icon/brand/bank-vozrozhdenie/bank-vozrozhdenie.tsx
@@ -18,4 +18,6 @@ class IconBankVozrozhdenie extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankVozrozhdenie);
+class ThemedIconBankVozrozhdenie extends IconBankVozrozhdenie {}
+(ThemedIconBankVozrozhdenie as any) = withTheme(IconBankVozrozhdenie);
+export default ThemedIconBankVozrozhdenie;

--- a/src/icon/brand/bank-vtb/bank-vtb.tsx
+++ b/src/icon/brand/bank-vtb/bank-vtb.tsx
@@ -18,4 +18,6 @@ class IconBankVtb extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankVtb);
+class ThemedIconBankVtb extends IconBankVtb {}
+(ThemedIconBankVtb as any) = withTheme(IconBankVtb);
+export default ThemedIconBankVtb;

--- a/src/icon/brand/bank-yandexmoney/bank-yandexmoney.tsx
+++ b/src/icon/brand/bank-yandexmoney/bank-yandexmoney.tsx
@@ -18,4 +18,6 @@ class IconBankYandexmoney extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBankYandexmoney);
+class ThemedIconBankYandexmoney extends IconBankYandexmoney {}
+(ThemedIconBankYandexmoney as any) = withTheme(IconBankYandexmoney);
+export default ThemedIconBankYandexmoney;

--- a/src/icon/brand/beeline/beeline.tsx
+++ b/src/icon/brand/beeline/beeline.tsx
@@ -18,4 +18,6 @@ class IconBeeline extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBeeline);
+class ThemedIconBeeline extends IconBeeline {}
+(ThemedIconBeeline as any) = withTheme(IconBeeline);
+export default ThemedIconBeeline;

--- a/src/icon/brand/card-belkart/card-belkart.tsx
+++ b/src/icon/brand/card-belkart/card-belkart.tsx
@@ -18,4 +18,6 @@ class IconCardBelkart extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardBelkart);
+class ThemedIconCardBelkart extends IconCardBelkart {}
+(ThemedIconCardBelkart as any) = withTheme(IconCardBelkart);
+export default ThemedIconCardBelkart;

--- a/src/icon/brand/card-googlepay/card-googlepay.tsx
+++ b/src/icon/brand/card-googlepay/card-googlepay.tsx
@@ -18,4 +18,6 @@ class IconCardGooglepay extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardGooglepay);
+class ThemedIconCardGooglepay extends IconCardGooglepay {}
+(ThemedIconCardGooglepay as any) = withTheme(IconCardGooglepay);
+export default ThemedIconCardGooglepay;

--- a/src/icon/brand/card-maestro/card-maestro.tsx
+++ b/src/icon/brand/card-maestro/card-maestro.tsx
@@ -18,4 +18,6 @@ class IconCardMaestro extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardMaestro);
+class ThemedIconCardMaestro extends IconCardMaestro {}
+(ThemedIconCardMaestro as any) = withTheme(IconCardMaestro);
+export default ThemedIconCardMaestro;

--- a/src/icon/brand/card-mastercard/card-mastercard.tsx
+++ b/src/icon/brand/card-mastercard/card-mastercard.tsx
@@ -18,4 +18,6 @@ class IconCardMastercard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardMastercard);
+class ThemedIconCardMastercard extends IconCardMastercard {}
+(ThemedIconCardMastercard as any) = withTheme(IconCardMastercard);
+export default ThemedIconCardMastercard;

--- a/src/icon/brand/card-mastero/card-mastero.tsx
+++ b/src/icon/brand/card-mastero/card-mastero.tsx
@@ -18,4 +18,6 @@ class IconCardMastero extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardMastero);
+class ThemedIconCardMastero extends IconCardMastero {}
+(ThemedIconCardMastero as any) = withTheme(IconCardMastero);
+export default ThemedIconCardMastero;

--- a/src/icon/brand/card-mir/card-mir.tsx
+++ b/src/icon/brand/card-mir/card-mir.tsx
@@ -18,4 +18,6 @@ class IconCardMir extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardMir);
+class ThemedIconCardMir extends IconCardMir {}
+(ThemedIconCardMir as any) = withTheme(IconCardMir);
+export default ThemedIconCardMir;

--- a/src/icon/brand/card-visa-electron/card-visa-electron.tsx
+++ b/src/icon/brand/card-visa-electron/card-visa-electron.tsx
@@ -18,4 +18,6 @@ class IconCardVisaElectron extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardVisaElectron);
+class ThemedIconCardVisaElectron extends IconCardVisaElectron {}
+(ThemedIconCardVisaElectron as any) = withTheme(IconCardVisaElectron);
+export default ThemedIconCardVisaElectron;

--- a/src/icon/brand/card-visa/card-visa.tsx
+++ b/src/icon/brand/card-visa/card-visa.tsx
@@ -18,4 +18,6 @@ class IconCardVisa extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardVisa);
+class ThemedIconCardVisa extends IconCardVisa {}
+(ThemedIconCardVisa as any) = withTheme(IconCardVisa);
+export default ThemedIconCardVisa;

--- a/src/icon/brand/fifa-trophy/fifa-trophy.tsx
+++ b/src/icon/brand/fifa-trophy/fifa-trophy.tsx
@@ -18,4 +18,6 @@ class IconFifaTrophy extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFifaTrophy);
+class ThemedIconFifaTrophy extends IconFifaTrophy {}
+(ThemedIconFifaTrophy as any) = withTheme(IconFifaTrophy);
+export default ThemedIconFifaTrophy;

--- a/src/icon/brand/forex/forex.tsx
+++ b/src/icon/brand/forex/forex.tsx
@@ -18,4 +18,6 @@ class IconForex extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconForex);
+class ThemedIconForex extends IconForex {}
+(ThemedIconForex as any) = withTheme(IconForex);
+export default ThemedIconForex;

--- a/src/icon/brand/logo-alfabank/logo-alfabank.tsx
+++ b/src/icon/brand/logo-alfabank/logo-alfabank.tsx
@@ -18,4 +18,6 @@ class IconLogoAlfabank extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconLogoAlfabank);
+class ThemedIconLogoAlfabank extends IconLogoAlfabank {}
+(ThemedIconLogoAlfabank as any) = withTheme(IconLogoAlfabank);
+export default ThemedIconLogoAlfabank;

--- a/src/icon/brand/maestro/maestro.tsx
+++ b/src/icon/brand/maestro/maestro.tsx
@@ -18,4 +18,6 @@ class IconMaestro extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMaestro);
+class ThemedIconMaestro extends IconMaestro {}
+(ThemedIconMaestro as any) = withTheme(IconMaestro);
+export default ThemedIconMaestro;

--- a/src/icon/brand/mastercard/mastercard.tsx
+++ b/src/icon/brand/mastercard/mastercard.tsx
@@ -18,4 +18,6 @@ class IconMastercard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMastercard);
+class ThemedIconMastercard extends IconMastercard {}
+(ThemedIconMastercard as any) = withTheme(IconMastercard);
+export default ThemedIconMastercard;

--- a/src/icon/brand/mir/mir.tsx
+++ b/src/icon/brand/mir/mir.tsx
@@ -18,4 +18,6 @@ class IconMir extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMir);
+class ThemedIconMir extends IconMir {}
+(ThemedIconMir as any) = withTheme(IconMir);
+export default ThemedIconMir;

--- a/src/icon/brand/network-facebook/network-facebook.tsx
+++ b/src/icon/brand/network-facebook/network-facebook.tsx
@@ -18,4 +18,6 @@ class IconNetworkFacebook extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNetworkFacebook);
+class ThemedIconNetworkFacebook extends IconNetworkFacebook {}
+(ThemedIconNetworkFacebook as any) = withTheme(IconNetworkFacebook);
+export default ThemedIconNetworkFacebook;

--- a/src/icon/brand/network-twitter/network-twitter.tsx
+++ b/src/icon/brand/network-twitter/network-twitter.tsx
@@ -18,4 +18,6 @@ class IconNetworkTwitter extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNetworkTwitter);
+class ThemedIconNetworkTwitter extends IconNetworkTwitter {}
+(ThemedIconNetworkTwitter as any) = withTheme(IconNetworkTwitter);
+export default ThemedIconNetworkTwitter;

--- a/src/icon/brand/network-vk/network-vk.tsx
+++ b/src/icon/brand/network-vk/network-vk.tsx
@@ -18,4 +18,6 @@ class IconNetworkVk extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNetworkVk);
+class ThemedIconNetworkVk extends IconNetworkVk {}
+(ThemedIconNetworkVk as any) = withTheme(IconNetworkVk);
+export default ThemedIconNetworkVk;

--- a/src/icon/brand/sbp/sbp.tsx
+++ b/src/icon/brand/sbp/sbp.tsx
@@ -18,4 +18,6 @@ class IconSbp extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSbp);
+class ThemedIconSbp extends IconSbp {}
+(ThemedIconSbp as any) = withTheme(IconSbp);
+export default ThemedIconSbp;

--- a/src/icon/brand/unionpay/unionpay.tsx
+++ b/src/icon/brand/unionpay/unionpay.tsx
@@ -18,4 +18,6 @@ class IconUnionpay extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconUnionpay);
+class ThemedIconUnionpay extends IconUnionpay {}
+(ThemedIconUnionpay as any) = withTheme(IconUnionpay);
+export default ThemedIconUnionpay;

--- a/src/icon/brand/visa/visa.tsx
+++ b/src/icon/brand/visa/visa.tsx
@@ -18,4 +18,6 @@ class IconVisa extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconVisa);
+class ThemedIconVisa extends IconVisa {}
+(ThemedIconVisa as any) = withTheme(IconVisa);
+export default ThemedIconVisa;

--- a/src/icon/category/category-appliances/category-appliances.tsx
+++ b/src/icon/category/category-appliances/category-appliances.tsx
@@ -18,4 +18,6 @@ class IconCategoryAppliances extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryAppliances);
+class ThemedIconCategoryAppliances extends IconCategoryAppliances {}
+(ThemedIconCategoryAppliances as any) = withTheme(IconCategoryAppliances);
+export default ThemedIconCategoryAppliances;

--- a/src/icon/category/category-atm/category-atm.tsx
+++ b/src/icon/category/category-atm/category-atm.tsx
@@ -18,4 +18,6 @@ class IconCategoryAtm extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryAtm);
+class ThemedIconCategoryAtm extends IconCategoryAtm {}
+(ThemedIconCategoryAtm as any) = withTheme(IconCategoryAtm);
+export default ThemedIconCategoryAtm;

--- a/src/icon/category/category-auto-loan/category-auto-loan.tsx
+++ b/src/icon/category/category-auto-loan/category-auto-loan.tsx
@@ -18,4 +18,6 @@ class IconCategoryAutoLoan extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryAutoLoan);
+class ThemedIconCategoryAutoLoan extends IconCategoryAutoLoan {}
+(ThemedIconCategoryAutoLoan as any) = withTheme(IconCategoryAutoLoan);
+export default ThemedIconCategoryAutoLoan;

--- a/src/icon/category/category-auto/category-auto.tsx
+++ b/src/icon/category/category-auto/category-auto.tsx
@@ -18,4 +18,6 @@ class IconCategoryAuto extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryAuto);
+class ThemedIconCategoryAuto extends IconCategoryAuto {}
+(ThemedIconCategoryAuto as any) = withTheme(IconCategoryAuto);
+export default ThemedIconCategoryAuto;

--- a/src/icon/category/category-books-movies/category-books-movies.tsx
+++ b/src/icon/category/category-books-movies/category-books-movies.tsx
@@ -18,4 +18,6 @@ class IconCategoryBooksMovies extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryBooksMovies);
+class ThemedIconCategoryBooksMovies extends IconCategoryBooksMovies {}
+(ThemedIconCategoryBooksMovies as any) = withTheme(IconCategoryBooksMovies);
+export default ThemedIconCategoryBooksMovies;

--- a/src/icon/category/category-budget/category-budget.tsx
+++ b/src/icon/category/category-budget/category-budget.tsx
@@ -18,4 +18,6 @@ class IconCategoryBudget extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryBudget);
+class ThemedIconCategoryBudget extends IconCategoryBudget {}
+(ThemedIconCategoryBudget as any) = withTheme(IconCategoryBudget);
+export default ThemedIconCategoryBudget;

--- a/src/icon/category/category-business-activity/category-business-activity.tsx
+++ b/src/icon/category/category-business-activity/category-business-activity.tsx
@@ -18,4 +18,6 @@ class IconCategoryBusinessActivity extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryBusinessActivity);
+class ThemedIconCategoryBusinessActivity extends IconCategoryBusinessActivity {}
+(ThemedIconCategoryBusinessActivity as any) = withTheme(IconCategoryBusinessActivity);
+export default ThemedIconCategoryBusinessActivity;

--- a/src/icon/category/category-business/category-business.tsx
+++ b/src/icon/category/category-business/category-business.tsx
@@ -18,4 +18,6 @@ class IconCategoryBusiness extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryBusiness);
+class ThemedIconCategoryBusiness extends IconCategoryBusiness {}
+(ThemedIconCategoryBusiness as any) = withTheme(IconCategoryBusiness);
+export default ThemedIconCategoryBusiness;

--- a/src/icon/category/category-cards/category-cards.tsx
+++ b/src/icon/category/category-cards/category-cards.tsx
@@ -18,4 +18,6 @@ class IconCategoryCards extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryCards);
+class ThemedIconCategoryCards extends IconCategoryCards {}
+(ThemedIconCategoryCards as any) = withTheme(IconCategoryCards);
+export default ThemedIconCategoryCards;

--- a/src/icon/category/category-cash/category-cash.tsx
+++ b/src/icon/category/category-cash/category-cash.tsx
@@ -18,4 +18,6 @@ class IconCategoryCash extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryCash);
+class ThemedIconCategoryCash extends IconCategoryCash {}
+(ThemedIconCategoryCash as any) = withTheme(IconCategoryCash);
+export default ThemedIconCategoryCash;

--- a/src/icon/category/category-cashback/category-cashback.tsx
+++ b/src/icon/category/category-cashback/category-cashback.tsx
@@ -18,4 +18,6 @@ class IconCategoryCashback extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryCashback);
+class ThemedIconCategoryCashback extends IconCategoryCashback {}
+(ThemedIconCategoryCashback as any) = withTheme(IconCategoryCashback);
+export default ThemedIconCategoryCashback;

--- a/src/icon/category/category-charity/category-charity.tsx
+++ b/src/icon/category/category-charity/category-charity.tsx
@@ -18,4 +18,6 @@ class IconCategoryCharity extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryCharity);
+class ThemedIconCategoryCharity extends IconCategoryCharity {}
+(ThemedIconCategoryCharity as any) = withTheme(IconCategoryCharity);
+export default ThemedIconCategoryCharity;

--- a/src/icon/category/category-consulting/category-consulting.tsx
+++ b/src/icon/category/category-consulting/category-consulting.tsx
@@ -18,4 +18,6 @@ class IconCategoryConsulting extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryConsulting);
+class ThemedIconCategoryConsulting extends IconCategoryConsulting {}
+(ThemedIconCategoryConsulting as any) = withTheme(IconCategoryConsulting);
+export default ThemedIconCategoryConsulting;

--- a/src/icon/category/category-default/category-default.tsx
+++ b/src/icon/category/category-default/category-default.tsx
@@ -18,4 +18,6 @@ class IconCategoryDefault extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryDefault);
+class ThemedIconCategoryDefault extends IconCategoryDefault {}
+(ThemedIconCategoryDefault as any) = withTheme(IconCategoryDefault);
+export default ThemedIconCategoryDefault;

--- a/src/icon/category/category-dress/category-dress.tsx
+++ b/src/icon/category/category-dress/category-dress.tsx
@@ -18,4 +18,6 @@ class IconCategoryDress extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryDress);
+class ThemedIconCategoryDress extends IconCategoryDress {}
+(ThemedIconCategoryDress as any) = withTheme(IconCategoryDress);
+export default ThemedIconCategoryDress;

--- a/src/icon/category/category-education/category-education.tsx
+++ b/src/icon/category/category-education/category-education.tsx
@@ -18,4 +18,6 @@ class IconCategoryEducation extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryEducation);
+class ThemedIconCategoryEducation extends IconCategoryEducation {}
+(ThemedIconCategoryEducation as any) = withTheme(IconCategoryEducation);
+export default ThemedIconCategoryEducation;

--- a/src/icon/category/category-entertainment/category-entertainment.tsx
+++ b/src/icon/category/category-entertainment/category-entertainment.tsx
@@ -18,4 +18,6 @@ class IconCategoryEntertainment extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryEntertainment);
+class ThemedIconCategoryEntertainment extends IconCategoryEntertainment {}
+(ThemedIconCategoryEntertainment as any) = withTheme(IconCategoryEntertainment);
+export default ThemedIconCategoryEntertainment;

--- a/src/icon/category/category-experiments/category-experiments.tsx
+++ b/src/icon/category/category-experiments/category-experiments.tsx
@@ -18,4 +18,6 @@ class IconCategoryExperiments extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryExperiments);
+class ThemedIconCategoryExperiments extends IconCategoryExperiments {}
+(ThemedIconCategoryExperiments as any) = withTheme(IconCategoryExperiments);
+export default ThemedIconCategoryExperiments;

--- a/src/icon/category/category-family/category-family.tsx
+++ b/src/icon/category/category-family/category-family.tsx
@@ -18,4 +18,6 @@ class IconCategoryFamily extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryFamily);
+class ThemedIconCategoryFamily extends IconCategoryFamily {}
+(ThemedIconCategoryFamily as any) = withTheme(IconCategoryFamily);
+export default ThemedIconCategoryFamily;

--- a/src/icon/category/category-finance/category-finance.tsx
+++ b/src/icon/category/category-finance/category-finance.tsx
@@ -18,4 +18,6 @@ class IconCategoryFinance extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryFinance);
+class ThemedIconCategoryFinance extends IconCategoryFinance {}
+(ThemedIconCategoryFinance as any) = withTheme(IconCategoryFinance);
+export default ThemedIconCategoryFinance;

--- a/src/icon/category/category-fines/category-fines.tsx
+++ b/src/icon/category/category-fines/category-fines.tsx
@@ -18,4 +18,6 @@ class IconCategoryFines extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryFines);
+class ThemedIconCategoryFines extends IconCategoryFines {}
+(ThemedIconCategoryFines as any) = withTheme(IconCategoryFines);
+export default ThemedIconCategoryFines;

--- a/src/icon/category/category-gaming/category-gaming.tsx
+++ b/src/icon/category/category-gaming/category-gaming.tsx
@@ -18,4 +18,6 @@ class IconCategoryGaming extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryGaming);
+class ThemedIconCategoryGaming extends IconCategoryGaming {}
+(ThemedIconCategoryGaming as any) = withTheme(IconCategoryGaming);
+export default ThemedIconCategoryGaming;

--- a/src/icon/category/category-gasoline/category-gasoline.tsx
+++ b/src/icon/category/category-gasoline/category-gasoline.tsx
@@ -18,4 +18,6 @@ class IconCategoryGasoline extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryGasoline);
+class ThemedIconCategoryGasoline extends IconCategoryGasoline {}
+(ThemedIconCategoryGasoline as any) = withTheme(IconCategoryGasoline);
+export default ThemedIconCategoryGasoline;

--- a/src/icon/category/category-gibdd-fines/category-gibdd-fines.tsx
+++ b/src/icon/category/category-gibdd-fines/category-gibdd-fines.tsx
@@ -18,4 +18,6 @@ class IconCategoryGibddFines extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryGibddFines);
+class ThemedIconCategoryGibddFines extends IconCategoryGibddFines {}
+(ThemedIconCategoryGibddFines as any) = withTheme(IconCategoryGibddFines);
+export default ThemedIconCategoryGibddFines;

--- a/src/icon/category/category-guard/category-guard.tsx
+++ b/src/icon/category/category-guard/category-guard.tsx
@@ -18,4 +18,6 @@ class IconCategoryGuard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryGuard);
+class ThemedIconCategoryGuard extends IconCategoryGuard {}
+(ThemedIconCategoryGuard as any) = withTheme(IconCategoryGuard);
+export default ThemedIconCategoryGuard;

--- a/src/icon/category/category-health/category-health.tsx
+++ b/src/icon/category/category-health/category-health.tsx
@@ -18,4 +18,6 @@ class IconCategoryHealth extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryHealth);
+class ThemedIconCategoryHealth extends IconCategoryHealth {}
+(ThemedIconCategoryHealth as any) = withTheme(IconCategoryHealth);
+export default ThemedIconCategoryHealth;

--- a/src/icon/category/category-hobby/category-hobby.tsx
+++ b/src/icon/category/category-hobby/category-hobby.tsx
@@ -18,4 +18,6 @@ class IconCategoryHobby extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryHobby);
+class ThemedIconCategoryHobby extends IconCategoryHobby {}
+(ThemedIconCategoryHobby as any) = withTheme(IconCategoryHobby);
+export default ThemedIconCategoryHobby;

--- a/src/icon/category/category-house/category-house.tsx
+++ b/src/icon/category/category-house/category-house.tsx
@@ -18,4 +18,6 @@ class IconCategoryHouse extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryHouse);
+class ThemedIconCategoryHouse extends IconCategoryHouse {}
+(ThemedIconCategoryHouse as any) = withTheme(IconCategoryHouse);
+export default ThemedIconCategoryHouse;

--- a/src/icon/category/category-housekeeping/category-housekeeping.tsx
+++ b/src/icon/category/category-housekeeping/category-housekeeping.tsx
@@ -18,4 +18,6 @@ class IconCategoryHousekeeping extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryHousekeeping);
+class ThemedIconCategoryHousekeeping extends IconCategoryHousekeeping {}
+(ThemedIconCategoryHousekeeping as any) = withTheme(IconCategoryHousekeeping);
+export default ThemedIconCategoryHousekeeping;

--- a/src/icon/category/category-investments/category-investments.tsx
+++ b/src/icon/category/category-investments/category-investments.tsx
@@ -18,4 +18,6 @@ class IconCategoryInvestments extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryInvestments);
+class ThemedIconCategoryInvestments extends IconCategoryInvestments {}
+(ThemedIconCategoryInvestments as any) = withTheme(IconCategoryInvestments);
+export default ThemedIconCategoryInvestments;

--- a/src/icon/category/category-loans/category-loans.tsx
+++ b/src/icon/category/category-loans/category-loans.tsx
@@ -18,4 +18,6 @@ class IconCategoryLoans extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryLoans);
+class ThemedIconCategoryLoans extends IconCategoryLoans {}
+(ThemedIconCategoryLoans as any) = withTheme(IconCategoryLoans);
+export default ThemedIconCategoryLoans;

--- a/src/icon/category/category-medicine/category-medicine.tsx
+++ b/src/icon/category/category-medicine/category-medicine.tsx
@@ -18,4 +18,6 @@ class IconCategoryMedicine extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryMedicine);
+class ThemedIconCategoryMedicine extends IconCategoryMedicine {}
+(ThemedIconCategoryMedicine as any) = withTheme(IconCategoryMedicine);
+export default ThemedIconCategoryMedicine;

--- a/src/icon/category/category-mortgage/category-mortgage.tsx
+++ b/src/icon/category/category-mortgage/category-mortgage.tsx
@@ -18,4 +18,6 @@ class IconCategoryMortgage extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryMortgage);
+class ThemedIconCategoryMortgage extends IconCategoryMortgage {}
+(ThemedIconCategoryMortgage as any) = withTheme(IconCategoryMortgage);
+export default ThemedIconCategoryMortgage;

--- a/src/icon/category/category-other/category-other.tsx
+++ b/src/icon/category/category-other/category-other.tsx
@@ -18,4 +18,6 @@ class IconCategoryOther extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryOther);
+class ThemedIconCategoryOther extends IconCategoryOther {}
+(ThemedIconCategoryOther as any) = withTheme(IconCategoryOther);
+export default ThemedIconCategoryOther;

--- a/src/icon/category/category-person/category-person.tsx
+++ b/src/icon/category/category-person/category-person.tsx
@@ -18,4 +18,6 @@ class IconCategoryPerson extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryPerson);
+class ThemedIconCategoryPerson extends IconCategoryPerson {}
+(ThemedIconCategoryPerson as any) = withTheme(IconCategoryPerson);
+export default ThemedIconCategoryPerson;

--- a/src/icon/category/category-pets/category-pets.tsx
+++ b/src/icon/category/category-pets/category-pets.tsx
@@ -18,4 +18,6 @@ class IconCategoryPets extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryPets);
+class ThemedIconCategoryPets extends IconCategoryPets {}
+(ThemedIconCategoryPets as any) = withTheme(IconCategoryPets);
+export default ThemedIconCategoryPets;

--- a/src/icon/category/category-plane/category-plane.tsx
+++ b/src/icon/category/category-plane/category-plane.tsx
@@ -18,4 +18,6 @@ class IconCategoryPlane extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryPlane);
+class ThemedIconCategoryPlane extends IconCategoryPlane {}
+(ThemedIconCategoryPlane as any) = withTheme(IconCategoryPlane);
+export default ThemedIconCategoryPlane;

--- a/src/icon/category/category-rent/category-rent.tsx
+++ b/src/icon/category/category-rent/category-rent.tsx
@@ -18,4 +18,6 @@ class IconCategoryRent extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryRent);
+class ThemedIconCategoryRent extends IconCategoryRent {}
+(ThemedIconCategoryRent as any) = withTheme(IconCategoryRent);
+export default ThemedIconCategoryRent;

--- a/src/icon/category/category-repairs/category-repairs.tsx
+++ b/src/icon/category/category-repairs/category-repairs.tsx
@@ -18,4 +18,6 @@ class IconCategoryRepairs extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryRepairs);
+class ThemedIconCategoryRepairs extends IconCategoryRepairs {}
+(ThemedIconCategoryRepairs as any) = withTheme(IconCategoryRepairs);
+export default ThemedIconCategoryRepairs;

--- a/src/icon/category/category-restaurants/category-restaurants.tsx
+++ b/src/icon/category/category-restaurants/category-restaurants.tsx
@@ -18,4 +18,6 @@ class IconCategoryRestaurants extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryRestaurants);
+class ThemedIconCategoryRestaurants extends IconCategoryRestaurants {}
+(ThemedIconCategoryRestaurants as any) = withTheme(IconCategoryRestaurants);
+export default ThemedIconCategoryRestaurants;

--- a/src/icon/category/category-salary/category-salary.tsx
+++ b/src/icon/category/category-salary/category-salary.tsx
@@ -18,4 +18,6 @@ class IconCategorySalary extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategorySalary);
+class ThemedIconCategorySalary extends IconCategorySalary {}
+(ThemedIconCategorySalary as any) = withTheme(IconCategorySalary);
+export default ThemedIconCategorySalary;

--- a/src/icon/category/category-scholarship/category-scholarship.tsx
+++ b/src/icon/category/category-scholarship/category-scholarship.tsx
@@ -18,4 +18,6 @@ class IconCategoryScholarship extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryScholarship);
+class ThemedIconCategoryScholarship extends IconCategoryScholarship {}
+(ThemedIconCategoryScholarship as any) = withTheme(IconCategoryScholarship);
+export default ThemedIconCategoryScholarship;

--- a/src/icon/category/category-shield/category-shield.tsx
+++ b/src/icon/category/category-shield/category-shield.tsx
@@ -18,4 +18,6 @@ class IconCategoryShield extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryShield);
+class ThemedIconCategoryShield extends IconCategoryShield {}
+(ThemedIconCategoryShield as any) = withTheme(IconCategoryShield);
+export default ThemedIconCategoryShield;

--- a/src/icon/category/category-shopping/category-shopping.tsx
+++ b/src/icon/category/category-shopping/category-shopping.tsx
@@ -18,4 +18,6 @@ class IconCategoryShopping extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryShopping);
+class ThemedIconCategoryShopping extends IconCategoryShopping {}
+(ThemedIconCategoryShopping as any) = withTheme(IconCategoryShopping);
+export default ThemedIconCategoryShopping;

--- a/src/icon/category/category-state/category-state.tsx
+++ b/src/icon/category/category-state/category-state.tsx
@@ -18,4 +18,6 @@ class IconCategoryState extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryState);
+class ThemedIconCategoryState extends IconCategoryState {}
+(ThemedIconCategoryState as any) = withTheme(IconCategoryState);
+export default ThemedIconCategoryState;

--- a/src/icon/category/category-telecom/category-telecom.tsx
+++ b/src/icon/category/category-telecom/category-telecom.tsx
@@ -18,4 +18,6 @@ class IconCategoryTelecom extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryTelecom);
+class ThemedIconCategoryTelecom extends IconCategoryTelecom {}
+(ThemedIconCategoryTelecom as any) = withTheme(IconCategoryTelecom);
+export default ThemedIconCategoryTelecom;

--- a/src/icon/category/category-transfer/category-transfer.tsx
+++ b/src/icon/category/category-transfer/category-transfer.tsx
@@ -18,4 +18,6 @@ class IconCategoryTransfer extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryTransfer);
+class ThemedIconCategoryTransfer extends IconCategoryTransfer {}
+(ThemedIconCategoryTransfer as any) = withTheme(IconCategoryTransfer);
+export default ThemedIconCategoryTransfer;

--- a/src/icon/category/category-transport/category-transport.tsx
+++ b/src/icon/category/category-transport/category-transport.tsx
@@ -18,4 +18,6 @@ class IconCategoryTransport extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryTransport);
+class ThemedIconCategoryTransport extends IconCategoryTransport {}
+(ThemedIconCategoryTransport as any) = withTheme(IconCategoryTransport);
+export default ThemedIconCategoryTransport;

--- a/src/icon/category/category-travel/category-travel.tsx
+++ b/src/icon/category/category-travel/category-travel.tsx
@@ -18,4 +18,6 @@ class IconCategoryTravel extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryTravel);
+class ThemedIconCategoryTravel extends IconCategoryTravel {}
+(ThemedIconCategoryTravel as any) = withTheme(IconCategoryTravel);
+export default ThemedIconCategoryTravel;

--- a/src/icon/category/category-troika/category-troika.tsx
+++ b/src/icon/category/category-troika/category-troika.tsx
@@ -18,4 +18,6 @@ class IconCategoryTroika extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryTroika);
+class ThemedIconCategoryTroika extends IconCategoryTroika {}
+(ThemedIconCategoryTroika as any) = withTheme(IconCategoryTroika);
+export default ThemedIconCategoryTroika;

--- a/src/icon/category/category-tv/category-tv.tsx
+++ b/src/icon/category/category-tv/category-tv.tsx
@@ -18,4 +18,6 @@ class IconCategoryTv extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryTv);
+class ThemedIconCategoryTv extends IconCategoryTv {}
+(ThemedIconCategoryTv as any) = withTheme(IconCategoryTv);
+export default ThemedIconCategoryTv;

--- a/src/icon/category/category-unknown/category-unknown.tsx
+++ b/src/icon/category/category-unknown/category-unknown.tsx
@@ -18,4 +18,6 @@ class IconCategoryUnknown extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryUnknown);
+class ThemedIconCategoryUnknown extends IconCategoryUnknown {}
+(ThemedIconCategoryUnknown as any) = withTheme(IconCategoryUnknown);
+export default ThemedIconCategoryUnknown;

--- a/src/icon/category/category-user/category-user.tsx
+++ b/src/icon/category/category-user/category-user.tsx
@@ -18,4 +18,6 @@ class IconCategoryUser extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryUser);
+class ThemedIconCategoryUser extends IconCategoryUser {}
+(ThemedIconCategoryUser as any) = withTheme(IconCategoryUser);
+export default ThemedIconCategoryUser;

--- a/src/icon/category/category-vacation/category-vacation.tsx
+++ b/src/icon/category/category-vacation/category-vacation.tsx
@@ -18,4 +18,6 @@ class IconCategoryVacation extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryVacation);
+class ThemedIconCategoryVacation extends IconCategoryVacation {}
+(ThemedIconCategoryVacation as any) = withTheme(IconCategoryVacation);
+export default ThemedIconCategoryVacation;

--- a/src/icon/category/category-vip-manager/category-vip-manager.tsx
+++ b/src/icon/category/category-vip-manager/category-vip-manager.tsx
@@ -18,4 +18,6 @@ class IconCategoryVipManager extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryVipManager);
+class ThemedIconCategoryVipManager extends IconCategoryVipManager {}
+(ThemedIconCategoryVipManager as any) = withTheme(IconCategoryVipManager);
+export default ThemedIconCategoryVipManager;

--- a/src/icon/category/category-vip-room/category-vip-room.tsx
+++ b/src/icon/category/category-vip-room/category-vip-room.tsx
@@ -18,4 +18,6 @@ class IconCategoryVipRoom extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryVipRoom);
+class ThemedIconCategoryVipRoom extends IconCategoryVipRoom {}
+(ThemedIconCategoryVipRoom as any) = withTheme(IconCategoryVipRoom);
+export default ThemedIconCategoryVipRoom;

--- a/src/icon/category/category-wallet/category-wallet.tsx
+++ b/src/icon/category/category-wallet/category-wallet.tsx
@@ -18,4 +18,6 @@ class IconCategoryWallet extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCategoryWallet);
+class ThemedIconCategoryWallet extends IconCategoryWallet {}
+(ThemedIconCategoryWallet as any) = withTheme(IconCategoryWallet);
+export default ThemedIconCategoryWallet;

--- a/src/icon/category/utilities/utilities.tsx
+++ b/src/icon/category/utilities/utilities.tsx
@@ -18,4 +18,6 @@ class IconUtilities extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconUtilities);
+class ThemedIconUtilities extends IconUtilities {}
+(ThemedIconUtilities as any) = withTheme(IconUtilities);
+export default ThemedIconUtilities;

--- a/src/icon/currency/currency-chf/currency-chf.tsx
+++ b/src/icon/currency/currency-chf/currency-chf.tsx
@@ -18,4 +18,6 @@ class IconCurrencyChf extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCurrencyChf);
+class ThemedIconCurrencyChf extends IconCurrencyChf {}
+(ThemedIconCurrencyChf as any) = withTheme(IconCurrencyChf);
+export default ThemedIconCurrencyChf;

--- a/src/icon/currency/currency-eur-usd/currency-eur-usd.tsx
+++ b/src/icon/currency/currency-eur-usd/currency-eur-usd.tsx
@@ -18,4 +18,6 @@ class IconCurrencyEurUsd extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCurrencyEurUsd);
+class ThemedIconCurrencyEurUsd extends IconCurrencyEurUsd {}
+(ThemedIconCurrencyEurUsd as any) = withTheme(IconCurrencyEurUsd);
+export default ThemedIconCurrencyEurUsd;

--- a/src/icon/currency/currency-eur/currency-eur.tsx
+++ b/src/icon/currency/currency-eur/currency-eur.tsx
@@ -18,4 +18,6 @@ class IconCurrencyEur extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCurrencyEur);
+class ThemedIconCurrencyEur extends IconCurrencyEur {}
+(ThemedIconCurrencyEur as any) = withTheme(IconCurrencyEur);
+export default ThemedIconCurrencyEur;

--- a/src/icon/currency/currency-gbp/currency-gbp.tsx
+++ b/src/icon/currency/currency-gbp/currency-gbp.tsx
@@ -18,4 +18,6 @@ class IconCurrencyGbp extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCurrencyGbp);
+class ThemedIconCurrencyGbp extends IconCurrencyGbp {}
+(ThemedIconCurrencyGbp as any) = withTheme(IconCurrencyGbp);
+export default ThemedIconCurrencyGbp;

--- a/src/icon/currency/currency-jpy/currency-jpy.tsx
+++ b/src/icon/currency/currency-jpy/currency-jpy.tsx
@@ -18,4 +18,6 @@ class IconCurrencyJpy extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCurrencyJpy);
+class ThemedIconCurrencyJpy extends IconCurrencyJpy {}
+(ThemedIconCurrencyJpy as any) = withTheme(IconCurrencyJpy);
+export default ThemedIconCurrencyJpy;

--- a/src/icon/currency/currency-rub-usd/currency-rub-usd.tsx
+++ b/src/icon/currency/currency-rub-usd/currency-rub-usd.tsx
@@ -18,4 +18,6 @@ class IconCurrencyRubUsd extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCurrencyRubUsd);
+class ThemedIconCurrencyRubUsd extends IconCurrencyRubUsd {}
+(ThemedIconCurrencyRubUsd as any) = withTheme(IconCurrencyRubUsd);
+export default ThemedIconCurrencyRubUsd;

--- a/src/icon/currency/currency-rub/currency-rub.tsx
+++ b/src/icon/currency/currency-rub/currency-rub.tsx
@@ -18,4 +18,6 @@ class IconCurrencyRub extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCurrencyRub);
+class ThemedIconCurrencyRub extends IconCurrencyRub {}
+(ThemedIconCurrencyRub as any) = withTheme(IconCurrencyRub);
+export default ThemedIconCurrencyRub;

--- a/src/icon/currency/currency-usd/currency-usd.tsx
+++ b/src/icon/currency/currency-usd/currency-usd.tsx
@@ -18,4 +18,6 @@ class IconCurrencyUsd extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCurrencyUsd);
+class ThemedIconCurrencyUsd extends IconCurrencyUsd {}
+(ThemedIconCurrencyUsd as any) = withTheme(IconCurrencyUsd);
+export default ThemedIconCurrencyUsd;

--- a/src/icon/entity/APC-bonus/APC-bonus.tsx
+++ b/src/icon/entity/APC-bonus/APC-bonus.tsx
@@ -18,4 +18,6 @@ class IconApcBonus extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconApcBonus);
+class ThemedIconApcBonus extends IconApcBonus {}
+(ThemedIconApcBonus as any) = withTheme(IconApcBonus);
+export default ThemedIconApcBonus;

--- a/src/icon/entity/alfacheck/alfacheck.tsx
+++ b/src/icon/entity/alfacheck/alfacheck.tsx
@@ -18,4 +18,6 @@ class IconAlfacheck extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAlfacheck);
+class ThemedIconAlfacheck extends IconAlfacheck {}
+(ThemedIconAlfacheck as any) = withTheme(IconAlfacheck);
+export default ThemedIconAlfacheck;

--- a/src/icon/entity/alfadialogue/alfadialogue.tsx
+++ b/src/icon/entity/alfadialogue/alfadialogue.tsx
@@ -18,4 +18,6 @@ class IconAlfadialogue extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAlfadialogue);
+class ThemedIconAlfadialogue extends IconAlfadialogue {}
+(ThemedIconAlfadialogue as any) = withTheme(IconAlfadialogue);
+export default ThemedIconAlfadialogue;

--- a/src/icon/entity/alfamobile/alfamobile.tsx
+++ b/src/icon/entity/alfamobile/alfamobile.tsx
@@ -18,4 +18,6 @@ class IconAlfamobile extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAlfamobile);
+class ThemedIconAlfamobile extends IconAlfamobile {}
+(ThemedIconAlfamobile as any) = withTheme(IconAlfamobile);
+export default ThemedIconAlfamobile;

--- a/src/icon/entity/atm/atm.tsx
+++ b/src/icon/entity/atm/atm.tsx
@@ -18,4 +18,6 @@ class IconAtm extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAtm);
+class ThemedIconAtm extends IconAtm {}
+(ThemedIconAtm as any) = withTheme(IconAtm);
+export default ThemedIconAtm;

--- a/src/icon/entity/bag/bag.tsx
+++ b/src/icon/entity/bag/bag.tsx
@@ -18,4 +18,6 @@ class IconBag extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBag);
+class ThemedIconBag extends IconBag {}
+(ThemedIconBag as any) = withTheme(IconBag);
+export default ThemedIconBag;

--- a/src/icon/entity/calendar/calendar.tsx
+++ b/src/icon/entity/calendar/calendar.tsx
@@ -18,4 +18,6 @@ class IconCalendar extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCalendar);
+class ThemedIconCalendar extends IconCalendar {}
+(ThemedIconCalendar as any) = withTheme(IconCalendar);
+export default ThemedIconCalendar;

--- a/src/icon/entity/card-void/card-void.tsx
+++ b/src/icon/entity/card-void/card-void.tsx
@@ -18,4 +18,6 @@ class IconCardVoid extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCardVoid);
+class ThemedIconCardVoid extends IconCardVoid {}
+(ThemedIconCardVoid as any) = withTheme(IconCardVoid);
+export default ThemedIconCardVoid;

--- a/src/icon/entity/cashback-bonus/cashback-bonus.tsx
+++ b/src/icon/entity/cashback-bonus/cashback-bonus.tsx
@@ -18,4 +18,6 @@ class IconCashbackBonus extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCashbackBonus);
+class ThemedIconCashbackBonus extends IconCashbackBonus {}
+(ThemedIconCashbackBonus as any) = withTheme(IconCashbackBonus);
+export default ThemedIconCashbackBonus;

--- a/src/icon/entity/cashback/cashback.tsx
+++ b/src/icon/entity/cashback/cashback.tsx
@@ -18,4 +18,6 @@ class IconCashback extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCashback);
+class ThemedIconCashback extends IconCashback {}
+(ThemedIconCashback as any) = withTheme(IconCashback);
+export default ThemedIconCashback;

--- a/src/icon/entity/chat-photo/chat-photo.tsx
+++ b/src/icon/entity/chat-photo/chat-photo.tsx
@@ -18,4 +18,6 @@ class IconChatPhoto extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconChatPhoto);
+class ThemedIconChatPhoto extends IconChatPhoto {}
+(ThemedIconChatPhoto as any) = withTheme(IconChatPhoto);
+export default ThemedIconChatPhoto;

--- a/src/icon/entity/clock-filled/clock-filled.tsx
+++ b/src/icon/entity/clock-filled/clock-filled.tsx
@@ -18,4 +18,6 @@ class IconClockFilled extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconClockFilled);
+class ThemedIconClockFilled extends IconClockFilled {}
+(ThemedIconClockFilled as any) = withTheme(IconClockFilled);
+export default ThemedIconClockFilled;

--- a/src/icon/entity/clock/clock.tsx
+++ b/src/icon/entity/clock/clock.tsx
@@ -18,4 +18,6 @@ class IconClock extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconClock);
+class ThemedIconClock extends IconClock {}
+(ThemedIconClock as any) = withTheme(IconClock);
+export default ThemedIconClock;

--- a/src/icon/entity/contact-list/contact-list.tsx
+++ b/src/icon/entity/contact-list/contact-list.tsx
@@ -18,4 +18,6 @@ class IconContactList extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconContactList);
+class ThemedIconContactList extends IconContactList {}
+(ThemedIconContactList as any) = withTheme(IconContactList);
+export default ThemedIconContactList;

--- a/src/icon/entity/contactless-off/contactless-off.tsx
+++ b/src/icon/entity/contactless-off/contactless-off.tsx
@@ -18,4 +18,6 @@ class IconContactlessOff extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconContactlessOff);
+class ThemedIconContactlessOff extends IconContactlessOff {}
+(ThemedIconContactlessOff as any) = withTheme(IconContactlessOff);
+export default ThemedIconContactlessOff;

--- a/src/icon/entity/contactless-on/contactless-on.tsx
+++ b/src/icon/entity/contactless-on/contactless-on.tsx
@@ -18,4 +18,6 @@ class IconContactlessOn extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconContactlessOn);
+class ThemedIconContactlessOn extends IconContactlessOn {}
+(ThemedIconContactlessOn as any) = withTheme(IconContactlessOn);
+export default ThemedIconContactlessOn;

--- a/src/icon/entity/contactless/contactless.tsx
+++ b/src/icon/entity/contactless/contactless.tsx
@@ -18,4 +18,6 @@ class IconContactless extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconContactless);
+class ThemedIconContactless extends IconContactless {}
+(ThemedIconContactless as any) = withTheme(IconContactless);
+export default ThemedIconContactless;

--- a/src/icon/entity/directions/directions.tsx
+++ b/src/icon/entity/directions/directions.tsx
@@ -18,4 +18,6 @@ class IconDirections extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDirections);
+class ThemedIconDirections extends IconDirections {}
+(ThemedIconDirections as any) = withTheme(IconDirections);
+export default ThemedIconDirections;

--- a/src/icon/entity/discount/discount.tsx
+++ b/src/icon/entity/discount/discount.tsx
@@ -18,4 +18,6 @@ class IconDiscount extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDiscount);
+class ThemedIconDiscount extends IconDiscount {}
+(ThemedIconDiscount as any) = withTheme(IconDiscount);
+export default ThemedIconDiscount;

--- a/src/icon/entity/draft/draft.tsx
+++ b/src/icon/entity/draft/draft.tsx
@@ -18,4 +18,6 @@ class IconDraft extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDraft);
+class ThemedIconDraft extends IconDraft {}
+(ThemedIconDraft as any) = withTheme(IconDraft);
+export default ThemedIconDraft;

--- a/src/icon/entity/emoney/emoney.tsx
+++ b/src/icon/entity/emoney/emoney.tsx
@@ -18,4 +18,6 @@ class IconEmoney extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconEmoney);
+class ThemedIconEmoney extends IconEmoney {}
+(ThemedIconEmoney as any) = withTheme(IconEmoney);
+export default ThemedIconEmoney;

--- a/src/icon/entity/fault/fault.tsx
+++ b/src/icon/entity/fault/fault.tsx
@@ -18,4 +18,6 @@ class IconFault extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFault);
+class ThemedIconFault extends IconFault {}
+(ThemedIconFault as any) = withTheme(IconFault);
+export default ThemedIconFault;

--- a/src/icon/entity/fingerprint/fingerprint.tsx
+++ b/src/icon/entity/fingerprint/fingerprint.tsx
@@ -18,4 +18,6 @@ class IconFingerprint extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFingerprint);
+class ThemedIconFingerprint extends IconFingerprint {}
+(ThemedIconFingerprint as any) = withTheme(IconFingerprint);
+export default ThemedIconFingerprint;

--- a/src/icon/entity/history/history.tsx
+++ b/src/icon/entity/history/history.tsx
@@ -18,4 +18,6 @@ class IconHistory extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconHistory);
+class ThemedIconHistory extends IconHistory {}
+(ThemedIconHistory as any) = withTheme(IconHistory);
+export default ThemedIconHistory;

--- a/src/icon/entity/hold/hold.tsx
+++ b/src/icon/entity/hold/hold.tsx
@@ -18,4 +18,6 @@ class IconHold extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconHold);
+class ThemedIconHold extends IconHold {}
+(ThemedIconHold as any) = withTheme(IconHold);
+export default ThemedIconHold;

--- a/src/icon/entity/inbox/inbox.tsx
+++ b/src/icon/entity/inbox/inbox.tsx
@@ -18,4 +18,6 @@ class IconInbox extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconInbox);
+class ThemedIconInbox extends IconInbox {}
+(ThemedIconInbox as any) = withTheme(IconInbox);
+export default ThemedIconInbox;

--- a/src/icon/entity/internet/internet.tsx
+++ b/src/icon/entity/internet/internet.tsx
@@ -18,4 +18,6 @@ class IconInternet extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconInternet);
+class ThemedIconInternet extends IconInternet {}
+(ThemedIconInternet as any) = withTheme(IconInternet);
+export default ThemedIconInternet;

--- a/src/icon/entity/keyboard-hide/keyboard-hide.tsx
+++ b/src/icon/entity/keyboard-hide/keyboard-hide.tsx
@@ -18,4 +18,6 @@ class IconKeyboardHide extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconKeyboardHide);
+class ThemedIconKeyboardHide extends IconKeyboardHide {}
+(ThemedIconKeyboardHide as any) = withTheme(IconKeyboardHide);
+export default ThemedIconKeyboardHide;

--- a/src/icon/entity/keyboard/keyboard.tsx
+++ b/src/icon/entity/keyboard/keyboard.tsx
@@ -18,4 +18,6 @@ class IconKeyboard extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconKeyboard);
+class ThemedIconKeyboard extends IconKeyboard {}
+(ThemedIconKeyboard as any) = withTheme(IconKeyboard);
+export default ThemedIconKeyboard;

--- a/src/icon/entity/manager/manager.tsx
+++ b/src/icon/entity/manager/manager.tsx
@@ -18,4 +18,6 @@ class IconManager extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconManager);
+class ThemedIconManager extends IconManager {}
+(ThemedIconManager as any) = withTheme(IconManager);
+export default ThemedIconManager;

--- a/src/icon/entity/message/message.tsx
+++ b/src/icon/entity/message/message.tsx
@@ -18,4 +18,6 @@ class IconMessage extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMessage);
+class ThemedIconMessage extends IconMessage {}
+(ThemedIconMessage as any) = withTheme(IconMessage);
+export default ThemedIconMessage;

--- a/src/icon/entity/metro/metro.tsx
+++ b/src/icon/entity/metro/metro.tsx
@@ -18,4 +18,6 @@ class IconMetro extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMetro);
+class ThemedIconMetro extends IconMetro {}
+(ThemedIconMetro as any) = withTheme(IconMetro);
+export default ThemedIconMetro;

--- a/src/icon/entity/mobile-android/mobile-android.tsx
+++ b/src/icon/entity/mobile-android/mobile-android.tsx
@@ -18,4 +18,6 @@ class IconMobileAndroid extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMobileAndroid);
+class ThemedIconMobileAndroid extends IconMobileAndroid {}
+(ThemedIconMobileAndroid as any) = withTheme(IconMobileAndroid);
+export default ThemedIconMobileAndroid;

--- a/src/icon/entity/mobile-ios/mobile-ios.tsx
+++ b/src/icon/entity/mobile-ios/mobile-ios.tsx
@@ -18,4 +18,6 @@ class IconMobileIos extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMobileIos);
+class ThemedIconMobileIos extends IconMobileIos {}
+(ThemedIconMobileIos as any) = withTheme(IconMobileIos);
+export default ThemedIconMobileIos;

--- a/src/icon/entity/mobile/mobile.tsx
+++ b/src/icon/entity/mobile/mobile.tsx
@@ -18,4 +18,6 @@ class IconMobile extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMobile);
+class ThemedIconMobile extends IconMobile {}
+(ThemedIconMobile as any) = withTheme(IconMobile);
+export default ThemedIconMobile;

--- a/src/icon/entity/moneybox/moneybox.tsx
+++ b/src/icon/entity/moneybox/moneybox.tsx
@@ -18,4 +18,6 @@ class IconMoneybox extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMoneybox);
+class ThemedIconMoneybox extends IconMoneybox {}
+(ThemedIconMoneybox as any) = withTheme(IconMoneybox);
+export default ThemedIconMoneybox;

--- a/src/icon/entity/mypayments/mypayments.tsx
+++ b/src/icon/entity/mypayments/mypayments.tsx
@@ -18,4 +18,6 @@ class IconMypayments extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMypayments);
+class ThemedIconMypayments extends IconMypayments {}
+(ThemedIconMypayments as any) = withTheme(IconMypayments);
+export default ThemedIconMypayments;

--- a/src/icon/entity/news/news.tsx
+++ b/src/icon/entity/news/news.tsx
@@ -18,4 +18,6 @@ class IconNews extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNews);
+class ThemedIconNews extends IconNews {}
+(ThemedIconNews as any) = withTheme(IconNews);
+export default ThemedIconNews;

--- a/src/icon/entity/notification-badge/notification-badge.tsx
+++ b/src/icon/entity/notification-badge/notification-badge.tsx
@@ -18,4 +18,6 @@ class IconNotificationBadge extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNotificationBadge);
+class ThemedIconNotificationBadge extends IconNotificationBadge {}
+(ThemedIconNotificationBadge as any) = withTheme(IconNotificationBadge);
+export default ThemedIconNotificationBadge;

--- a/src/icon/entity/notifications/notifications.tsx
+++ b/src/icon/entity/notifications/notifications.tsx
@@ -18,4 +18,6 @@ class IconNotifications extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconNotifications);
+class ThemedIconNotifications extends IconNotifications {}
+(ThemedIconNotifications as any) = withTheme(IconNotifications);
+export default ThemedIconNotifications;

--- a/src/icon/entity/office/office.tsx
+++ b/src/icon/entity/office/office.tsx
@@ -18,4 +18,6 @@ class IconOffice extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconOffice);
+class ThemedIconOffice extends IconOffice {}
+(ThemedIconOffice as any) = withTheme(IconOffice);
+export default ThemedIconOffice;

--- a/src/icon/entity/person/person.tsx
+++ b/src/icon/entity/person/person.tsx
@@ -18,4 +18,6 @@ class IconPerson extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPerson);
+class ThemedIconPerson extends IconPerson {}
+(ThemedIconPerson as any) = withTheme(IconPerson);
+export default ThemedIconPerson;

--- a/src/icon/entity/photo/photo.tsx
+++ b/src/icon/entity/photo/photo.tsx
@@ -18,4 +18,6 @@ class IconPhoto extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPhoto);
+class ThemedIconPhoto extends IconPhoto {}
+(ThemedIconPhoto as any) = withTheme(IconPhoto);
+export default ThemedIconPhoto;

--- a/src/icon/entity/pillow/pillow.tsx
+++ b/src/icon/entity/pillow/pillow.tsx
@@ -18,4 +18,6 @@ class IconPillow extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPillow);
+class ThemedIconPillow extends IconPillow {}
+(ThemedIconPillow as any) = withTheme(IconPillow);
+export default ThemedIconPillow;

--- a/src/icon/entity/predictions/predictions.tsx
+++ b/src/icon/entity/predictions/predictions.tsx
@@ -18,4 +18,6 @@ class IconPredictions extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPredictions);
+class ThemedIconPredictions extends IconPredictions {}
+(ThemedIconPredictions as any) = withTheme(IconPredictions);
+export default ThemedIconPredictions;

--- a/src/icon/entity/present/present.tsx
+++ b/src/icon/entity/present/present.tsx
@@ -18,4 +18,6 @@ class IconPresent extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPresent);
+class ThemedIconPresent extends IconPresent {}
+(ThemedIconPresent as any) = withTheme(IconPresent);
+export default ThemedIconPresent;

--- a/src/icon/entity/qr/qr.tsx
+++ b/src/icon/entity/qr/qr.tsx
@@ -18,4 +18,6 @@ class IconQr extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconQr);
+class ThemedIconQr extends IconQr {}
+(ThemedIconQr as any) = withTheme(IconQr);
+export default ThemedIconQr;

--- a/src/icon/entity/registry/registry.tsx
+++ b/src/icon/entity/registry/registry.tsx
@@ -18,4 +18,6 @@ class IconRegistry extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconRegistry);
+class ThemedIconRegistry extends IconRegistry {}
+(ThemedIconRegistry as any) = withTheme(IconRegistry);
+export default ThemedIconRegistry;

--- a/src/icon/entity/security/security.tsx
+++ b/src/icon/entity/security/security.tsx
@@ -18,4 +18,6 @@ class IconSecurity extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSecurity);
+class ThemedIconSecurity extends IconSecurity {}
+(ThemedIconSecurity as any) = withTheme(IconSecurity);
+export default ThemedIconSecurity;

--- a/src/icon/entity/site/site.tsx
+++ b/src/icon/entity/site/site.tsx
@@ -18,4 +18,6 @@ class IconSite extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSite);
+class ThemedIconSite extends IconSite {}
+(ThemedIconSite as any) = withTheme(IconSite);
+export default ThemedIconSite;

--- a/src/icon/entity/sixty/sixty.tsx
+++ b/src/icon/entity/sixty/sixty.tsx
@@ -18,4 +18,6 @@ class IconSixty extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSixty);
+class ThemedIconSixty extends IconSixty {}
+(ThemedIconSixty as any) = withTheme(IconSixty);
+export default ThemedIconSixty;

--- a/src/icon/entity/templates/templates.tsx
+++ b/src/icon/entity/templates/templates.tsx
@@ -18,4 +18,6 @@ class IconTemplates extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTemplates);
+class ThemedIconTemplates extends IconTemplates {}
+(ThemedIconTemplates as any) = withTheme(IconTemplates);
+export default ThemedIconTemplates;

--- a/src/icon/entity/todo/todo.tsx
+++ b/src/icon/entity/todo/todo.tsx
@@ -18,4 +18,6 @@ class IconTodo extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTodo);
+class ThemedIconTodo extends IconTodo {}
+(ThemedIconTodo as any) = withTheme(IconTodo);
+export default ThemedIconTodo;

--- a/src/icon/entity/waiting/waiting.tsx
+++ b/src/icon/entity/waiting/waiting.tsx
@@ -18,4 +18,6 @@ class IconWaiting extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconWaiting);
+class ThemedIconWaiting extends IconWaiting {}
+(ThemedIconWaiting as any) = withTheme(IconWaiting);
+export default ThemedIconWaiting;

--- a/src/icon/file/account-euro/account-euro.tsx
+++ b/src/icon/file/account-euro/account-euro.tsx
@@ -18,4 +18,6 @@ class IconAccountEuro extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAccountEuro);
+class ThemedIconAccountEuro extends IconAccountEuro {}
+(ThemedIconAccountEuro as any) = withTheme(IconAccountEuro);
+export default ThemedIconAccountEuro;

--- a/src/icon/file/account-info/account-info.tsx
+++ b/src/icon/file/account-info/account-info.tsx
@@ -18,4 +18,6 @@ class IconAccountInfo extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAccountInfo);
+class ThemedIconAccountInfo extends IconAccountInfo {}
+(ThemedIconAccountInfo as any) = withTheme(IconAccountInfo);
+export default ThemedIconAccountInfo;

--- a/src/icon/file/account-rub/account-rub.tsx
+++ b/src/icon/file/account-rub/account-rub.tsx
@@ -18,4 +18,6 @@ class IconAccountRub extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAccountRub);
+class ThemedIconAccountRub extends IconAccountRub {}
+(ThemedIconAccountRub as any) = withTheme(IconAccountRub);
+export default ThemedIconAccountRub;

--- a/src/icon/file/account-text/account-text.tsx
+++ b/src/icon/file/account-text/account-text.tsx
@@ -18,4 +18,6 @@ class IconAccountText extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAccountText);
+class ThemedIconAccountText extends IconAccountText {}
+(ThemedIconAccountText as any) = withTheme(IconAccountText);
+export default ThemedIconAccountText;

--- a/src/icon/file/account-usd/account-usd.tsx
+++ b/src/icon/file/account-usd/account-usd.tsx
@@ -18,4 +18,6 @@ class IconAccountUsd extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAccountUsd);
+class ThemedIconAccountUsd extends IconAccountUsd {}
+(ThemedIconAccountUsd as any) = withTheme(IconAccountUsd);
+export default ThemedIconAccountUsd;

--- a/src/icon/file/account/account.tsx
+++ b/src/icon/file/account/account.tsx
@@ -18,4 +18,6 @@ class IconAccount extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAccount);
+class ThemedIconAccount extends IconAccount {}
+(ThemedIconAccount as any) = withTheme(IconAccount);
+export default ThemedIconAccount;

--- a/src/icon/file/format-1c/format-1c.tsx
+++ b/src/icon/file/format-1c/format-1c.tsx
@@ -18,4 +18,6 @@ class IconFormat1c extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormat1c);
+class ThemedIconFormat1c extends IconFormat1c {}
+(ThemedIconFormat1c as any) = withTheme(IconFormat1c);
+export default ThemedIconFormat1c;

--- a/src/icon/file/format-attach/format-attach.tsx
+++ b/src/icon/file/format-attach/format-attach.tsx
@@ -18,4 +18,6 @@ class IconFormatAttach extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatAttach);
+class ThemedIconFormatAttach extends IconFormatAttach {}
+(ThemedIconFormatAttach as any) = withTheme(IconFormatAttach);
+export default ThemedIconFormatAttach;

--- a/src/icon/file/format-csv/format-csv.tsx
+++ b/src/icon/file/format-csv/format-csv.tsx
@@ -18,4 +18,6 @@ class IconFormatCsv extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatCsv);
+class ThemedIconFormatCsv extends IconFormatCsv {}
+(ThemedIconFormatCsv as any) = withTheme(IconFormatCsv);
+export default ThemedIconFormatCsv;

--- a/src/icon/file/format-default/format-default.tsx
+++ b/src/icon/file/format-default/format-default.tsx
@@ -18,4 +18,6 @@ class IconFormatDefault extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatDefault);
+class ThemedIconFormatDefault extends IconFormatDefault {}
+(ThemedIconFormatDefault as any) = withTheme(IconFormatDefault);
+export default ThemedIconFormatDefault;

--- a/src/icon/file/format-doc/format-doc.tsx
+++ b/src/icon/file/format-doc/format-doc.tsx
@@ -18,4 +18,6 @@ class IconFormatDoc extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatDoc);
+class ThemedIconFormatDoc extends IconFormatDoc {}
+(ThemedIconFormatDoc as any) = withTheme(IconFormatDoc);
+export default ThemedIconFormatDoc;

--- a/src/icon/file/format-jpg/format-jpg.tsx
+++ b/src/icon/file/format-jpg/format-jpg.tsx
@@ -18,4 +18,6 @@ class IconFormatJpg extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatJpg);
+class ThemedIconFormatJpg extends IconFormatJpg {}
+(ThemedIconFormatJpg as any) = withTheme(IconFormatJpg);
+export default ThemedIconFormatJpg;

--- a/src/icon/file/format-pdf/format-pdf.tsx
+++ b/src/icon/file/format-pdf/format-pdf.tsx
@@ -18,4 +18,6 @@ class IconFormatPdf extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatPdf);
+class ThemedIconFormatPdf extends IconFormatPdf {}
+(ThemedIconFormatPdf as any) = withTheme(IconFormatPdf);
+export default ThemedIconFormatPdf;

--- a/src/icon/file/format-png/format-png.tsx
+++ b/src/icon/file/format-png/format-png.tsx
@@ -18,4 +18,6 @@ class IconFormatPng extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatPng);
+class ThemedIconFormatPng extends IconFormatPng {}
+(ThemedIconFormatPng as any) = withTheme(IconFormatPng);
+export default ThemedIconFormatPng;

--- a/src/icon/file/format-ppt/format-ppt.tsx
+++ b/src/icon/file/format-ppt/format-ppt.tsx
@@ -18,4 +18,6 @@ class IconFormatPpt extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatPpt);
+class ThemedIconFormatPpt extends IconFormatPpt {}
+(ThemedIconFormatPpt as any) = withTheme(IconFormatPpt);
+export default ThemedIconFormatPpt;

--- a/src/icon/file/format-rar/format-rar.tsx
+++ b/src/icon/file/format-rar/format-rar.tsx
@@ -18,4 +18,6 @@ class IconFormatRar extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatRar);
+class ThemedIconFormatRar extends IconFormatRar {}
+(ThemedIconFormatRar as any) = withTheme(IconFormatRar);
+export default ThemedIconFormatRar;

--- a/src/icon/file/format-sketch/format-sketch.tsx
+++ b/src/icon/file/format-sketch/format-sketch.tsx
@@ -18,4 +18,6 @@ class IconFormatSketch extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatSketch);
+class ThemedIconFormatSketch extends IconFormatSketch {}
+(ThemedIconFormatSketch as any) = withTheme(IconFormatSketch);
+export default ThemedIconFormatSketch;

--- a/src/icon/file/format-svg/format-svg.tsx
+++ b/src/icon/file/format-svg/format-svg.tsx
@@ -18,4 +18,6 @@ class IconFormatSvg extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatSvg);
+class ThemedIconFormatSvg extends IconFormatSvg {}
+(ThemedIconFormatSvg as any) = withTheme(IconFormatSvg);
+export default ThemedIconFormatSvg;

--- a/src/icon/file/format-txt/format-txt.tsx
+++ b/src/icon/file/format-txt/format-txt.tsx
@@ -18,4 +18,6 @@ class IconFormatTxt extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatTxt);
+class ThemedIconFormatTxt extends IconFormatTxt {}
+(ThemedIconFormatTxt as any) = withTheme(IconFormatTxt);
+export default ThemedIconFormatTxt;

--- a/src/icon/file/format-unknown/format-unknown.tsx
+++ b/src/icon/file/format-unknown/format-unknown.tsx
@@ -18,4 +18,6 @@ class IconFormatUnknown extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatUnknown);
+class ThemedIconFormatUnknown extends IconFormatUnknown {}
+(ThemedIconFormatUnknown as any) = withTheme(IconFormatUnknown);
+export default ThemedIconFormatUnknown;

--- a/src/icon/file/format-xls/format-xls.tsx
+++ b/src/icon/file/format-xls/format-xls.tsx
@@ -18,4 +18,6 @@ class IconFormatXls extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatXls);
+class ThemedIconFormatXls extends IconFormatXls {}
+(ThemedIconFormatXls as any) = withTheme(IconFormatXls);
+export default ThemedIconFormatXls;

--- a/src/icon/file/format-xml/format-xml.tsx
+++ b/src/icon/file/format-xml/format-xml.tsx
@@ -18,4 +18,6 @@ class IconFormatXml extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatXml);
+class ThemedIconFormatXml extends IconFormatXml {}
+(ThemedIconFormatXml as any) = withTheme(IconFormatXml);
+export default ThemedIconFormatXml;

--- a/src/icon/file/format-zip/format-zip.tsx
+++ b/src/icon/file/format-zip/format-zip.tsx
@@ -18,4 +18,6 @@ class IconFormatZip extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFormatZip);
+class ThemedIconFormatZip extends IconFormatZip {}
+(ThemedIconFormatZip as any) = withTheme(IconFormatZip);
+export default ThemedIconFormatZip;

--- a/src/icon/icon.tsx
+++ b/src/icon/icon.tsx
@@ -81,4 +81,6 @@ export class Icon extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(Icon);
+class ThemedIcon extends Icon {}
+(ThemedIcon as any) = withTheme(Icon);
+export default ThemedIcon;

--- a/src/icon/ui/android-reorder/android-reorder.tsx
+++ b/src/icon/ui/android-reorder/android-reorder.tsx
@@ -18,4 +18,6 @@ class IconAndroidReorder extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAndroidReorder);
+class ThemedIconAndroidReorder extends IconAndroidReorder {}
+(ThemedIconAndroidReorder as any) = withTheme(IconAndroidReorder);
+export default ThemedIconAndroidReorder;

--- a/src/icon/ui/arrow-bottom/arrow-bottom.tsx
+++ b/src/icon/ui/arrow-bottom/arrow-bottom.tsx
@@ -18,4 +18,6 @@ class IconArrowBottom extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowBottom);
+class ThemedIconArrowBottom extends IconArrowBottom {}
+(ThemedIconArrowBottom as any) = withTheme(IconArrowBottom);
+export default ThemedIconArrowBottom;

--- a/src/icon/ui/arrow-collapse/arrow-collapse.tsx
+++ b/src/icon/ui/arrow-collapse/arrow-collapse.tsx
@@ -18,4 +18,6 @@ class IconArrowCollapse extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowCollapse);
+class ThemedIconArrowCollapse extends IconArrowCollapse {}
+(ThemedIconArrowCollapse as any) = withTheme(IconArrowCollapse);
+export default ThemedIconArrowCollapse;

--- a/src/icon/ui/arrow-double/arrow-double.tsx
+++ b/src/icon/ui/arrow-double/arrow-double.tsx
@@ -18,4 +18,6 @@ class IconArrowDouble extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowDouble);
+class ThemedIconArrowDouble extends IconArrowDouble {}
+(ThemedIconArrowDouble as any) = withTheme(IconArrowDouble);
+export default ThemedIconArrowDouble;

--- a/src/icon/ui/arrow-down/arrow-down.tsx
+++ b/src/icon/ui/arrow-down/arrow-down.tsx
@@ -18,4 +18,6 @@ class IconArrowDown extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowDown);
+class ThemedIconArrowDown extends IconArrowDown {}
+(ThemedIconArrowDown as any) = withTheme(IconArrowDown);
+export default ThemedIconArrowDown;

--- a/src/icon/ui/arrow-expand/arrow-expand.tsx
+++ b/src/icon/ui/arrow-expand/arrow-expand.tsx
@@ -18,4 +18,6 @@ class IconArrowExpand extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowExpand);
+class ThemedIconArrowExpand extends IconArrowExpand {}
+(ThemedIconArrowExpand as any) = withTheme(IconArrowExpand);
+export default ThemedIconArrowExpand;

--- a/src/icon/ui/arrow-left-double/arrow-left-double.tsx
+++ b/src/icon/ui/arrow-left-double/arrow-left-double.tsx
@@ -18,4 +18,6 @@ class IconArrowLeftDouble extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowLeftDouble);
+class ThemedIconArrowLeftDouble extends IconArrowLeftDouble {}
+(ThemedIconArrowLeftDouble as any) = withTheme(IconArrowLeftDouble);
+export default ThemedIconArrowLeftDouble;

--- a/src/icon/ui/arrow-left/arrow-left.tsx
+++ b/src/icon/ui/arrow-left/arrow-left.tsx
@@ -18,4 +18,6 @@ class IconArrowLeft extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowLeft);
+class ThemedIconArrowLeft extends IconArrowLeft {}
+(ThemedIconArrowLeft as any) = withTheme(IconArrowLeft);
+export default ThemedIconArrowLeft;

--- a/src/icon/ui/arrow-right-double/arrow-right-double.tsx
+++ b/src/icon/ui/arrow-right-double/arrow-right-double.tsx
@@ -18,4 +18,6 @@ class IconArrowRightDouble extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowRightDouble);
+class ThemedIconArrowRightDouble extends IconArrowRightDouble {}
+(ThemedIconArrowRightDouble as any) = withTheme(IconArrowRightDouble);
+export default ThemedIconArrowRightDouble;

--- a/src/icon/ui/arrow-right/arrow-right.tsx
+++ b/src/icon/ui/arrow-right/arrow-right.tsx
@@ -18,4 +18,6 @@ class IconArrowRight extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowRight);
+class ThemedIconArrowRight extends IconArrowRight {}
+(ThemedIconArrowRight as any) = withTheme(IconArrowRight);
+export default ThemedIconArrowRight;

--- a/src/icon/ui/arrow-top/arrow-top.tsx
+++ b/src/icon/ui/arrow-top/arrow-top.tsx
@@ -18,4 +18,6 @@ class IconArrowTop extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowTop);
+class ThemedIconArrowTop extends IconArrowTop {}
+(ThemedIconArrowTop as any) = withTheme(IconArrowTop);
+export default ThemedIconArrowTop;

--- a/src/icon/ui/arrow-up/arrow-up.tsx
+++ b/src/icon/ui/arrow-up/arrow-up.tsx
@@ -18,4 +18,6 @@ class IconArrowUp extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconArrowUp);
+class ThemedIconArrowUp extends IconArrowUp {}
+(ThemedIconArrowUp as any) = withTheme(IconArrowUp);
+export default ThemedIconArrowUp;

--- a/src/icon/ui/attention-mark/attention-mark.tsx
+++ b/src/icon/ui/attention-mark/attention-mark.tsx
@@ -18,4 +18,6 @@ class IconAttentionMark extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAttentionMark);
+class ThemedIconAttentionMark extends IconAttentionMark {}
+(ThemedIconAttentionMark as any) = withTheme(IconAttentionMark);
+export default ThemedIconAttentionMark;

--- a/src/icon/ui/attention/attention.tsx
+++ b/src/icon/ui/attention/attention.tsx
@@ -18,4 +18,6 @@ class IconAttention extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAttention);
+class ThemedIconAttention extends IconAttention {}
+(ThemedIconAttention as any) = withTheme(IconAttention);
+export default ThemedIconAttention;

--- a/src/icon/ui/autopayment/autopayment.tsx
+++ b/src/icon/ui/autopayment/autopayment.tsx
@@ -18,4 +18,6 @@ class IconAutopayment extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconAutopayment);
+class ThemedIconAutopayment extends IconAutopayment {}
+(ThemedIconAutopayment as any) = withTheme(IconAutopayment);
+export default ThemedIconAutopayment;

--- a/src/icon/ui/backspace/backspace.tsx
+++ b/src/icon/ui/backspace/backspace.tsx
@@ -18,4 +18,6 @@ class IconBackspace extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBackspace);
+class ThemedIconBackspace extends IconBackspace {}
+(ThemedIconBackspace as any) = withTheme(IconBackspace);
+export default ThemedIconBackspace;

--- a/src/icon/ui/buy/buy.tsx
+++ b/src/icon/ui/buy/buy.tsx
@@ -18,4 +18,6 @@ class IconBuy extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconBuy);
+class ThemedIconBuy extends IconBuy {}
+(ThemedIconBuy as any) = withTheme(IconBuy);
+export default ThemedIconBuy;

--- a/src/icon/ui/cancel/cancel.tsx
+++ b/src/icon/ui/cancel/cancel.tsx
@@ -18,4 +18,6 @@ class IconCancel extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCancel);
+class ThemedIconCancel extends IconCancel {}
+(ThemedIconCancel as any) = withTheme(IconCancel);
+export default ThemedIconCancel;

--- a/src/icon/ui/check-bold/check-bold.tsx
+++ b/src/icon/ui/check-bold/check-bold.tsx
@@ -18,4 +18,6 @@ class IconCheckBold extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCheckBold);
+class ThemedIconCheckBold extends IconCheckBold {}
+(ThemedIconCheckBold as any) = withTheme(IconCheckBold);
+export default ThemedIconCheckBold;

--- a/src/icon/ui/check-chat/check-chat.tsx
+++ b/src/icon/ui/check-chat/check-chat.tsx
@@ -18,4 +18,6 @@ class IconCheckChat extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCheckChat);
+class ThemedIconCheckChat extends IconCheckChat {}
+(ThemedIconCheckChat as any) = withTheme(IconCheckChat);
+export default ThemedIconCheckChat;

--- a/src/icon/ui/check-indeterminate/check-indeterminate.tsx
+++ b/src/icon/ui/check-indeterminate/check-indeterminate.tsx
@@ -18,4 +18,6 @@ class IconCheckIndeterminate extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCheckIndeterminate);
+class ThemedIconCheckIndeterminate extends IconCheckIndeterminate {}
+(ThemedIconCheckIndeterminate as any) = withTheme(IconCheckIndeterminate);
+export default ThemedIconCheckIndeterminate;

--- a/src/icon/ui/check/check.tsx
+++ b/src/icon/ui/check/check.tsx
@@ -18,4 +18,6 @@ class IconCheck extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCheck);
+class ThemedIconCheck extends IconCheck {}
+(ThemedIconCheck as any) = withTheme(IconCheck);
+export default ThemedIconCheck;

--- a/src/icon/ui/checkbox-disabled/checkbox-disabled.tsx
+++ b/src/icon/ui/checkbox-disabled/checkbox-disabled.tsx
@@ -18,4 +18,6 @@ class IconCheckboxDisabled extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCheckboxDisabled);
+class ThemedIconCheckboxDisabled extends IconCheckboxDisabled {}
+(ThemedIconCheckboxDisabled as any) = withTheme(IconCheckboxDisabled);
+export default ThemedIconCheckboxDisabled;

--- a/src/icon/ui/chevron-right/chevron-right.tsx
+++ b/src/icon/ui/chevron-right/chevron-right.tsx
@@ -18,4 +18,6 @@ class IconChevronRight extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconChevronRight);
+class ThemedIconChevronRight extends IconChevronRight {}
+(ThemedIconChevronRight as any) = withTheme(IconChevronRight);
+export default ThemedIconChevronRight;

--- a/src/icon/ui/close-circle/close-circle.tsx
+++ b/src/icon/ui/close-circle/close-circle.tsx
@@ -18,4 +18,6 @@ class IconCloseCircle extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconCloseCircle);
+class ThemedIconCloseCircle extends IconCloseCircle {}
+(ThemedIconCloseCircle as any) = withTheme(IconCloseCircle);
+export default ThemedIconCloseCircle;

--- a/src/icon/ui/close/close.tsx
+++ b/src/icon/ui/close/close.tsx
@@ -18,4 +18,6 @@ class IconClose extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconClose);
+class ThemedIconClose extends IconClose {}
+(ThemedIconClose as any) = withTheme(IconClose);
+export default ThemedIconClose;

--- a/src/icon/ui/done/done.tsx
+++ b/src/icon/ui/done/done.tsx
@@ -18,4 +18,6 @@ class IconDone extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDone);
+class ThemedIconDone extends IconDone {}
+(ThemedIconDone as any) = withTheme(IconDone);
+export default ThemedIconDone;

--- a/src/icon/ui/down/down.tsx
+++ b/src/icon/ui/down/down.tsx
@@ -18,4 +18,6 @@ class IconDown extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconDown);
+class ThemedIconDown extends IconDown {}
+(ThemedIconDown as any) = withTheme(IconDown);
+export default ThemedIconDown;

--- a/src/icon/ui/error/error.tsx
+++ b/src/icon/ui/error/error.tsx
@@ -18,4 +18,6 @@ class IconError extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconError);
+class ThemedIconError extends IconError {}
+(ThemedIconError as any) = withTheme(IconError);
+export default ThemedIconError;

--- a/src/icon/ui/exchange/exchange.tsx
+++ b/src/icon/ui/exchange/exchange.tsx
@@ -18,4 +18,6 @@ class IconExchange extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconExchange);
+class ThemedIconExchange extends IconExchange {}
+(ThemedIconExchange as any) = withTheme(IconExchange);
+export default ThemedIconExchange;

--- a/src/icon/ui/expand-down/expand-down.tsx
+++ b/src/icon/ui/expand-down/expand-down.tsx
@@ -18,4 +18,6 @@ class IconExpandDown extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconExpandDown);
+class ThemedIconExpandDown extends IconExpandDown {}
+(ThemedIconExpandDown as any) = withTheme(IconExpandDown);
+export default ThemedIconExpandDown;

--- a/src/icon/ui/fail/fail.tsx
+++ b/src/icon/ui/fail/fail.tsx
@@ -18,4 +18,6 @@ class IconFail extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFail);
+class ThemedIconFail extends IconFail {}
+(ThemedIconFail as any) = withTheme(IconFail);
+export default ThemedIconFail;

--- a/src/icon/ui/favorite/favorite.tsx
+++ b/src/icon/ui/favorite/favorite.tsx
@@ -18,4 +18,6 @@ class IconFavorite extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFavorite);
+class ThemedIconFavorite extends IconFavorite {}
+(ThemedIconFavorite as any) = withTheme(IconFavorite);
+export default ThemedIconFavorite;

--- a/src/icon/ui/feature/feature.tsx
+++ b/src/icon/ui/feature/feature.tsx
@@ -18,4 +18,6 @@ class IconFeature extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFeature);
+class ThemedIconFeature extends IconFeature {}
+(ThemedIconFeature as any) = withTheme(IconFeature);
+export default ThemedIconFeature;

--- a/src/icon/ui/finger-pointing/finger-pointing.tsx
+++ b/src/icon/ui/finger-pointing/finger-pointing.tsx
@@ -18,4 +18,6 @@ class IconFingerPointing extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconFingerPointing);
+class ThemedIconFingerPointing extends IconFingerPointing {}
+(ThemedIconFingerPointing as any) = withTheme(IconFingerPointing);
+export default ThemedIconFingerPointing;

--- a/src/icon/ui/geolocation-map/geolocation-map.tsx
+++ b/src/icon/ui/geolocation-map/geolocation-map.tsx
@@ -18,4 +18,6 @@ class IconGeolocationMap extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconGeolocationMap);
+class ThemedIconGeolocationMap extends IconGeolocationMap {}
+(ThemedIconGeolocationMap as any) = withTheme(IconGeolocationMap);
+export default ThemedIconGeolocationMap;

--- a/src/icon/ui/geolocation/geolocation.tsx
+++ b/src/icon/ui/geolocation/geolocation.tsx
@@ -18,4 +18,6 @@ class IconGeolocation extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconGeolocation);
+class ThemedIconGeolocation extends IconGeolocation {}
+(ThemedIconGeolocation as any) = withTheme(IconGeolocation);
+export default ThemedIconGeolocation;

--- a/src/icon/ui/help-filled/help-filled.tsx
+++ b/src/icon/ui/help-filled/help-filled.tsx
@@ -18,4 +18,6 @@ class IconHelpFilled extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconHelpFilled);
+class ThemedIconHelpFilled extends IconHelpFilled {}
+(ThemedIconHelpFilled as any) = withTheme(IconHelpFilled);
+export default ThemedIconHelpFilled;

--- a/src/icon/ui/help/help.tsx
+++ b/src/icon/ui/help/help.tsx
@@ -18,4 +18,6 @@ class IconHelp extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconHelp);
+class ThemedIconHelp extends IconHelp {}
+(ThemedIconHelp as any) = withTheme(IconHelp);
+export default ThemedIconHelp;

--- a/src/icon/ui/home/home.tsx
+++ b/src/icon/ui/home/home.tsx
@@ -18,4 +18,6 @@ class IconHome extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconHome);
+class ThemedIconHome extends IconHome {}
+(ThemedIconHome as any) = withTheme(IconHome);
+export default ThemedIconHome;

--- a/src/icon/ui/info/info.tsx
+++ b/src/icon/ui/info/info.tsx
@@ -18,4 +18,6 @@ class IconInfo extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconInfo);
+class ThemedIconInfo extends IconInfo {}
+(ThemedIconInfo as any) = withTheme(IconInfo);
+export default ThemedIconInfo;

--- a/src/icon/ui/left/left.tsx
+++ b/src/icon/ui/left/left.tsx
@@ -18,4 +18,6 @@ class IconLeft extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconLeft);
+class ThemedIconLeft extends IconLeft {}
+(ThemedIconLeft as any) = withTheme(IconLeft);
+export default ThemedIconLeft;

--- a/src/icon/ui/list/list.tsx
+++ b/src/icon/ui/list/list.tsx
@@ -18,4 +18,6 @@ class IconList extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconList);
+class ThemedIconList extends IconList {}
+(ThemedIconList as any) = withTheme(IconList);
+export default ThemedIconList;

--- a/src/icon/ui/location/location.tsx
+++ b/src/icon/ui/location/location.tsx
@@ -18,4 +18,6 @@ class IconLocation extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconLocation);
+class ThemedIconLocation extends IconLocation {}
+(ThemedIconLocation as any) = withTheme(IconLocation);
+export default ThemedIconLocation;

--- a/src/icon/ui/metro-map/metro-map.tsx
+++ b/src/icon/ui/metro-map/metro-map.tsx
@@ -18,4 +18,6 @@ class IconMetroMap extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconMetroMap);
+class ThemedIconMetroMap extends IconMetroMap {}
+(ThemedIconMetroMap as any) = withTheme(IconMetroMap);
+export default ThemedIconMetroMap;

--- a/src/icon/ui/ok-filled/ok-filled.tsx
+++ b/src/icon/ui/ok-filled/ok-filled.tsx
@@ -18,4 +18,6 @@ class IconOkFilled extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconOkFilled);
+class ThemedIconOkFilled extends IconOkFilled {}
+(ThemedIconOkFilled as any) = withTheme(IconOkFilled);
+export default ThemedIconOkFilled;

--- a/src/icon/ui/ok/ok.tsx
+++ b/src/icon/ui/ok/ok.tsx
@@ -18,4 +18,6 @@ class IconOk extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconOk);
+class ThemedIconOk extends IconOk {}
+(ThemedIconOk as any) = withTheme(IconOk);
+export default ThemedIconOk;

--- a/src/icon/ui/outside/outside.tsx
+++ b/src/icon/ui/outside/outside.tsx
@@ -18,4 +18,6 @@ class IconOutside extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconOutside);
+class ThemedIconOutside extends IconOutside {}
+(ThemedIconOutside as any) = withTheme(IconOutside);
+export default ThemedIconOutside;

--- a/src/icon/ui/pause/pause.tsx
+++ b/src/icon/ui/pause/pause.tsx
@@ -18,4 +18,6 @@ class IconPause extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPause);
+class ThemedIconPause extends IconPause {}
+(ThemedIconPause as any) = withTheme(IconPause);
+export default ThemedIconPause;

--- a/src/icon/ui/play/play.tsx
+++ b/src/icon/ui/play/play.tsx
@@ -18,4 +18,6 @@ class IconPlay extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconPlay);
+class ThemedIconPlay extends IconPlay {}
+(ThemedIconPlay as any) = withTheme(IconPlay);
+export default ThemedIconPlay;

--- a/src/icon/ui/right/right.tsx
+++ b/src/icon/ui/right/right.tsx
@@ -18,4 +18,6 @@ class IconRight extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconRight);
+class ThemedIconRight extends IconRight {}
+(ThemedIconRight as any) = withTheme(IconRight);
+export default ThemedIconRight;

--- a/src/icon/ui/sell/sell.tsx
+++ b/src/icon/ui/sell/sell.tsx
@@ -18,4 +18,6 @@ class IconSell extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSell);
+class ThemedIconSell extends IconSell {}
+(ThemedIconSell as any) = withTheme(IconSell);
+export default ThemedIconSell;

--- a/src/icon/ui/slider-arrow-double/slider-arrow-double.tsx
+++ b/src/icon/ui/slider-arrow-double/slider-arrow-double.tsx
@@ -18,4 +18,6 @@ class IconSliderArrowDouble extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSliderArrowDouble);
+class ThemedIconSliderArrowDouble extends IconSliderArrowDouble {}
+(ThemedIconSliderArrowDouble as any) = withTheme(IconSliderArrowDouble);
+export default ThemedIconSliderArrowDouble;

--- a/src/icon/ui/star-active/star-active.tsx
+++ b/src/icon/ui/star-active/star-active.tsx
@@ -18,4 +18,6 @@ class IconStarActive extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconStarActive);
+class ThemedIconStarActive extends IconStarActive {}
+(ThemedIconStarActive as any) = withTheme(IconStarActive);
+export default ThemedIconStarActive;

--- a/src/icon/ui/star-inactive/star-inactive.tsx
+++ b/src/icon/ui/star-inactive/star-inactive.tsx
@@ -18,4 +18,6 @@ class IconStarInactive extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconStarInactive);
+class ThemedIconStarInactive extends IconStarInactive {}
+(ThemedIconStarInactive as any) = withTheme(IconStarInactive);
+export default ThemedIconStarInactive;

--- a/src/icon/ui/star/star.tsx
+++ b/src/icon/ui/star/star.tsx
@@ -18,4 +18,6 @@ class IconStar extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconStar);
+class ThemedIconStar extends IconStar {}
+(ThemedIconStar as any) = withTheme(IconStar);
+export default ThemedIconStar;

--- a/src/icon/ui/status-urgent/status-urgent.tsx
+++ b/src/icon/ui/status-urgent/status-urgent.tsx
@@ -18,4 +18,6 @@ class IconStatusUrgent extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconStatusUrgent);
+class ThemedIconStatusUrgent extends IconStatusUrgent {}
+(ThemedIconStatusUrgent as any) = withTheme(IconStatusUrgent);
+export default ThemedIconStatusUrgent;

--- a/src/icon/ui/submit/submit.tsx
+++ b/src/icon/ui/submit/submit.tsx
@@ -18,4 +18,6 @@ class IconSubmit extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSubmit);
+class ThemedIconSubmit extends IconSubmit {}
+(ThemedIconSubmit as any) = withTheme(IconSubmit);
+export default ThemedIconSubmit;

--- a/src/icon/ui/system-back/system-back.tsx
+++ b/src/icon/ui/system-back/system-back.tsx
@@ -18,4 +18,6 @@ class IconSystemBack extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSystemBack);
+class ThemedIconSystemBack extends IconSystemBack {}
+(ThemedIconSystemBack as any) = withTheme(IconSystemBack);
+export default ThemedIconSystemBack;

--- a/src/icon/ui/system-help/system-help.tsx
+++ b/src/icon/ui/system-help/system-help.tsx
@@ -18,4 +18,6 @@ class IconSystemHelp extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSystemHelp);
+class ThemedIconSystemHelp extends IconSystemHelp {}
+(ThemedIconSystemHelp as any) = withTheme(IconSystemHelp);
+export default ThemedIconSystemHelp;

--- a/src/icon/ui/system-hide-arrow/system-hide-arrow.tsx
+++ b/src/icon/ui/system-hide-arrow/system-hide-arrow.tsx
@@ -18,4 +18,6 @@ class IconSystemHideArrow extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconSystemHideArrow);
+class ThemedIconSystemHideArrow extends IconSystemHideArrow {}
+(ThemedIconSystemHideArrow as any) = withTheme(IconSystemHideArrow);
+export default ThemedIconSystemHideArrow;

--- a/src/icon/ui/table/table.tsx
+++ b/src/icon/ui/table/table.tsx
@@ -18,4 +18,6 @@ class IconTable extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTable);
+class ThemedIconTable extends IconTable {}
+(ThemedIconTable as any) = withTheme(IconTable);
+export default ThemedIconTable;

--- a/src/icon/ui/tick/tick.tsx
+++ b/src/icon/ui/tick/tick.tsx
@@ -18,4 +18,6 @@ class IconTick extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconTick);
+class ThemedIconTick extends IconTick {}
+(ThemedIconTick as any) = withTheme(IconTick);
+export default ThemedIconTick;

--- a/src/icon/ui/up/up.tsx
+++ b/src/icon/ui/up/up.tsx
@@ -18,4 +18,6 @@ class IconUp extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconUp);
+class ThemedIconUp extends IconUp {}
+(ThemedIconUp as any) = withTheme(IconUp);
+export default ThemedIconUp;

--- a/src/icon/ui/verifying/verifying.tsx
+++ b/src/icon/ui/verifying/verifying.tsx
@@ -18,4 +18,6 @@ class IconVerifying extends React.PureComponent<IconProps> {
     }
 }
 
-export default withTheme(IconVerifying);
+class ThemedIconVerifying extends IconVerifying {}
+(ThemedIconVerifying as any) = withTheme(IconVerifying);
+export default ThemedIconVerifying;

--- a/src/input-autocomplete/input-autocomplete.tsx
+++ b/src/input-autocomplete/input-autocomplete.tsx
@@ -797,4 +797,6 @@ export class InputAutocomplete extends React.Component<InputAutocompleteProps, I
     }
 }
 
-export default withTheme(InputAutocomplete);
+class ThemedInputAutocomplete extends InputAutocomplete {}
+(ThemedInputAutocomplete as any) = withTheme(InputAutocomplete);
+export default ThemedInputAutocomplete;

--- a/src/input-group/input-group.tsx
+++ b/src/input-group/input-group.tsx
@@ -91,4 +91,6 @@ export class InputGroup extends React.PureComponent<InputGroupProps> {
     }
 }
 
-export default withTheme(InputGroup);
+class ThemedInputGroup extends InputGroup {}
+(ThemedInputGroup as any) = withTheme(InputGroup);
+export default ThemedInputGroup;

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -646,4 +646,6 @@ export class Input extends React.PureComponent<InputProps> {
     }
 }
 
-export default withTheme(Input);
+class ThemedInput extends Input {}
+(ThemedInput as any) = withTheme(Input);
+export default ThemedInput;

--- a/src/intl-phone-input/intl-phone-input.tsx
+++ b/src/intl-phone-input/intl-phone-input.tsx
@@ -360,4 +360,6 @@ export class IntlPhoneInput extends React.PureComponent<IntlPhoneInputProps, Int
     }
 }
 
-export default withTheme(IntlPhoneInput);
+class ThemedIntlPhoneInput extends IntlPhoneInput {}
+(ThemedIntlPhoneInput as any) = withTheme(IntlPhoneInput);
+export default ThemedIntlPhoneInput;

--- a/src/label/label.tsx
+++ b/src/label/label.tsx
@@ -74,4 +74,6 @@ export class Label extends React.PureComponent<LabelProps> {
     }
 }
 
-export default withTheme(Label);
+class ThemedLabel extends Label {}
+(ThemedLabel as any) = withTheme(Label);
+export default ThemedLabel;

--- a/src/link/link.tsx
+++ b/src/link/link.tsx
@@ -281,4 +281,6 @@ export class Link extends React.PureComponent<LinkProps> {
     }
 }
 
-export default withTheme(Link);
+class ThemedLink extends Link {}
+(ThemedLink as any) = withTheme(Link);
+export default ThemedLink;

--- a/src/list-header/list-header.tsx
+++ b/src/list-header/list-header.tsx
@@ -65,4 +65,6 @@ export class ListHeader extends React.PureComponent<ListHeaderProps> {
     }
 }
 
-export default withTheme(ListHeader);
+class ThemedListHeader extends ListHeader {}
+(ThemedListHeader as any) = withTheme(ListHeader);
+export default ThemedListHeader;

--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -99,4 +99,6 @@ export class List extends React.Component<ListProps> {
     }
 }
 
-export default withTheme(List);
+class ThemedList extends List {}
+(ThemedList as any) = withTheme(List);
+export default ThemedList;

--- a/src/menu-item/menu-item.tsx
+++ b/src/menu-item/menu-item.tsx
@@ -294,4 +294,6 @@ export class MenuItem extends React.PureComponent<MenuItemProps> {
     }
 }
 
-export default withTheme(MenuItem);
+class ThemedMenuItem extends MenuItem {}
+(ThemedMenuItem as any) = withTheme(MenuItem);
+export default ThemedMenuItem;

--- a/src/menu/menu.tsx
+++ b/src/menu/menu.tsx
@@ -622,4 +622,6 @@ export class Menu extends React.Component<MenuProps> {
     }
 }
 
-export default withTheme(Menu);
+class ThemedMenu extends Menu {}
+(ThemedMenu as any) = withTheme(Menu);
+export default ThemedMenu;

--- a/src/money-input/money-input.tsx
+++ b/src/money-input/money-input.tsx
@@ -248,4 +248,6 @@ export class MoneyInput extends React.PureComponent<MoneyInputProps, MoneyInputS
     }
 }
 
-export default withTheme(MoneyInput);
+class ThemedMoneyInput extends MoneyInput {}
+(ThemedMoneyInput as any) = withTheme(MoneyInput);
+export default ThemedMoneyInput;

--- a/src/notification/notification.tsx
+++ b/src/notification/notification.tsx
@@ -328,4 +328,6 @@ export class Notification extends React.PureComponent<NotificationProps> {
     }
 }
 
-export default withTheme(Notification);
+class ThemedNotification extends Notification {}
+(ThemedNotification as any) = withTheme(Notification);
+export default ThemedNotification;

--- a/src/paragraph/paragraph.tsx
+++ b/src/paragraph/paragraph.tsx
@@ -67,4 +67,6 @@ export class Paragraph extends React.PureComponent<ParagraphProps> {
     }
 }
 
-export default withTheme(Paragraph);
+class ThemedParagraph extends Paragraph {}
+(ThemedParagraph as any) = withTheme(Paragraph);
+export default ThemedParagraph;

--- a/src/phone-input/phone-input.tsx
+++ b/src/phone-input/phone-input.tsx
@@ -74,4 +74,6 @@ export class PhoneInput extends React.PureComponent<PhoneInputProps> {
     }
 }
 
-export default withTheme(PhoneInput);
+class ThemedPhoneInput extends PhoneInput {}
+(ThemedPhoneInput as any) = withTheme(PhoneInput);
+export default ThemedPhoneInput;

--- a/src/plate/plate.tsx
+++ b/src/plate/plate.tsx
@@ -246,4 +246,6 @@ export class Plate extends React.PureComponent<PlateProps> {
     }
 }
 
-export default withTheme(Plate);
+class ThemedPlate extends Plate {}
+(ThemedPlate as any) = withTheme(Plate);
+export default ThemedPlate;

--- a/src/popup-header/popup-header.tsx
+++ b/src/popup-header/popup-header.tsx
@@ -85,4 +85,6 @@ export class PopupHeader extends React.PureComponent<PopupHeaderProps> {
     }
 }
 
-export default withTheme(PopupHeader);
+class ThemedPopupHeader extends PopupHeader {}
+(ThemedPopupHeader as any) = withTheme(PopupHeader);
+export default ThemedPopupHeader;

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -690,4 +690,6 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     }
 }
 
-export default withTheme(Popup);
+class ThemedPopup extends Popup {}
+(ThemedPopup as any) = withTheme(Popup);
+export default ThemedPopup;

--- a/src/progress-bar/progress-bar.tsx
+++ b/src/progress-bar/progress-bar.tsx
@@ -60,4 +60,6 @@ export class ProgressBar extends React.PureComponent<ProgressBarProps> {
     }
 }
 
-export default withTheme(ProgressBar);
+class ThemedProgressBar extends ProgressBar {}
+(ThemedProgressBar as any) = withTheme(ProgressBar);
+export default ThemedProgressBar;

--- a/src/radio-group/radio-group.tsx
+++ b/src/radio-group/radio-group.tsx
@@ -222,4 +222,6 @@ export class RadioGroup extends React.PureComponent<RadioGroupProps> {
     }
 }
 
-export default withTheme(RadioGroup);
+class ThemedRadioGroup extends RadioGroup {}
+(ThemedRadioGroup as any) = withTheme(RadioGroup);
+export default ThemedRadioGroup;

--- a/src/radio/radio.tsx
+++ b/src/radio/radio.tsx
@@ -340,4 +340,6 @@ export class Radio extends React.PureComponent<RadioProps, RadioState> {
     }
 }
 
-export default withTheme(Radio);
+class ThemedRadio extends Radio {}
+(ThemedRadio as any) = withTheme(Radio);
+export default ThemedRadio;

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -1113,4 +1113,6 @@ export class Select extends React.Component<SelectProps, SelectState> {
     }
 }
 
-export default withTheme(Select);
+class ThemedSelect extends Select {}
+(ThemedSelect as any) = withTheme(Select);
+export default ThemedSelect;

--- a/src/sidebar/sidebar.tsx
+++ b/src/sidebar/sidebar.tsx
@@ -273,4 +273,6 @@ export class Sidebar extends React.PureComponent<SidebarProps> {
     }
 }
 
-export default withTheme(Sidebar);
+class ThemedSidebar extends Sidebar {}
+(ThemedSidebar as any) = withTheme(Sidebar);
+export default ThemedSidebar;

--- a/src/slide-down/slide-down.tsx
+++ b/src/slide-down/slide-down.tsx
@@ -147,4 +147,6 @@ export class SlideDown extends React.PureComponent<SlideDownProps> {
     }
 }
 
-export default withTheme(SlideDown);
+class ThemedSlideDown extends SlideDown {}
+(ThemedSlideDown as any) = withTheme(SlideDown);
+export default ThemedSlideDown;

--- a/src/spin/spin.tsx
+++ b/src/spin/spin.tsx
@@ -65,4 +65,6 @@ export class Spin extends React.PureComponent<SpinProps> {
     }
 }
 
-export default withTheme(Spin);
+class ThemedSpin extends Spin {}
+(ThemedSpin as any) = withTheme(Spin);
+export default ThemedSpin;

--- a/src/tab-item/tab-item.tsx
+++ b/src/tab-item/tab-item.tsx
@@ -21,4 +21,6 @@ export class TabItem extends Link {
     };
 }
 
-export default withTheme(TabItem);
+class ThemedTabItem extends TabItem {}
+(ThemedTabItem as any) = withTheme(TabItem);
+export default ThemedTabItem;

--- a/src/tabs/tabs.tsx
+++ b/src/tabs/tabs.tsx
@@ -68,4 +68,6 @@ export class Tabs extends React.PureComponent<TabsProps> {
     }
 }
 
-export default withTheme(Tabs);
+class ThemedTabs extends Tabs {}
+(ThemedTabs as any) = withTheme(Tabs);
+export default ThemedTabs;

--- a/src/tag-button/tag-button.tsx
+++ b/src/tag-button/tag-button.tsx
@@ -15,4 +15,6 @@ export class TagButton extends Button {
     cn = createCn('tag-button');
 }
 
-export default withTheme(TagButton);
+class ThemedTagButton extends TagButton {}
+(ThemedTagButton as any) = withTheme(TagButton);
+export default ThemedTagButton;

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -349,4 +349,6 @@ export class Textarea extends React.PureComponent<TextareaProps> {
     }
 }
 
-export default withTheme(Textarea);
+class ThemedTextarea extends Textarea {}
+(ThemedTextarea as any) = withTheme(Textarea);
+export default ThemedTextarea;

--- a/src/toggle/toggle.tsx
+++ b/src/toggle/toggle.tsx
@@ -181,4 +181,6 @@ export class Toggle extends React.PureComponent<ToggleProps> {
     }
 }
 
-export default withTheme(Toggle);
+class ThemedToggle extends Toggle {}
+(ThemedToggle as any) = withTheme(Toggle);
+export default ThemedToggle;


### PR DESCRIPTION
Лучший способ который я нешел чтобы сказать что мы экспортим именно class.
Интересно что скорость компиляции увеличилась, дефенишены стали чище и навигейшн в IDE починился. Если знаете как это сделать иначе - буду рад услышать

Если не понятно что происходит - решается проблема
```
// first.ts
class MyComponent {}
function withTheme<T>(myComponentType): T  {
    return myComponentType
}
export default withTheme(MyComponent);
```

```
// second.ts
import ThemedMyComponent from './first.ts';
// тут будет ошибка что вы хотите использовать тип, но это value
let component: ThemedMyComponent;
```

Так же тут есть пример https://github.com/alfa-laboratory/bem-react-classname/pull/9