### PR TITLE
fix(*): fix hbs-templates for build:icons command

### DIFF
--- a/tools/icon/icon.test.tsx.hbs
+++ b/tools/icon/icon.test.tsx.hbs
@@ -13,21 +13,21 @@ import {{this.componentName}} from './{{this.category}}/{{this.name}}';
 
 describe('icon', () => {
     it('renders without problems', () => {
-        let icon = shallow(<Icon />);
+        const icon = shallow(<Icon />);
         expect(icon).toMatchSnapshot();
     });
 
     (() => {
-        let icons = [
+        const icons = [
         {{#each this}}
-            { componentName: {{this.componentName}}, name: '{{this.name}}' }{{#unless @last }},{{/unless}}
+            { componentName: {{this.componentName}}, name: '{{this.name}}' },
         {{/each}}
         ];
 
         return icons.map((icon, index) => (
             it(`render ${icon.componentName.name} without problems`, () => {
-                let CurrentComponent = icons[index].componentName;
-                let renderedIcon = shallow(<CurrentComponent />);
+                const CurrentComponent = icons[index].componentName;
+                const renderedIcon = shallow(<CurrentComponent />);
                 expect(renderedIcon).toMatchSnapshot(icon.componentName.name);
             })
         ));

--- a/tools/icon/icon.tsx.hbs
+++ b/tools/icon/icon.tsx.hbs
@@ -4,15 +4,15 @@
 
 import React from 'react';
 import { withTheme } from '../../../cn';
-import Icon from '../../../icon';
-import { IconProps } from '../../../icon/icon';
+import Icon from '../..';
+import { IconProps } from '../../icon';
 
 class {{componentName}} extends React.PureComponent<IconProps> {
     render() {
         return (
             <Icon
                 { ...this.props }
-                name='{{name}}'
+                name="{{name}}"
             />
         );
     }

--- a/tools/icon/index.ts.hbs
+++ b/tools/icon/index.ts.hbs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import './{{name}}.css';
-import '../../../icon';
+import '../..';
 
 export * from './{{name}}';
 export { default } from './{{name}}';


### PR DESCRIPTION
Обновил темплейты для build:icons npm-команды

## Мотивация и контекст
Захотелось научиться обновлять иконки - нашел команду build:icons, которая, как я понимаю, должна для этого использоваться. Она сгенерировала более 900 файлов - все иконки.
Кажется, hbs-шаблоны для команды устарели, пути по-моему там неверные.
После моих изменений запуск команды не генерирует кучу новых файлов.