### PR TITLE
fix(button): remove legacy styles

### DIFF
--- a/src/button/button.css
+++ b/src/button/button.css
@@ -37,10 +37,6 @@
         border: 0;
     }
 
-    & + & {
-        margin-left: var(--gap-s);
-    }
-
     &__addon {
         flex: 0 0 auto;
 


### PR DESCRIPTION
Убрал лишние стили, которые задают отступы для рядом стоящих кнопок

## Мотивация и контекст
<!--- Почему эти изменения необходимы? Какую проблему они решают? -->
Отступы для рядом стоящих кнопок должны задаваться извне и при необходимости, а не быть захардкожеными в самом компоненте. Если нужны дополнительные стили, на пример, внешние отступы, то они должны задаваться через className
