### PR TITLE
fix(masked-input): remove implicit maxLength setting

### DIFF
--- a/src/masked-input/__snapshots__/masked-input.test.tsx.snap
+++ b/src/masked-input/__snapshots__/masked-input.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`masked-input should render without problems 1`] = `
 <input
-  maxLength={19}
   onBeforeInput={[Function]}
   onChange={[Function]}
   onInput={[Function]}

--- a/src/masked-input/masked-input.tsx
+++ b/src/masked-input/masked-input.tsx
@@ -158,7 +158,6 @@ class MaskedInput extends React.PureComponent<MaskedInputProps> {
 
     render() {
         const props = { ...this.props };
-        const length = props.maxLength === undefined ? this.mask.length : props.maxLength;
 
         delete props.mask;
         delete props.formatCharacters;
@@ -171,7 +170,6 @@ class MaskedInput extends React.PureComponent<MaskedInputProps> {
                 ref={ (ref) => {
                     this.input = ref;
                 } }
-                maxLength={ length }
                 value={ this.value }
                 onBeforeInput={ this.handleBeforeInput }
                 onInput={ this.handleInput }


### PR DESCRIPTION
- Убрал неявную установку атрибута maxLength в `<MaskedInput/>`

`inputmask-core` не даст ввести больше символов, чем определено маской, поэтому специально устанавливать данный атрибут не нужно.
Но если очень хочется, то это можно сделать явно, через пропс `maxLength` 🤷‍♂️

## Мотивация и контекст
https://github.com/alfa-laboratory/arui-feather/issues/1141