### PR TITLE
fix(input): fix label position when input has addons

### DIFF
--- a/src/input-autocomplete/__snapshots__/input-autocomplete.test.tsx.snap
+++ b/src/input-autocomplete/__snapshots__/input-autocomplete.test.tsx.snap
@@ -126,25 +126,29 @@ exports[`input-autocomplete should render input with provided default value 1`] 
               className="input__box"
               key="input-wrapper"
             >
-              <input
-                autoComplete="off"
-                className="input__control"
-                formNoValidate={false}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onPaste={[Function]}
-                onTouchCancel={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                type="text"
-                value="default"
-                view="default"
-              />
+              <span
+                className="input__input-wrapper"
+              >
+                <input
+                  autoComplete="off"
+                  className="input__control"
+                  formNoValidate={false}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onPaste={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  type="text"
+                  value="default"
+                  view="default"
+                />
+              </span>
             </span>
           </span>
         </span>
@@ -653,25 +657,29 @@ exports[`input-autocomplete should render without problem 1`] = `
               className="input__box"
               key="input-wrapper"
             >
-              <input
-                autoComplete="off"
-                className="input__control"
-                formNoValidate={false}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onPaste={[Function]}
-                onTouchCancel={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                type="text"
-                value=""
-                view="default"
-              />
+              <span
+                className="input__input-wrapper"
+              >
+                <input
+                  autoComplete="off"
+                  className="input__control"
+                  formNoValidate={false}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onPaste={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  type="text"
+                  value=""
+                  view="default"
+                />
+              </span>
             </span>
           </span>
         </span>

--- a/src/input/__snapshots__/input.test.tsx.snap
+++ b/src/input/__snapshots__/input.test.tsx.snap
@@ -11,25 +11,29 @@ exports[`input should render without problems 1`] = `
       className="input__box"
       key="input-wrapper"
     >
-      <input
-        autoComplete="on"
-        className="input__control"
-        formNoValidate={false}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onPaste={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        type="text"
-        value=""
-        view="default"
-      />
+      <span
+        className="input__input-wrapper"
+      >
+        <input
+          autoComplete="on"
+          className="input__control"
+          formNoValidate={false}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onPaste={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          type="text"
+          value=""
+          view="default"
+        />
+      </span>
     </span>
   </span>
 </span>

--- a/src/input/input.css
+++ b/src/input/input.css
@@ -32,7 +32,6 @@
     }
 
     &__box {
-        overflow: hidden;
         display: table-cell;
         position: relative;
         user-select: none;
@@ -46,6 +45,11 @@
             1
         ); /* TODO @teryaew: add custom easings to styles */
         -webkit-touch-callout: none;
+    }
+
+    &__input-wrapper {
+        position: relative;
+        display: block;
     }
 
     &__top {
@@ -205,14 +209,20 @@
             padding-right: var(--gap-s);
         }
 
-        .input__addons_left + .input__control {
-            padding-right: 0;
-            padding-left: var(--gap-s);
+        .input__input-wrapper:nth-child(2) {
+            .input__control,
+            .input__top {
+                padding-right: 0;
+                padding-left: var(--gap-s);
+            }
         }
 
         /* If has left & right addons */
-        .input__control:nth-child(2):nth-last-child(2) {
-            padding-right: var(--gap-s);
+        .input__input-wrapper:nth-child(2):nth-last-child(2) {
+            .input__control,
+            .input__top {
+                padding-right: var(--gap-s);
+            }
         }
     }
 
@@ -451,7 +461,6 @@
     &.input_size_s {
         .input__top {
             line-height: 43px;
-            padding: 0 var(--gap-xs);
         }
 
         .input__box {
@@ -503,18 +512,11 @@
                 height: 43px;
             }
         }
-
-        &.input_has-left-addons {
-            .input__top {
-                padding-left: 38px;
-            }
-        }
     }
 
     &.input_size_m {
         .input__top {
             line-height: 56px;
-            padding: 0 var(--gap-s);
         }
 
         .input__box {
@@ -564,12 +566,6 @@
         &.input_has-addons {
             .input__box {
                 height: 56px;
-            }
-        }
-
-        &.input_has-left-addons {
-            .input__top {
-                padding-left: var(--gap-4xl);
             }
         }
     }
@@ -648,20 +644,28 @@
     }
 
     &.input_has-addons {
-        .input__addons_left + .input__control {
-            padding-right: var(--gap-s);
-        }
-
-        .input__control {
-            padding-left: var(--gap-s);
-            padding-right: var(--gap-s);
+        .input__input-wrapper {
+            .input__control {
+                padding-left: var(--gap-s);
+                padding-right: var(--gap-s);
+            }
 
             &:first-child {
-                padding-left: 0;
+                .input__control {
+                    padding-left: 0;
+                }
             }
 
             &:last-child {
-                padding-right: 0;
+                .input__control {
+                    padding-right: 0;
+                }
+            }
+
+            &:nth-child(2) {
+                .input__control {
+                    padding-right: var(--gap-s);
+                }
             }
         }
     }

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -342,14 +342,6 @@ export class Input extends React.PureComponent<InputProps, InputState> {
                 data-test-id={ this.props['data-test-id'] }
             >
                 <span className={ this.cn('inner') }>
-                    {
-                        !!this.props.label
-                        && (
-                            <span className={ this.cn('top') }>
-                                { this.props.label }
-                            </span>
-                        )
-                    }
                     { this.renderContent() }
                     {
                         (this.state.error || this.props.hint)
@@ -415,19 +407,29 @@ export class Input extends React.PureComponent<InputProps, InputState> {
                         </span>
                     )
                 }
-                {
-                    isMaskedInput
-                        ? (
-                            <MaskedInput
-                                { ...inputProps }
-                                mask={ this.props.mask }
-                                formatCharacters={ this.props.maskFormatCharacters }
-                                onProcessInputEvent={ this.props.onProcessMaskInputEvent }
-                                useWhitespaces={ this.props.useWhitespacesInMask }
-                            />
+                <span className={ this.cn('input-wrapper')}>
+                    {
+                        !!this.props.label
+                        && (
+                            <span className={ this.cn('top') }>
+                                { this.props.label }
+                            </span>
                         )
-                        : <input { ...inputProps } />
-                }
+                    }
+                    {
+                        isMaskedInput
+                            ? (
+                                <MaskedInput
+                                    { ...inputProps }
+                                    mask={ this.props.mask }
+                                    formatCharacters={ this.props.maskFormatCharacters }
+                                    onProcessInputEvent={ this.props.onProcessMaskInputEvent }
+                                    useWhitespaces={ this.props.useWhitespacesInMask }
+                                />
+                            )
+                            : <input { ...inputProps } />
+                    }
+                </span>
                 {
                     this.props.clear && value
                     && (

--- a/src/intl-phone-input/intl-phone-input.css
+++ b/src/intl-phone-input/intl-phone-input.css
@@ -6,8 +6,11 @@
 
 .intl-phone-input {
     &.input {
-        .input__addons_left + .input__control {
-            padding-left: 0;
+        .input__input-wrapper:nth-child(2) {
+            .input__control,
+            .input__top {
+                padding-left: 0;
+            }
         }
     }
 

--- a/src/money-input/money-input.css
+++ b/src/money-input/money-input.css
@@ -74,22 +74,13 @@
                 left: 0;
                 top: 0;
                 white-space: nowrap;
+            }
 
-                + .input__control {
+            .input__input-wrapper:nth-child(2) {
+                .input__control,
+                .input__top {
                     padding-left: 0;
                 }
-            }
-        }
-
-        .input_view_filled.input_size_s {
-            .input__top {
-                padding-left: var(--gap-xs);
-            }
-        }
-
-        .input_view_filled.input_size_m {
-            .input__top {
-                padding-left: var(--gap-s);
             }
         }
     }


### PR DESCRIPTION
Исправлен баг с позиционированием лейбла при наличии аддонов.

## Мотивация и контекст

https://github.com/alfa-laboratory/arui-feather/issues/1169

## Решение

- Обернул инпут в контейнер
- Перенес в этот контейнер рендер лейбла, чтобы его позиция всегда совпадала с позицией инпута, не смотря на наличие аддонов и их размер.
- Исправил оверрайды стилей в MoneyInput и IntlPhoneInput

<img src="https://user-images.githubusercontent.com/9968618/84288701-30084780-ab4a-11ea-9d85-a55fbf9f000d.png" width="240"/>

<img src="https://user-images.githubusercontent.com/9968618/84288720-38f91900-ab4a-11ea-8707-8d08b0f26366.png" width="240"/>
