### PR TITLE
feat(calendar-input): pass resetError through Calendar to Input

### DIFF
--- a/src/calendar-input/calendar-input.tsx
+++ b/src/calendar-input/calendar-input.tsx
@@ -133,6 +133,11 @@ export type CalendarInputProps = DeepReadonly<{
     error?: React.ReactNode;
 
     /**
+     * Сброс ошибки при установке фокуса в компоненте Input
+     */
+    resetError?: boolean;
+
+    /**
      * Управление нативным режимом на мобильных устройствах
      */
     mobileMode?: 'native' | 'popup' | 'input';
@@ -369,6 +374,7 @@ export class CalendarInput extends React.Component<CalendarInputProps> {
                         placeholder={ this.props.placeholder }
                         hint={ this.props.hint }
                         error={ this.props.error }
+                        resetError={ this.props.resetError }
                         value={ value }
                         view={ this.props.view }
                         width={ this.props.width }


### PR DESCRIPTION
Передача `resetError` через `CalendarInput`. 

## Мотивация и контекст
Компонент `CalendarInput` использует `Input` с некоторыми заданными пропсами, но не передает `resetError` если мы его зададим в `CalendarInput`. Из-за этого ошибка на инпуте ресетится при фокусе и этим невозможно никак управлять. 
Проблема связана с issues, но так как они не имеют пока решения, надо как-то управлять компонентом: 
https://github.com/alfa-laboratory/arui-feather/issues/1119
https://github.com/alfa-laboratory/arui-feather/issues/1120