### PR TITLE
fix(money-input): fix currency overlapping

### DIFF
--- a/src/money-input/money-input.test.tsx
+++ b/src/money-input/money-input.test.tsx
@@ -119,4 +119,20 @@ describe('money-input', () => {
             done();
         }, 0);
     });
+
+    it('should use placeholder as currency spacer if value is empty', () => {
+        const moneyInput = mount(<MoneyInput placeholder="placeholder" showCurrency={ true } />);
+        const spacerValue = moneyInput.find('.money-input__value').text();
+
+        expect(spacerValue).toBe('placeholder');
+    });
+
+    it('should format currency spacer the same way as value', () => {
+        const moneyInput = mount(<MoneyInput value="1234,567" showCurrency={ true } />);
+
+        const inputValue = moneyInput.find('input').prop('value');
+        const spacerValue = moneyInput.find('.money-input__value').text();
+
+        expect(spacerValue).toBe(inputValue);
+    });
 });

--- a/src/money-input/money-input.tsx
+++ b/src/money-input/money-input.tsx
@@ -153,7 +153,7 @@ export class MoneyInput extends React.PureComponent<MoneyInputProps, MoneyInputS
                     leftAddons={
                         this.props.showCurrency ? (
                             <span className={ this.cn('currency') }>
-                                <span className={ this.cn('value') }>{ this.getValue() }</span>
+                                <span className={ this.cn('value') }>{ this.getCurrencySpacer() }</span>
                                 <span>{ getCurrencySymbol(this.props.currencyCode) }</span>
                             </span>
                         ) : (
@@ -306,6 +306,13 @@ export class MoneyInput extends React.PureComponent<MoneyInputProps, MoneyInputS
             this.root.control.input.selectionStart = selection;
             this.root.control.input.selectionEnd = selection;
         }, 0);
+    }
+
+    /**
+     * Возвращает значение (невидимый текст) для корректного отображения значка валюты.
+     */
+    private getCurrencySpacer() {
+        return this.mask.format(this.getValue()) || this.props.placeholder;
     }
 }
 


### PR DESCRIPTION
Фиксит отображение значка валюты

## Мотивация и контекст

Значок валюты некорректно отображается при использовании плейсхолдера и длинных значений.

Связанные issues: https://github.com/alfa-laboratory/arui-feather/issues/1159 и https://github.com/alfa-laboratory/arui-feather/issues/1164

