### PR TITLE
fix(*): temporary fix for chrome font bug

### DIFF
--- a/src/vars/font.css
+++ b/src/vars/font.css
@@ -15,7 +15,12 @@
      * односимвольный шрифт Roboto Rouble (~3kb gzipped). Использование именно этого семейства обосновано
      * свободой лицензии, в отличии от Segoe UI.
      */
-    --font: BlinkMacSystemFont, -apple-system, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', 'Roboto Rouble', sans-serif;
+
+    /**
+     * Временно убираем BlinkMacSystemFont пока выйдет Chrome с фиксом
+     * https://www.bram.us/2020/04/09/chrome-vs-blinkmacsystemfont-when-bold-is-not-bold/
+     */
+    --font: -apple-system, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', 'Roboto Rouble', sans-serif;
 
     /**
      * Облегченная толщина шрифта. Может быть использована для


### PR DESCRIPTION
В последнем Chrome 81 на маке есть баг, ломающий наши шрифты:
https://www.bram.us/2020/04/09/chrome-vs-blinkmacsystemfont-when-bold-is-not-bold/

В этом реквесте — временное решение. Шрифт в Chrome поменяется, но болд вернётся.

Chrome с фиксом ждать до середины мая (если не ускорят).