### PR TITLE
fix(radio-group): adds 'isValidElement' check for children

### DIFF
--- a/src/checkbox-group/__snapshots__/checkbox-group.test.tsx.snap
+++ b/src/checkbox-group/__snapshots__/checkbox-group.test.tsx.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`checkbox-group should render with children like boolean or string or others react children type without problems 1`] = `
+<span
+  className="checkbox-group checkbox-group_type_normal control-group"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  tabIndex={-1}
+>
+  <div
+    className="checkbox-group__box"
+  >
+    <div
+      key="checkbox-0/.0"
+    >
+      <CheckBox
+        checked={false}
+        key="1"
+        onChange={[Function]}
+        size="m"
+        text="label"
+        type="normal"
+      />
+    </div>
+    <div
+      key="checkbox-1/.0"
+    >
+      <CheckBox
+        checked={false}
+        key="2"
+        onChange={[Function]}
+        size="m"
+        text="label"
+        type="normal"
+      />
+    </div>
+  </div>
+</span>
+`;
+
 exports[`checkbox-group should render with many checkbox children without problems 1`] = `
 <span
   className="checkbox-group checkbox-group_type_normal control-group"

--- a/src/checkbox-group/__snapshots__/checkbox-group.test.tsx.snap
+++ b/src/checkbox-group/__snapshots__/checkbox-group.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`checkbox-group should render with children like boolean or string or ot
     >
       <CheckBox
         checked={false}
-        key="1"
+        key=".$1"
         onChange={[Function]}
         size="m"
         text="label"
@@ -28,7 +28,7 @@ exports[`checkbox-group should render with children like boolean or string or ot
     >
       <CheckBox
         checked={false}
-        key="2"
+        key=".$2"
         onChange={[Function]}
         size="m"
         text="label"
@@ -55,7 +55,7 @@ exports[`checkbox-group should render with many checkbox children without proble
     >
       <CheckBox
         checked={false}
-        key="1"
+        key=".$1"
         onChange={[Function]}
         size="m"
         text="label"
@@ -67,7 +67,7 @@ exports[`checkbox-group should render with many checkbox children without proble
     >
       <CheckBox
         checked={false}
-        key="2"
+        key=".$2"
         onChange={[Function]}
         size="m"
         text="label"
@@ -94,7 +94,7 @@ exports[`checkbox-group should render with only one children 1`] = `
     >
       <CheckBox
         checked={false}
-        key="1"
+        key=".$1"
         onChange={[Function]}
         size="m"
         type="normal"

--- a/src/checkbox-group/checkbox-group.test.tsx
+++ b/src/checkbox-group/checkbox-group.test.tsx
@@ -157,4 +157,19 @@ describe('checkbox-group', () => {
 
         expect(onChange).not.toHaveBeenCalled();
     });
+
+    it('should render with children like boolean or string or others react children type without problems', () => {
+        const checkboxGroup = shallow(
+            <CheckBoxGroup>
+                <CheckBox key='1' text='label' />
+                <CheckBox key='2' text='label' />
+                { false && <CheckBox key='3' text='label' /> }
+                { 0 && <CheckBox key='4' text='label' /> }
+                { '' && <CheckBox key='5' text='label' /> }
+                { null && <CheckBox key='6' text='label' /> }
+            </CheckBoxGroup>
+        );
+
+        expect(checkboxGroup).toMatchSnapshot();
+    });
 });

