### PR TITLE
feat(*): change 'npm i' on 'npm ci'

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           npm cache clean --force
           rm -rf ~/.npm node_modules
-          npm i
+          npm ci
 
       - name: Lint's checks
         if: ${{ matrix.test-scope == 'lint' }}


### PR DESCRIPTION
Меняет план для запуска тестов

## Мотивация и контекст
В старой версии при необновленном package-lock сборка не падала на тестах, но валилась на релизе. 
С этими изменениями будет бадать на тестах. 