### PR TITLE
BREAKING CHANGE: add rightAddons in textarea

### DIFF
--- a/src/textarea/README.md
+++ b/src/textarea/README.md
@@ -70,3 +70,16 @@ function handleChangeAsync(value) {
     />
 </div>
 ```
+
+Новое отображение с иконкой
+```jsx
+import InputIcon from 'arui-feather/icon/ui/info';
+
+<Textarea placeholder='Введите назначение платежа'
+    label='Filled input'
+    view='filled'
+    rightAddons={
+        <InputIcon />
+    }
+/>
+```

--- a/src/textarea/textarea.css
+++ b/src/textarea/textarea.css
@@ -15,7 +15,7 @@
     --filled-m-top-padding: 28px;
     --filled-height: 110px;
     --filled-s-min-height: 43px;
-    --filled-m-min-height: 56px;
+    --filled-m-min-height: 45px;
 }
 
 .textarea {
@@ -307,6 +307,7 @@
         }
 
         .textarea__control {
+            margin-top: 14px;
             min-height: var(--filled-s-min-height);
             padding: 14px var(--gap-xs) 6px;
         }
@@ -331,6 +332,7 @@
             }
 
             .textarea__control {
+                margin-top: 28px;
                 min-height: calc(
                     var(--filled-s-min-height) - var(--filled-s-top-padding)
                 );
@@ -354,6 +356,7 @@
         }
 
         .textarea__control {
+            margin-top: 8px;
             min-height: var(--filled-m-min-height);
             padding: 18px var(--gap-s) var(--gap-xs);
         }
@@ -378,6 +381,7 @@
             }
 
             .textarea__control {
+                margin-top: 0;
                 min-height: calc(
                     var(--filled-m-min-height) - var(--filled-m-top-padding)
                 );
@@ -438,7 +442,6 @@
 
     &.textarea_focused {
         border-bottom-color: var(--color-dark-indigo);
-        box-shadow: inset 0 -1px 0 var(--color-dark-indigo);
     }
 
     &.textarea_has-label {

--- a/src/textarea/textarea.css
+++ b/src/textarea/textarea.css
@@ -31,9 +31,12 @@
     }
 
     &__inner {
-        display: inline-table;
         position: relative;
+        display: inline-table;
         width: 100%;
+        transition-duration: 250ms;
+        transition-property: border-bottom-color, box-shadow;
+        transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
     }
 
     &__top {
@@ -75,8 +78,7 @@
         border: none;
         border-radius: 0;
         transition-duration: 250ms;
-        transition-property: border-bottom-color, box-shadow, width,
-            background-color;
+        transition-property: width, background-color;
         transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
         -webkit-appearance: none;
         -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -274,9 +276,30 @@
             }
         }
     }
+
+    &&_addons {
+        .textarea__inner {
+            display: flex;
+            flex-grow: 1;
+            justify-content: space-between;
+            width: 100%;
+            height: 100%;
+        }
+    }
+
+    &__addons {
+        display: flex;
+        flex-shrink: 0; /* Avoid overflow cutting of addons in IE11 */
+        padding-right: 12px;
+        padding-top: 8px;
+    }
 }
 
 .textarea_view_filled {
+    &.textarea {
+        padding-top: 0;
+    }
+
     &.textarea_size_s {
         .textarea__top {
             padding: 0 var(--gap-xs);
@@ -299,18 +322,8 @@
             font-size: var(--font-size-xs);
         }
 
-        &.textarea_has-label {
-            .textarea__control {
-                padding-top: var(--filled-s-top-padding);
-            }
-        }
-
         &.textarea_has-label.textarea_focused,
         &.textarea_has-label.textarea_has-value {
-            .textarea__inner {
-                padding-top: var(--filled-s-top-padding);
-            }
-
             &:not(.textarea_autosize) .textarea__control {
                 min-height: calc(
                     var(--filled-height) - var(--filled-s-top-padding)
@@ -356,18 +369,8 @@
             font-size: var(--font-size-s);
         }
 
-        &.textarea_has-label {
-            .textarea__control {
-                padding-top: var(--filled-m-top-padding);
-            }
-        }
-
         &.textarea_has-label.textarea_focused,
         &.textarea_has-label.textarea_has-value {
-            .textarea__inner {
-                padding-top: var(--filled-m-top-padding);
-            }
-
             &:not(.textarea_autosize) .textarea__control {
                 min-height: calc(
                     var(--filled-height) - var(--filled-m-top-padding)
@@ -378,7 +381,7 @@
                 min-height: calc(
                     var(--filled-m-min-height) - var(--filled-m-top-padding)
                 );
-                padding-top: 0;
+                padding-top: 26px;
             }
         }
 
@@ -403,20 +406,17 @@
         transition-property: border-bottom-color, box-shadow, width,
             background-color;
         transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+        border-bottom-color: var(--color-dark-indigo-15);
 
         &:hover {
             background-color: var(--color-dark-indigo-10);
+            border-color: var(--color-dark-indigo-60);
         }
     }
 
     .textarea__control {
         margin: 0;
         color: var(--color-dark-indigo);
-        border-bottom-color: var(--color-dark-indigo-15);
-
-        &:hover {
-            border-color: var(--color-dark-indigo-60);
-        }
 
         &::placeholder {
             color: var(--color-dark-indigo-60);
@@ -437,15 +437,11 @@
     }
 
     &.textarea_focused {
-        .textarea__control {
-            border-bottom-color: var(--color-dark-indigo);
-            box-shadow: inset 0 -1px 0 var(--color-dark-indigo);
-        }
+        border-bottom-color: var(--color-dark-indigo);
+        box-shadow: inset 0 -1px 0 var(--color-dark-indigo);
     }
 
     &.textarea_has-label {
-        padding-top: 0;
-
         .textarea__control::placeholder {
             color: transparent;
         }
@@ -469,16 +465,16 @@
             color: var(--color-error);
         }
 
-        .textarea__control {
+        border-bottom-color: var(--color-error);
+        box-shadow: inset 0 -1px 0 var(--color-error);
+
+        &.textarea_focused {
             border-bottom-color: var(--color-error);
             box-shadow: inset 0 -1px 0 var(--color-error);
         }
+    }
 
-        &.textarea_focused {
-            .textarea__control {
-                border-bottom-color: var(--color-error);
-                box-shadow: inset 0 -1px 0 var(--color-error);
-            }
-        }
+    .textarea__addons {
+        padding-top: 16px;
     }
 }

--- a/src/textarea/textarea.css
+++ b/src/textarea/textarea.css
@@ -11,11 +11,11 @@
     --top-scale-xl: calc(
         strip(var(--font-size-l)) / strip(var(--font-size-xl))
     );
-    --filled-s-top-padding: 21px;
+    --filled-s-top-padding: 14px;
     --filled-m-top-padding: 28px;
     --filled-height: 110px;
     --filled-s-min-height: 43px;
-    --filled-m-min-height: 45px;
+    --filled-m-min-height: 40px;
 }
 
 .textarea {
@@ -283,7 +283,6 @@
             flex-grow: 1;
             justify-content: space-between;
             width: 100%;
-            height: 100%;
         }
     }
 
@@ -469,11 +468,9 @@
         }
 
         border-bottom-color: var(--color-error);
-        box-shadow: inset 0 -1px 0 var(--color-error);
 
         &.textarea_focused {
             border-bottom-color: var(--color-error);
-            box-shadow: inset 0 -1px 0 var(--color-error);
         }
     }
 

--- a/src/textarea/textarea.test.tsx
+++ b/src/textarea/textarea.test.tsx
@@ -8,6 +8,7 @@ import { mount, shallow } from 'enzyme';
 import { Textarea } from './textarea';
 
 import { SCROLL_TO_CORRECTION } from '../vars';
+import { Icon } from '../icon';
 
 describe('textarea', () => {
     const originalWindowScrollTo = window.scrollTo;
@@ -188,5 +189,17 @@ describe('textarea', () => {
         textarea.find('textarea').simulate('keyDown', { key: 'Down' });
 
         expect(onKeyDown).toHaveBeenCalled();
+    });
+
+    it('should display right addons', () => {
+        const textarea = mount(<Textarea rightAddons={ <Icon /> } />);
+
+        expect(textarea.find('.icon').exists()).toBe(true);
+    });
+
+    it('should not display right addons', () => {
+        const textarea = mount(<Textarea />);
+
+        expect(textarea.find('.icon').exists()).toBe(false);
     });
 });

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -276,15 +276,15 @@ export class Textarea extends React.PureComponent<TextareaProps> {
                             </span>
                         )
                     }
-                    {
-                        (this.props.error || this.props.hint)
-                        && (
-                            <span className={ this.cn('sub') }>
-                                { this.props.error || this.props.hint }
-                            </span>
-                        )
-                    }
                 </span>
+                {
+                    (this.props.error || this.props.hint)
+                    && (
+                        <span className={ this.cn('sub') }>
+                            { this.props.error || this.props.hint }
+                        </span>
+                    )
+                }
             </span>
         );
     }

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import { DeepReadonly } from 'utility-types';
-import TextareaAutosize from 'react-textarea-autosize';
 import { createCn } from 'bem-react-classname';
+import React from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
+import { DeepReadonly } from 'utility-types';
 import { withTheme } from '../cn';
-
 import scrollTo from '../lib/scroll-to';
 import { SCROLL_TO_CORRECTION } from '../vars';
 
@@ -108,6 +107,11 @@ export type TextareaProps = DeepReadonly<{
      * Отображение ошибки
      */
     error?: React.ReactNode;
+
+    /**
+     * Добавление дополнительных элементов к инпуту справа
+     */
+    rightAddons?: React.ReactNode;
 
     /**
      * Размер компонента
@@ -233,6 +237,7 @@ export class Textarea extends React.PureComponent<TextareaProps> {
                     invalid: !!this.props.error,
                     'has-label': !!this.props.label,
                     'has-value': !!value,
+                    addons: !!this.props.rightAddons,
                 }) }
                 ref={ (root) => {
                     this.root = root;
@@ -260,6 +265,16 @@ export class Textarea extends React.PureComponent<TextareaProps> {
                                 />
                             )
                             : <textarea { ...textareaProps } />
+                    }
+                    {
+                        this.props.rightAddons && (
+                            <span
+                                className={ this.cn('addons', { right: true }) }
+                                key="right-addons"
+                            >
+                                { this.props.rightAddons }
+                            </span>
+                        )
                     }
                     {
                         (this.props.error || this.props.hint)

--- a/src/textarea/textarea_theme_alfa-on-color.css
+++ b/src/textarea/textarea_theme_alfa-on-color.css
@@ -7,11 +7,14 @@
 .textarea_theme_alfa-on-color {
     .textarea__control {
         color: var(--color-content-alfa-on-color);
-        border-bottom: 1px solid var(--color-border-control-alfa-on-color);
 
         &::placeholder {
             color: var(--color-content-minor-alfa-on-color);
         }
+    }
+
+    .textarea__inner {
+        border-bottom: 1px solid var(--color-border-control-alfa-on-color);
     }
 
     .textarea__top,
@@ -20,7 +23,7 @@
     }
 
     &.textarea_focused {
-        .textarea__control {
+        .textarea__inner {
             border-bottom-color: var(
                 --color-border-control-focused-alfa-on-color
             );
@@ -28,7 +31,7 @@
     }
 
     &.textarea_focused {
-        .textarea__control {
+        .textarea__inner {
             box-shadow: inset 0 -1px 0 var(--color-border-control-focused-alfa-on-color);
         }
     }
@@ -39,9 +42,11 @@
             color: var(--color-content-disabled-alfa-on-color);
         }
 
-        .textarea__control {
+        .textarea__inner {
             border-bottom-style: var(--border-style-control-disabled);
+        }
 
+        .textarea__control {
             &::placeholder {
                 color: var(--color-content-disabled-alfa-on-color);
             }
@@ -59,12 +64,16 @@
             color: var(--color-error);
         }
 
+        .textarea__inner {
+            border-bottom-color: var(--color-error-translucent);
+        }
+
         .textarea__control {
             border-bottom-color: var(--color-error-translucent);
         }
 
         &.textarea_focused {
-            .textarea__control {
+            .textarea__inner {
                 border-bottom-color: var(--color-error-translucent);
                 box-shadow: inset 0 -1px 0 var(--color-error-translucent);
             }

--- a/src/textarea/textarea_theme_alfa-on-white.css
+++ b/src/textarea/textarea_theme_alfa-on-white.css
@@ -5,9 +5,12 @@
 @import "../vars.css";
 
 .textarea_theme_alfa-on-white {
+    .textarea__inner {
+        border-bottom: 1px solid var(--color-border-control-alfa-on-white);
+    }
+
     .textarea__control {
         color: var(--color-content-alfa-on-white);
-        border-bottom: 1px solid var(--color-border-control-alfa-on-white);
 
         &::placeholder {
             color: var(--color-content-minor-alfa-on-white);
@@ -20,7 +23,7 @@
     }
 
     &.textarea_focused {
-        .textarea__control {
+        .textarea__inner {
             border-bottom-color: var(
                 --color-border-control-focused-alfa-on-white
             );
@@ -28,7 +31,7 @@
     }
 
     &.textarea_focused {
-        .textarea__control {
+        .textarea__inner {
             box-shadow: inset 0 -1px 0 var(--color-border-control-focused-alfa-on-white);
         }
     }
@@ -39,9 +42,11 @@
             color: var(--color-content-disabled-alfa-on-white);
         }
 
-        .textarea__control {
+        .textarea__inner {
             border-bottom-style: var(--border-style-control-disabled);
+        }
 
+        .textarea__control {
             &::placeholder {
                 color: var(--color-content-disabled-alfa-on-white);
             }
@@ -59,12 +64,12 @@
             color: var(--color-error);
         }
 
-        .textarea__control {
+        .textarea__inner {
             border-bottom-color: var(--color-error-translucent);
         }
 
         &.textarea_focused {
-            .textarea__control {
+            .textarea__inner {
                 border-bottom-color: var(--color-error-translucent);
                 box-shadow: inset 0 -1px 0 var(--color-error-translucent);
             }


### PR DESCRIPTION
Добавлена иконка для textarea и изменена его структура DOM и стили

<!--- Название для изменений -->

![image](https://user-images.githubusercontent.com/2098777/85143051-e9a19f80-b251-11ea-8ab0-e1deb88ac1f5.png)


## Мотивация и контекст
В Новом интернет банке, хочется, чтобы это иконка была внутри textarea
![image](https://user-images.githubusercontent.com/2098777/85143127-0938c800-b252-11ea-999c-0555d5767823.png)

