### PR TITLE
fix(calendar): show offDays and eventDays for different timezones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4569,14 +4569,21 @@
     "@types/lodash": {
       "version": "4.14.149",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-      "dev": true
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
     },
     "@types/lodash.debounce": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
       "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
       "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.sortedindexby": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.sortedindexby/-/lodash.sortedindexby-4.6.6.tgz",
+      "integrity": "sha512-h3SwJ6zBrcjh9bdzdkGXrDscUi1AC/xvet6/kwI9thND+kxd7/Dw6VsRGNY/4WH7vJEXSnFCkzMUdHHraYsGCw==",
       "requires": {
         "@types/lodash": "*"
       }
@@ -22638,6 +22645,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.sortedindexby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortedindexby/-/lodash.sortedindexby-4.6.0.tgz",
+      "integrity": "sha1-RvGY+9+80Jxv1MF303zaPMZS2fk="
     },
     "lodash.sortedindexof": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.7.6",
     "@types/enzyme-adapter-react-16": "^1.0.6",
+    "@types/lodash.sortedindexby": "^4.6.6",
     "bem-react-classname": "1.2.1",
     "bezier-easing": "2.1.0",
     "cn-decorator": "^2.1.0",
@@ -91,6 +92,7 @@
     "inputmask-core": "2.2.0",
     "libphonenumber-js": "1.0.24",
     "lodash.debounce": "4.0.8",
+    "lodash.sortedindexby": "^4.6.0",
     "lodash.sortedindexof": "4.1.0",
     "matches-selector-polyfill": "1.0.0",
     "prop-types": "15.7.2",

--- a/src/calendar/__snapshots__/calendar.test.tsx.snap
+++ b/src/calendar/__snapshots__/calendar.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`calendar should render without problems 1`] = `
 <Calendar
   eventDays={Array []}
+  ignoreTimezone={false}
   isKeyboard={true}
   month={1529020800000}
   months={

--- a/src/calendar/calendar.test.tsx
+++ b/src/calendar/calendar.test.tsx
@@ -371,6 +371,7 @@ describe('calendar', () => {
         ];
         const calendar = mount(
             <Calendar
+                value={startOfDay(new Date('2020-11-15')).valueOf()}
                 ignoreTimezone={ true }
                 eventDays={ eventDays }
             />
@@ -389,6 +390,7 @@ describe('calendar', () => {
         ];
         const calendar = mount(
             <Calendar
+                value={startOfDay(new Date('2020-11-15')).valueOf()}
                 ignoreTimezone={ true }
                 offDays={ offDays }
             />

--- a/src/calendar/calendar.test.tsx
+++ b/src/calendar/calendar.test.tsx
@@ -362,4 +362,40 @@ describe('calendar', () => {
 
         expect(days.length).toBe(42);
     });
+
+    it('should render eventDays for different timezone with enabled ignoreTimezone', () => {
+        const eventDays = [
+            1604696400000,
+            1604782800000,
+            1605042000000,
+        ];
+        const calendar = mount(
+            <Calendar
+                ignoreTimezone={ true }
+                eventDays={ eventDays }
+            />
+        );
+
+        const days = calendar.find('.calendar__event');
+
+        expect(days.length).toBe(3);
+    });
+
+    it('should render offDays for different timezone with enabled ignoreTimezone', () => {
+        const offDays = [
+            1605387600000,
+            1605992400000,
+            1606597200000,
+        ];
+        const calendar = mount(
+            <Calendar
+                ignoreTimezone={ true }
+                offDays={ offDays }
+            />
+        );
+
+        const days = calendar.find('.calendar__day_type_weekend-off');
+
+        expect(days.length).toBe(3);
+    });
 });

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -23,6 +23,7 @@ import setYear from 'date-fns/set_year';
 import endOfMonth from 'date-fns/end_of_month';
 import eachDay from 'date-fns/each_day';
 import sortedIndexOf from 'lodash.sortedindexof';
+import sortedIndexBy from 'lodash.sortedindexby';
 
 import keyboardCode from '../lib/keyboard-code';
 import performance from '../performance';
@@ -732,11 +733,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     private isOffDay(date: Date | number) {
         if (this.props.offDays && Array.isArray(this.props.offDays)) {
             if (this.props.ignoreTimezone) {
-                const dateWithoutTime = formatDate(date, WITHOUT_TIME_FORMAT);
-                
-                return this.props.offDays.findIndex(
-                    (offDay) => formatDate(offDay, WITHOUT_TIME_FORMAT) === dateWithoutTime
-                ) !== -1;
+                return Calendar.checkDaysIgnoringTimezone(this.props.offDays, date);
             }
             const timestamp = date.valueOf();
 
@@ -755,11 +752,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     private isEventDay(date: Date | number) {
         if (this.props.eventDays && Array.isArray(this.props.eventDays) && date !== null) {
             if (this.props.ignoreTimezone) {
-                const dateWithoutTime = formatDate(date, WITHOUT_TIME_FORMAT);
-
-                return this.props.eventDays.findIndex(
-                    (eventDay) => formatDate(eventDay, WITHOUT_TIME_FORMAT) === dateWithoutTime
-                ) !== -1;
+                return Calendar.checkDaysIgnoringTimezone(this.props.eventDays, date);
             }
             const timestamp = date.valueOf();
 
@@ -946,6 +939,19 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             this.selectedFrom = nextProps.selectedFrom
                 ? normalizeDate(nextProps.selectedFrom) : null;
         }
+    }
+
+    /**
+     * Проверяет наличие даты в списке дат с игнорированием таймзоны.
+     * 
+     * @param date Дата
+     * @param daysToСheck Список дат для проверки
+     */
+    private static checkDaysIgnoringTimezone(daysToCheck: readonly number[], date: Date | number) {
+        const dateWithoutTime = formatDate(date, WITHOUT_TIME_FORMAT);
+        /* Используем бинарный поиск */
+        const index = sortedIndexBy<string | number>(daysToCheck, dateWithoutTime, (day) => formatDate(day, WITHOUT_TIME_FORMAT));
+        return dateWithoutTime === formatDate(daysToCheck[index], WITHOUT_TIME_FORMAT);
     }
 }
 


### PR DESCRIPTION
Добавил флаг ignoreTimezones, при включении игнорируется время для дат offDays и eventDays, для корректного отображения у пользователей из разных таймзон.

## Мотивация и контекст
Проблема описана в issue #1232 
