### PR TITLE
fix(select): remove border-radius for select popup container

### DIFF
--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -59,6 +59,11 @@ export type PopupProps = DeepReadonly<{
     className?: string;
 
     /**
+     * Дополнительный класс контейнера
+     */
+    containerClassName?: string;
+
+    /**
      * Идентификатор компонента в DOM
      */
     id?: string;
@@ -368,7 +373,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
                 onMouseLeave={ this.handleMouseLeave }
                 data-test-id={ this.props['data-test-id'] }
             >
-                <div className={ this.cn('container') }>
+                <div className={ `${this.cn('container')} ${this.props.containerClassName ?? ''}`.trim() }>
                     { this.props.header && <div className={ this.cn('header') }>{ this.props.header }</div> }
                     <div
                         ref={ (inner) => {
@@ -577,27 +582,27 @@ export class Popup extends React.Component<PopupProps, PopupState> {
         let bestDrawingParams;
 
         switch (this.props.target) {
-        case 'position':
-            bestDrawingParams = { top: this.position.top, left: this.position.left };
-            break;
+            case 'position':
+                bestDrawingParams = { top: this.position.top, left: this.position.left };
+                break;
 
-        case 'screen':
-            bestDrawingParams = {
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                overflow: this.inner.scrollHeight > this.inner.clientHeight,
-            };
-            break;
+            case 'screen':
+                bestDrawingParams = {
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    overflow: this.inner.scrollHeight > this.inner.clientHeight,
+                };
+                break;
 
-        case 'anchor':
-            bestDrawingParams = calcBestDrawingParams(
-                popupHash,
-                calcTargetDimensions(popupHash),
-                calcFitContainerDimensions(popupHash),
-            );
-            break;
+            case 'anchor':
+                bestDrawingParams = calcBestDrawingParams(
+                    popupHash,
+                    calcTargetDimensions(popupHash),
+                    calcFitContainerDimensions(popupHash),
+                );
+                break;
         }
 
         this.setState({

--- a/src/select/__snapshots__/select.test.tsx.snap
+++ b/src/select/__snapshots__/select.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`select should render without problem 1`] = `
       />
       <ForwardRef(ThemedComponent(Popup))
         className="select__popup"
+        containerClassName="select__popup-container"
         directions={
           Array [
             "bottom-left",
@@ -199,6 +200,7 @@ exports[`select should render without problem 1`] = `
       >
         <Popup
           className="select__popup"
+          containerClassName="select__popup-container"
           directions={
             Array [
               "bottom-left",
@@ -227,7 +229,7 @@ exports[`select should render without problem 1`] = `
                   style="top: 0px; left: 0px; height: auto; min-width: 0; max-width: none; max-height: none;"
                 >
                   <div
-                    class="popup__container"
+                    class="popup__container select__popup-container"
                   >
                     <div
                       class="popup__inner"
@@ -296,7 +298,7 @@ exports[`select should render without problem 1`] = `
               }
             >
               <div
-                className="popup__container"
+                className="popup__container select__popup-container"
               >
                 <div
                   className="popup__inner"

--- a/src/select/select.css
+++ b/src/select/select.css
@@ -217,6 +217,10 @@
     &&_has-label&_has-placeholder &__placeholder {
         opacity: var(--opacity-active);
     }
+
+    &__popup-container {
+        border-radius: 0;
+    }
 }
 
 .select_size_s {

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -567,6 +567,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
                 ref={ this.setPopupRef }
                 for={ this.props.name }
                 className={ this.cn('popup') }
+                containerClassName={this.cn('popup-container')}
                 directions={ this.props.directions }
                 height="adaptive"
                 padded={ false }


### PR DESCRIPTION
Исправил border-radius для select

## Мотивация и контекст
Сейчас в компоненте [select](https://digital.alfabank.ru/components/select) неверный `border-radius`
Fix #1127
