### PR TITLE
fix(textarea): fixed height label overlapping on view=filled

### DIFF
--- a/src/textarea/textarea.css
+++ b/src/textarea/textarea.css
@@ -9,6 +9,11 @@
     --top-scale-m: calc(strip(var(--font-size-s)) / strip(var(--font-size-m)));
     --top-scale-l: calc(strip(var(--font-size-m)) / strip(var(--font-size-l)));
     --top-scale-xl: calc(strip(var(--font-size-l)) / strip(var(--font-size-xl)));
+    --filled-s-top-padding: 21px;
+    --filled-m-top-padding: 28px;
+    --filled-height: 110px;
+    --filled-s-min-height: 43px;
+    --filled-m-min-height: 56px;
 }
 
 .textarea {
@@ -269,11 +274,11 @@
     &.textarea_size_s {
         .textarea__top {
             padding: 0 var(--gap-xs);
-            line-height: 43px;
+            line-height: var(--filled-s-min-height);
         }
 
         .textarea__control {
-            min-height: 43px;
+            min-height: var(--filled-s-min-height);
             padding: 14px var(--gap-xs) 6px;
         }
 
@@ -290,22 +295,22 @@
 
         &.textarea_has-label {
             .textarea__control {
-                padding-top: 21px;
+                padding-top: var(--filled-s-top-padding);
             }
         }
 
         &.textarea_has-label.textarea_focused,
         &.textarea_has-label.textarea_has-value {
             .textarea__inner {
-                padding-top: 21px;
+                padding-top: var(--filled-s-top-padding);
             }
 
             &:not(.textarea_autosize) .textarea__control {
-                min-height: calc(110px - 21px);
+                min-height: calc(var(--filled-height) - var(--filled-s-top-padding));
             }
 
             .textarea__control {
-                min-height: calc(43px - 21px);
+                min-height: calc(var(--filled-s-min-height) - var(--filled-s-top-padding));
                 padding-top: 0;
             }
         }
@@ -322,11 +327,11 @@
     &.textarea_size_m {
         .textarea__top {
             padding: 0 var(--gap-s);
-            line-height: 56px;
+            line-height: var(--filled-m-min-height);
         }
 
         .textarea__control {
-            min-height: 56px;
+            min-height: var(--filled-m-min-height);
             padding: 18px var(--gap-s) var(--gap-xs);
         }
 
@@ -343,22 +348,22 @@
 
         &.textarea_has-label {
             .textarea__control {
-                padding-top: 28px;
+                padding-top: var(--filled-m-top-padding);
             }
         }
 
         &.textarea_has-label.textarea_focused,
         &.textarea_has-label.textarea_has-value {
             .textarea__inner {
-                padding-top: 28px;
+                padding-top: var(--filled-m-top-padding);
             }
 
             &:not(.textarea_autosize) .textarea__control {
-                min-height: calc(110px - 28px);
+                min-height: calc(var(--filled-height) - var(--filled-m-top-padding));
             }
 
             .textarea__control {
-                min-height: calc(56px - 28px);
+                min-height: calc(var(--filled-m-min-height) - var(--filled-m-top-padding));
                 padding-top: 0;
             }
         }
@@ -404,7 +409,7 @@
     }
 
     &:not(.textarea_autosize) .textarea__control {
-        min-height: 110px;
+        min-height: var(--filled-height);
     }
 
     &__sub {

--- a/src/textarea/textarea.css
+++ b/src/textarea/textarea.css
@@ -294,6 +294,22 @@
             }
         }
 
+        &.textarea_has-label.textarea_focused,
+        &.textarea_has-label.textarea_has-value {
+            .textarea__inner {
+                padding-top: 21px;
+            }
+
+            &:not(.textarea_autosize) .textarea__control {
+                min-height: calc(110px - 21px);
+            }
+
+            .textarea__control {
+                min-height: calc(43px - 21px);
+                padding-top: 0;
+            }
+        }
+
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {
@@ -331,6 +347,22 @@
             }
         }
 
+        &.textarea_has-label.textarea_focused,
+        &.textarea_has-label.textarea_has-value {
+            .textarea__inner {
+                padding-top: 28px;
+            }
+
+            &:not(.textarea_autosize) .textarea__control {
+                min-height: calc(110px - 28px);
+            }
+
+            .textarea__control {
+                min-height: calc(56px - 28px);
+                padding-top: 0;
+            }
+        }
+
         &.textarea_focused,
         &.textarea_has-value {
             .textarea__top {
@@ -345,15 +377,24 @@
         will-change: transform;
     }
 
+    .textarea__inner {
+        border-radius: 4px 4px 0 0;
+        background-color: var(--color-dark-indigo-05);
+        transition-duration: 250ms;
+        transition-property: border-bottom-color, box-shadow, width, background-color;
+        transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+
+        &:hover {
+            background-color: var(--color-dark-indigo-10);
+        }
+    }
+
     .textarea__control {
         margin: 0;
         color: var(--color-dark-indigo);
         border-bottom-color: var(--color-dark-indigo-15);
-        background-color: var(--color-dark-indigo-05);
-        border-radius: 4px 4px 0 0;
 
         &:hover {
-            background-color: var(--color-dark-indigo-10);
             border-color: var(--color-dark-indigo-60);
         }
 


### PR DESCRIPTION
## Мотивация и контекст
https://github.com/alfa-laboratory/arui-feather/issues/1118

Данная проблема возникает при сочетании `view="filled"` и `maxRows`.
Из-за особенностей вертки - контент во время скрола наезжает на лейбл. 

### Решение

Перенес заливку из `textarea.textarea__control` в родительский контейнер `.textarea__inner` и добавил дополнительный паддинг сверху при фокусе или если есть введенное значение.

### Было
<img src="https://user-images.githubusercontent.com/9968618/78107657-95c7ad00-73fe-11ea-803a-2ade69590189.png" width="300"/>

### Стало

<img src="https://user-images.githubusercontent.com/9968618/78107575-6add5900-73fe-11ea-9126-22d043f6da86.png" width="300"/>

