### PR TITLE
fix(*): emitting calendar month change in calendar input

### DIFF
--- a/src/calendar-input/calendar-input.tsx
+++ b/src/calendar-input/calendar-input.tsx
@@ -476,6 +476,10 @@ export class CalendarInput extends React.Component<CalendarInputProps> {
         this.setState({
             month,
         });
+
+        if (this.props.calendar && this.props.calendar.onMonthChange) {
+            this.props.calendar.onMonthChange();
+        }
     };
 
     private handleCalendarFocus = (event) => {


### PR DESCRIPTION
Пробрасываю calendar.onMonthChange в компонент календаря

## Мотивация и контекст
Сейчас при пробрасывании пропсов из CalendarInput в Calendar все пропсы пробрасываются кроме onMonthChange — метод перетирался локальным.
