### PR TITLE
fix(input): input wrapper take all remaining from addons space

### DIFF
--- a/src/input/input.css
+++ b/src/input/input.css
@@ -645,6 +645,8 @@
 
     &.input_has-addons {
         .input__input-wrapper {
+            width: 100%;
+
             .input__control {
                 padding-left: var(--gap-s);
                 padding-right: var(--gap-s);


### PR DESCRIPTION
Исправление для #1211 

