### PR TITLE
fix(*): revert font-family after fix in chrome

### DIFF
--- a/src/vars/font.css
+++ b/src/vars/font.css
@@ -15,13 +15,8 @@
      * односимвольный шрифт Roboto Rouble (~3kb gzipped). Использование именно этого семейства обосновано
      * свободой лицензии, в отличии от Segoe UI.
      */
-
-    /**
-     * Временно убираем BlinkMacSystemFont пока выйдет Chrome с фиксом
-     * https://www.bram.us/2020/04/09/chrome-vs-blinkmacsystemfont-when-bold-is-not-bold/
-     */
-    --font: -apple-system, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-        "Open Sans", "Helvetica Neue", "Roboto Rouble", sans-serif;
+    --font: system-ui, -apple-system, "Segoe UI", Roboto, Oxygen, Ubuntu,
+        Cantarell, "Open Sans", "Helvetica Neue", "Roboto Rouble", sans-serif;
 
     /**
      * Облегченная толщина шрифта. Может быть использована для


### PR DESCRIPTION
После фикса бага в хроме на маке возвращаем font-family, но возвращаем не устаревший `BlinkMacSystemFont`, а `system-ui`