### PR TITLE
chore(*): downgrade react-styleguidist

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "react-docgen-typescript": "1.16.1",
     "react-dom": "16.12.0",
     "react-frame-component": "4.1.1",
-    "react-styleguidist": "9.1.16",
+    "react-styleguidist": "9.1.5",
     "region-flags": "1.1.0",
     "style-loader": "^0.23.1",
     "stylelint": "^12.0.1",


### PR DESCRIPTION
Понижение версии react-styleguidist с 9.1.16 до 9.1.5

## Мотивация и контекст
Решаемая проблема: https://github.com/alfa-laboratory/arui-feather/issues/1102

Проблема заключается в том, что вместо ThemedComponent подтягивается Component

По результатам ресерча - по приоритетам в начале идет именованный экспорт, затем - экспорт по умолчанию

следовательно, если есть, к примеру

export { default } from './button';
export * from './button';

при импорте Button будет импортирован именно Button, а не экспортируемый по умолчанию ThemedButton

https://github.com/styleguidist/react-styleguidist/issues/1413

такое поведение начинается с версии 9.1.6

Возможное решение - переход на версию 9.1.5
