### PR TITLE
chore(package): allow to run semantic release by npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "build:demo": "styleguidist build",
     "build:flag-icons": "gulp --gulpfile ./src/flag-icon/flag-icon.gulpfile.js",
     "build:icons": "node ./tools/icon/build-icons.js && svgo ./src/icon/**/* --config=.svgo.yml",
-    "update-primitive-colors": "node ./tools/update-colors.js"
+    "update-primitive-colors": "node ./tools/update-colors.js",
+    "semantic-release": "semantic-release"
   },
   "lint-staged": {
     "concurrent": false,


### PR DESCRIPTION
Правим работу semantic-release

## Мотивация и контекст
В отличии от yarn, npm не умеет запускать бинарники через `npm run ...` если они явно не прописаны в package.json