### PR TITLE
fix(menu): top in .menu-item_checked:before

### DIFF
--- a/src/menu/menu.css
+++ b/src/menu/menu.css
@@ -73,7 +73,7 @@
 
     &.menu_mode_radio, &.menu_mode_radio-check {
         .menu-item_checked:before {
-            top: 12px;
+            top: calc(50% - 2px);
             width: 5px;
             height: 5px;
             margin-left: -14px;
@@ -116,7 +116,7 @@
 
     &.menu_mode_radio, &.menu_mode_radio-check {
         .menu-item_checked:before {
-            top: 17px;
+            top: calc(50% - 3px);
             width: 6px;
             height: 6px;
             margin-left: -14px;
@@ -159,7 +159,7 @@
 
     &.menu_mode_radio, &.menu_mode_radio-check {
         .menu-item_checked:before {
-            top: 21px;
+            top: calc(50% - 4px);
             width: 8px;
             height: 8px;
             margin-left: -21px;
@@ -202,7 +202,7 @@
 
     &.menu_mode_radio, &.menu_mode_radio-check {
         .menu-item_checked:before {
-            top: 21px;
+            top: calc(50% - 5px);
             width: 10px;
             height: 10px;
             margin-left: -22px;


### PR DESCRIPTION
top для .menu-item_checked:before вычисляется динамически

## Мотивация и контекст
Если top будет константой, то смотрится криво.

<img width="323" alt="Screenshot 2020-04-24 at 14 48 50" src="https://user-images.githubusercontent.com/3061978/80213796-647b7f00-8642-11ea-97fc-567fab8d1bbf.png">

