### PR TITLE
fix(popup-container-provider): restore childContextType

### DIFF
--- a/src/popup-container-provider/popup-container-provider.tsx
+++ b/src/popup-container-provider/popup-container-provider.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
+import Type from 'prop-types';
 import { createCn } from 'bem-react-classname';
 
 import { IsolatedContainer } from '../isolated-container/isolated-container';
@@ -79,6 +80,12 @@ type PopupContainerProviderState = {
  */
 class PopupContainerProvider extends
     React.PureComponent<PopupContainerProviderProps, PopupContainerProviderState> {
+    static childContextTypes = {
+        isInCustomContainer: Type.bool,
+        renderContainerElement: Type.shape({}),
+        positioningContainerElement: Type.shape({}),
+    };
+
     protected cn = createCn('popup-container');
 
     state = {


### PR DESCRIPTION
Восстанавливаем удаленные при переходе на ts contextType

## Мотивация и контекст
Старый contextApi зависит от них и не работает без них