--- a/src/checkbox-group/checkbox-group.tsx
+++ b/src/checkbox-group/checkbox-group.tsx
@@ -107,7 +107,7 @@ export class CheckBoxGroup extends React.PureComponent<CheckBoxGroupProps> {
     checkboxes: any[];
 
     render() {
-        let children: React.ReactNode[] = null;
+        let children: React.ReactNode = null;
         let props: { name: string; disabled?: boolean; width?: 'default' | 'available' } = { name: this.props.name };
         const checkboxGroupParts = {};
 
@@ -118,7 +118,7 @@ export class CheckBoxGroup extends React.PureComponent<CheckBoxGroupProps> {
         if (this.props.children) {
             const { children: propsChildren } = this.props;
 
-            children = (propsChildren instanceof Array && propsChildren.length) ? propsChildren : [propsChildren];
+            children = React.Children.toArray(propsChildren);
         }
 
         if (this.props.type === 'button') {

--- a/src/checkbox-group/checkbox-group.tsx
+++ b/src/checkbox-group/checkbox-group.tsx
@@ -107,7 +107,7 @@ export class CheckBoxGroup extends React.PureComponent<CheckBoxGroupProps> {
     checkboxes: any[];
 
     render() {
-        let children = null;
+        let children: React.ReactNode[] = null;
         let props: { name: string; disabled?: boolean; width?: 'default' | 'available' } = { name: this.props.name };
         const checkboxGroupParts = {};
 
@@ -116,9 +116,9 @@ export class CheckBoxGroup extends React.PureComponent<CheckBoxGroupProps> {
         }
 
         if (this.props.children) {
-            children = (
-                this.props.children as Array<React.ReactNode>).length
-                ? this.props.children : [this.props.children];
+            const { children: propsChildren } = this.props;
+
+            children = (propsChildren instanceof Array && propsChildren.length) ? propsChildren : [propsChildren];
         }
 
         if (this.props.type === 'button') {
@@ -130,20 +130,22 @@ export class CheckBoxGroup extends React.PureComponent<CheckBoxGroupProps> {
             const value = this.props.value === undefined ? this.state.value : this.props.value;
 
             React.Children.forEach(children, (checkbox, index) => {
-                const checkboxNode = React.cloneElement(checkbox, {
-                    ref: checkbox => this.checkboxes.push(checkbox),
-                    checked: checkbox.props.checked === undefined
-                        ? value.some(groupValue => groupValue === checkbox.props.value)
-                        : checkbox.props.checked,
-                    onChange: checkbox.props.onChange === undefined
-                        ? (checked, _text, event) => this.handleCheckboxChange(checkbox.props.value, checked, event)
-                        : checkbox.props.onChange,
-                    ...props
-                });
+                if (React.isValidElement(checkbox)) {
+                    const checkboxNode = React.cloneElement(checkbox, {
+                        ref: checkbox => this.checkboxes.push(checkbox),
+                        checked: checkbox.props.checked === undefined
+                            ? value.some(groupValue => groupValue === checkbox.props.value)
+                            : checkbox.props.checked,
+                        onChange: checkbox.props.onChange === undefined
+                            ? (checked, _text, event) => this.handleCheckboxChange(checkbox.props.value, checked, event)
+                            : checkbox.props.onChange,
+                        ...props
+                    });
 
-                checkboxGroupParts[`checkbox-${index}`] = (this.props.type !== 'button' && this.props.type !== 'line')
-                    ? <div>{ checkboxNode }</div>
-                    : checkboxNode;
+                    checkboxGroupParts[`checkbox-${index}`] = (this.props.type !== 'button' && this.props.type !== 'line')
+                        ? <div>{ checkboxNode }</div>
+                        : checkboxNode;
+                }
             });
         }
 

--- a/src/radio-group/__snapshots__/radio-group.test.tsx.snap
+++ b/src/radio-group/__snapshots__/radio-group.test.tsx.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`radio-group should render with children like boolean or string or others react children type without problems 1`] = `
+<div
+  className="radio-group radio-group_type_normal radio-group_size_m control-group"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  role="group"
+  tabIndex={-1}
+>
+  <div
+    className="radio-group__inner"
+  >
+    <div
+      className="radio-group__box"
+    >
+      <Radio
+        checked={false}
+        error={false}
+        key="radio-0/.$1"
+        onChange={[Function]}
+        size="m"
+        tabIndex={0}
+        text="label"
+      />
+      <Radio
+        checked={false}
+        error={false}
+        key="radio-1/.$2"
+        onChange={[Function]}
+        size="m"
+        tabIndex={0}
+        text="label"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`radio-group should render with many radio children without problems 1`] = `
 <div
   className="radio-group radio-group_type_normal radio-group_size_m control-group"

--- a/src/radio-group/__snapshots__/radio-group.test.tsx.snap
+++ b/src/radio-group/__snapshots__/radio-group.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`radio-group should render with children like boolean or string or other
       <Radio
         checked={false}
         error={false}
-        key="radio-0/.$1"
+        key="radio-0/.$.$1"
         onChange={[Function]}
         size="m"
         tabIndex={0}
@@ -26,7 +26,7 @@ exports[`radio-group should render with children like boolean or string or other
       <Radio
         checked={false}
         error={false}
-        key="radio-1/.$2"
+        key="radio-1/.$.$2"
         onChange={[Function]}
         size="m"
         tabIndex={0}
@@ -54,7 +54,7 @@ exports[`radio-group should render with many radio children without problems 1`]
       <Radio
         checked={false}
         error={false}
-        key="radio-0/.$1"
+        key="radio-0/.$.$1"
         onChange={[Function]}
         size="m"
         tabIndex={0}
@@ -63,7 +63,7 @@ exports[`radio-group should render with many radio children without problems 1`]
       <Radio
         checked={false}
         error={false}
-        key="radio-1/.$2"
+        key="radio-1/.$.$2"
         onChange={[Function]}
         size="m"
         tabIndex={0}
@@ -91,7 +91,7 @@ exports[`radio-group should render with only one children 1`] = `
       <Radio
         checked={false}
         error={false}
-        key="radio-0/.$1"
+        key="radio-0/.$.$1"
         onChange={[Function]}
         size="m"
         tabIndex={0}

--- a/src/radio-group/radio-group.test.tsx
+++ b/src/radio-group/radio-group.test.tsx
@@ -226,4 +226,19 @@ describe('radio-group', () => {
 
         expect(onChange).not.toHaveBeenCalled();
     });
+
+    it('should render with children like boolean or string or others react children type without problems', () => {
+        const radioGroup = shallow(
+            <RadioGroup>
+                <Radio key='1' text='label' />
+                <Radio key='2' text='label' />
+                { false && <Radio key='3' text='label' /> }
+                { 0 && <Radio key='4' text='label' /> }
+                { '' && <Radio key='5' text='label' /> }
+                { null && <Radio key='6' text='label' /> }
+            </RadioGroup>
+        );
+
+        expect(radioGroup).toMatchSnapshot();
+    });
 });

--- a/src/radio-group/radio-group.tsx
+++ b/src/radio-group/radio-group.tsx
@@ -111,7 +111,7 @@ export class RadioGroup extends React.PureComponent<RadioGroupProps> {
     radios: Radio[];
 
     render() {
-        let children = null;
+        let children: React.ReactNode[] = null;
         const { size, name } = this.props;
         let props: { name: string; disabled?: boolean; width?: 'default' | 'available' } = { name };
         const radioGroupParts = {};
@@ -121,9 +121,9 @@ export class RadioGroup extends React.PureComponent<RadioGroupProps> {
         }
 
         if (this.props.children) {
-            children = (
-                this.props.children as Array<React.ReactNode>
-            ).length ? this.props.children : [this.props.children];
+            const { children: propsChildren } = this.props;
+
+            children = (propsChildren instanceof Array && propsChildren.length) ? propsChildren : [propsChildren];
         }
 
         if (this.props.type === 'button') {
@@ -135,13 +135,17 @@ export class RadioGroup extends React.PureComponent<RadioGroupProps> {
             const value = this.props.value === undefined ? this.state.value : this.props.value;
 
             React.Children.forEach(children, (radio, index) => {
-                radioGroupParts[`radio-${index}`] = React.cloneElement(radio, {
-                    ref: radio => this.radios.push(radio),
-                    error: radio.props.error === undefined ? Boolean(this.props.error) : radio.props.error,
-                    checked: radio.props.checked === undefined ? (value === radio.props.value) : radio.props.checked,
-                    onChange: radio.props.onChange === undefined ? this.handleRadioChange : radio.props.onChange,
-                    ...props
-                });
+                if (React.isValidElement(radio)) {
+                    radioGroupParts[`radio-${index}`] = React.cloneElement(radio, {
+                        ref: radio => this.radios.push(radio),
+                        error: radio.props.error === undefined ? Boolean(this.props.error) : radio.props.error,
+                        checked: (
+                            radio.props.checked === undefined ? (value === radio.props.value) : radio.props.checked
+                        ),
+                        onChange: radio.props.onChange === undefined ? this.handleRadioChange : radio.props.onChange,
+                        ...props
+                    });
+                }
             });
         }
 

--- a/src/radio-group/radio-group.tsx
+++ b/src/radio-group/radio-group.tsx
@@ -111,7 +111,7 @@ export class RadioGroup extends React.PureComponent<RadioGroupProps> {
     radios: Radio[];
 
     render() {
-        let children: React.ReactNode[] = null;
+        let children: React.ReactNode = null;
         const { size, name } = this.props;
         let props: { name: string; disabled?: boolean; width?: 'default' | 'available' } = { name };
         const radioGroupParts = {};
@@ -123,7 +123,7 @@ export class RadioGroup extends React.PureComponent<RadioGroupProps> {
         if (this.props.children) {
             const { children: propsChildren } = this.props;
 
-            children = (propsChildren instanceof Array && propsChildren.length) ? propsChildren : [propsChildren];
+            children = React.Children.toArray(propsChildren);
         }
 
         if (this.props.type === 'button') {


### PR DESCRIPTION
Добавляет проверку для дочерних компонентов

## Мотивация и контекст
Иногда есть необходимость регулировать рендер детей через `&&`.
Например `{ isOneEl && <Radio />}`.

До изменений все падоло с ошибками по типу `Cannot read property 'error' of undefined`.
Ошибка происходила `error: radio.props.error === undefined`.

После добавления этой проверки, такого не происходит