### PR TITLE
feat(*): update date-fns

### DIFF
--- a/gemini/calendar.gemini.js
+++ b/gemini/calendar.gemini.js
@@ -1,7 +1,7 @@
-import startOfDay from 'date-fns/start_of_day';
-import addDays from 'date-fns/add_days';
-import subtractDays from 'date-fns/sub_days';
-import getTime from 'date-fns/get_time';
+import startOfDay from 'date-fns/startOfDay';
+import addDays from 'date-fns/addDays';
+import subtractDays from 'date-fns/subDays';
+import getTime from 'date-fns/getTime';
 
 import Calendar from '../src/calendar';
 import GeminiBox from '../gemini-utils/gemini-box/gemini-box';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5758,7 +5758,7 @@
       "dependencies": {
         "bem-react-classname": {
           "version": "1.1.4",
-          "resolved": "http://binary:80/artifactory/api/npm/npm/bem-react-classname/-/bem-react-classname-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/bem-react-classname/-/bem-react-classname-1.1.4.tgz",
           "integrity": "sha1-Pgp96yXgsZhw2TKKfcXh2/ywK1c=",
           "dev": true
         },
@@ -9005,7 +9005,7 @@
     },
     "bem-react-classname": {
       "version": "1.2.1",
-      "resolved": "http://binary:80/artifactory/api/npm/npm/bem-react-classname/-/bem-react-classname-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/bem-react-classname/-/bem-react-classname-1.2.1.tgz",
       "integrity": "sha1-TxF7epsjeDuZfro5FUhK4NSILHU="
     },
     "bezier-easing": {
@@ -11960,9 +11960,9 @@
       }
     },
     "date-fns": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
+      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -22284,6 +22284,14 @@
         "cli-cursor": "^2.1.0",
         "date-fns": "^1.27.2",
         "figures": "^2.0.0"
+      },
+      "dependencies": {
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+          "dev": true
+        }
       }
     },
     "load-json-file": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "bezier-easing": "2.1.0",
     "cn-decorator": "^2.1.0",
     "core-js": "2.5.5",
-    "date-fns": "1.29.0",
+    "date-fns": "^2.16.1",
     "deprecated-decorator": "0.1.6",
     "inputmask-core": "2.2.0",
     "libphonenumber-js": "1.0.24",

--- a/src/calendar-input/README.md
+++ b/src/calendar-input/README.md
@@ -26,13 +26,13 @@
 ```
 
 ```jsx
-const formatDate = require('date-fns/format');
+import { format as formatDate } from 'date-fns';
 
 <div>
     {
         ['s', 'm', 'l', 'xl'].map(size => (
             <div className='row' key={ size }>
-                <CalendarInput size={ size } placeholder={ formatDate(new Date(), 'DD.MM.YYYY') } width='available' />
+                <CalendarInput size={ size } placeholder={ formatDate(new Date(), 'dd.MM.yyyy') } width='available' />
             </div>
         ))
     }
@@ -81,8 +81,10 @@ const IconOk = require('../../src/icon/ui/ok').default;
 
 С отображением текущей даты
 ```jsx
-const addDays = require('date-fns/add_days');
-const formatDate = require('date-fns/format');
+import {
+    addDays,
+    format as formatDate
+} from 'date-fns';
 
 const currentDate = new Date();
 
@@ -94,7 +96,7 @@ const calendar = {
     <CalendarInput
         size='m'
         calendar={ calendar }
-        defaultValue={ formatDate(addDays(currentDate, 2), 'DD.MM.YYYY') }
+        defaultValue={ formatDate(addDays(currentDate, 2), 'dd.MM.yyyy') }
         mobileMode='popup'
     />
 </div>

--- a/src/calendar-input/calendar-input.test.tsx
+++ b/src/calendar-input/calendar-input.test.tsx
@@ -402,20 +402,20 @@ describe('calendar-input', () => {
 
     describe('calendar utils', () => {
         it('should change format of a date', () => {
-            const result = calendarUtils.changeDateFormat('2012-11-10', 'YYYY-MM-DD', 'DD.MM.YYYY');
+            const result = calendarUtils.changeDateFormat('2012-11-10', 'yyyy-MM-dd', 'dd.MM.yyyy');
 
             expect(result).toBe('10.11.2012');
         });
 
         it('should return start of month', () => {
-            const result = new Date(calendarUtils.calculateMonth('2012-11-10', 'YYYY-MM-DD'));
+            const result = new Date(calendarUtils.calculateMonth('2012-11-10', 'yyyy-MM-dd'));
 
             expect(result.getMonth() + 1).toBe(11); // getMonth is zero based
             expect(result.getFullYear()).toBe(2012);
         });
 
         it('should return current month if not valid value given', () => {
-            const result = new Date(calendarUtils.calculateMonth('foo', 'YYYY-MM-DD'));
+            const result = new Date(calendarUtils.calculateMonth('foo', 'yyyy-MM-dd'));
             const now = new Date();
 
             expect(result.getMonth()).toBe(now.getMonth());
@@ -425,7 +425,7 @@ describe('calendar-input', () => {
         it('should return earlierLimit month if it after given date', () => {
             const result = new Date(calendarUtils.calculateMonth(
                 '2012-11-10',
-                'YYYY-MM-DD',
+                'yyyy-MM-dd',
                 (new Date(2013, 8, 10).getTime()),
             ));
 
@@ -436,7 +436,7 @@ describe('calendar-input', () => {
         it('should return laterLimit month if it before given date', () => {
             const result = new Date(calendarUtils.calculateMonth(
                 '2012-11-10',
-                'YYYY-MM-DD',
+                'yyyy-MM-dd',
                 (new Date(2011, 8, 10).getTime()),
                 (new Date(2011, 9, 10).getTime()),
             ));
@@ -448,7 +448,7 @@ describe('calendar-input', () => {
         it('should return start of month if earlier and later limit given, but value is between them', () => {
             const result = new Date(calendarUtils.calculateMonth(
                 '2012-11-10',
-                'YYYY-MM-DD',
+                'yyyy-MM-dd',
                 (new Date(2011, 8, 10).getTime()),
                 (new Date(2014, 9, 10).getTime()),
             ));

--- a/src/calendar-input/calendar-input.tsx
+++ b/src/calendar-input/calendar-input.tsx
@@ -25,12 +25,12 @@ import {
 import performance from '../performance';
 
 /**
- * NB: В нативном календаре нельзя менять формат даты. Приемлем только YYYY-MM-DD формат.
+ * NB: В нативном календаре нельзя менять формат даты. Приемлем только yyyy-MM-dd формат.
  * https://www.w3.org/TR/html-markup/input.date.html#input.date.attrs.value
  * https://tools.ietf.org/html/rfc3339#section-5.6
 */
-const CUSTOM_DATE_FORMAT = 'DD.MM.YYYY';
-const NATIVE_DATE_FORMAT = 'YYYY-MM-DD';
+const CUSTOM_DATE_FORMAT = 'dd.MM.yyyy';
+const NATIVE_DATE_FORMAT = 'yyyy-MM-dd';
 const IS_BROWSER = typeof window !== 'undefined';
 const SUPPORTS_INPUT_TYPE_DATE = IS_BROWSER && isInputDateSupported();
 
@@ -569,7 +569,7 @@ export class CalendarInput extends React.Component<CalendarInputProps> {
         // Копируем пришедший из аргументов SyntheticEvent для дальнейшего редактирования
         const resultEvent = {
             ...event,
-            // Трансформируем нативную YYYY-MM-DD дату в кастомный формат на вывод в коллбэках
+            // Трансформируем нативную yyyy-MM-dd дату в кастомный формат на вывод в коллбэках
             target: { value: changeDateFormat(event.target.value, NATIVE_DATE_FORMAT, CUSTOM_DATE_FORMAT) },
         };
 
@@ -592,7 +592,7 @@ export class CalendarInput extends React.Component<CalendarInputProps> {
         // Копируем пришедший из аргументов SyntheticEvent для дальнейшего редактирования
         const resultEvent = {
             ...event,
-            // Трансформируем нативную YYYY-MM-DD дату в кастомный формат на вывод в коллбэках
+            // Трансформируем нативную yyyy-MM-dd дату в кастомный формат на вывод в коллбэках
             target: { value: changeDateFormat(event.target.value, NATIVE_DATE_FORMAT, CUSTOM_DATE_FORMAT) },
         };
 

--- a/src/calendar-input/utils.ts
+++ b/src/calendar-input/utils.ts
@@ -1,7 +1,8 @@
-import getTime from 'date-fns/get_time';
-import startOfDay from 'date-fns/start_of_day';
+import getTime from 'date-fns/getTime';
+import startOfDay from 'date-fns/startOfDay';
 import formatDate from 'date-fns/format';
-import isDateValid from 'date-fns/is_valid';
+import isDateValid from 'date-fns/isValid';
+
 import { parse } from '../lib/date-utils';
 
 /**

--- a/src/calendar/README.md
+++ b/src/calendar/README.md
@@ -18,8 +18,10 @@ initialState = {
 ### Выбор даты из ограниченного интервала
 Календарь с заданными левой и правой границей. Позволяет выбрать дату из заданного диапазона. Например, дату встречи с банком для заключения кредитного договора.
 ```jsx
-const addDays = require('date-fns/add_days');
-const subtractDays = require('date-fns/sub_days');
+import {
+    addDays,
+    subDays as subtractDays, 
+} from 'date-fns';
 
 initialState = {
     date: Date.now(),
@@ -42,9 +44,11 @@ initialState = {
 ### Недоступные даты
 Случается, что некоторые даты нельзя выбрать. Например, выходные или праздники.
 ```jsx
-const getTime = require('date-fns/get_time');
-const addDays = require('date-fns/add_days');
-const startOfDay = require('date-fns/start_of_day');
+import {
+    getTime,
+    addDays,
+    startOfDay 
+} from 'date-fns';
 
 initialState = {
     date: Date.now()
@@ -70,9 +74,11 @@ const offDays = [
 ### Отметка о событии
 К календарю могут быть привязаны события или мероприятия: запланированные платежи, даты сдачи отчётности в налоговую и т.д.
 ```jsx
-const getTime = require('date-fns/get_time');
-const addDays = require('date-fns/add_days');
-const startOfDay = require('date-fns/start_of_day');
+import {
+    getTime,
+    addDays,
+    startOfDay 
+} from 'date-fns';
 
 initialState = {
     date: Date.now()

--- a/src/calendar/__snapshots__/calendar.test.tsx.snap
+++ b/src/calendar/__snapshots__/calendar.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`calendar should render without problems 1`] = `
     ]
   }
   offDays={Array []}
-  outputFormat="DD.MM.YYYY"
+  outputFormat="dd.MM.yyyy"
   selectedFrom={null}
   selectedTo={null}
   showArrows={true}

--- a/src/calendar/calendar.test.tsx
+++ b/src/calendar/calendar.test.tsx
@@ -6,11 +6,11 @@ import React from 'react';
 import { mount } from 'enzyme';
 import timezoneMock from 'timezone-mock';
 
-import addDays from 'date-fns/add_days';
-import startOfDay from 'date-fns/start_of_day';
-import subtractDays from 'date-fns/sub_days';
-import subtractMonth from 'date-fns/sub_months';
-import addMonth from 'date-fns/add_months';
+import addDays from 'date-fns/addDays';
+import startOfDay from 'date-fns/startOfDay';
+import subtractDays from 'date-fns/subDays';
+import subtractMonth from 'date-fns/subMonths';
+import addMonth from 'date-fns/addMonths';
 import formatDate from 'date-fns/format';
 
 import { Calendar } from './calendar';
@@ -20,7 +20,7 @@ import keyboardCode from '../lib/keyboard-code';
 // initialize this later, after we will register timezoneMock
 let INITIAL_DAY;
 let TODAY_DAY;
-const DATE_FORMAT = 'DD.MM.YYYY';
+const DATE_FORMAT = 'dd.MM.yyyy';
 
 describe('calendar', () => {
     beforeAll(() => {

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -9,19 +9,19 @@ import React from 'react';
 
 import { createCn } from 'bem-react-classname';
 
-import differenceInMonths from 'date-fns/difference_in_months';
-import differenceInMilliseconds from 'date-fns/difference_in_milliseconds';
-import startOfDay from 'date-fns/start_of_day';
-import startOfMonth from 'date-fns/start_of_month';
-import addDays from 'date-fns/add_days';
-import addYears from 'date-fns/add_years';
-import subtractYears from 'date-fns/sub_years';
+import differenceInMonths from 'date-fns/differenceInMonths';
+import differenceInMilliseconds from 'date-fns/differenceInMilliseconds';
+import startOfDay from 'date-fns/startOfDay';
+import startOfMonth from 'date-fns/startOfMonth';
+import addDays from 'date-fns/addDays';
+import addYears from 'date-fns/addYears';
+import subtractYears from 'date-fns/subYears';
 import formatDate from 'date-fns/format';
-import isSameMonth from 'date-fns/is_same_month';
-import setMonth from 'date-fns/set_month';
-import setYear from 'date-fns/set_year';
-import endOfMonth from 'date-fns/end_of_month';
-import eachDay from 'date-fns/each_day';
+import isSameMonth from 'date-fns/isSameMonth';
+import setMonth from 'date-fns/setMonth';
+import setYear from 'date-fns/setYear';
+import endOfMonth from 'date-fns/endOfMonth';
+import eachDay from 'date-fns/eachDayOfInterval';
 import sortedIndexOf from 'lodash.sortedindexof';
 
 import keyboardCode from '../lib/keyboard-code';
@@ -181,7 +181,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     static defaultProps: Partial<CalendarProps> = {
         selectedFrom: null,
         selectedTo: null,
-        outputFormat: 'DD.MM.YYYY',
+        outputFormat: 'dd.MM.yyyy',
         weekdays: ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'],
         months: ['Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь',
             'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь'],
@@ -367,7 +367,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
                         this.props.months.map((month, index) => {
                             const monthStart = startOfMonth(setMonth(this.state.month, index));
                             const monthEnd = endOfMonth(monthStart);
-                            const allMonthDays = eachDay(monthStart, monthEnd);
+                            const allMonthDays = eachDay({
+                                start: monthStart,
+                                end: monthEnd,
+                            });
                             const off = !allMonthDays.find((day) => this.isValidDate(day));
                             const selectedDate = new Date(this.state.month);
                             const isSameMonth = selectedDate

--- a/src/calendar/utils.ts
+++ b/src/calendar/utils.ts
@@ -1,5 +1,5 @@
-import startOfToday from 'date-fns/start_of_today';
-import getTime from 'date-fns/get_time';
+import startOfToday from 'date-fns/startOfToday';
+import getTime from 'date-fns/getTime';
 
 /**
  * Возвращает `true`, если переданная дата является текущей датой.

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -43,16 +43,16 @@ describe('date utils', () => {
         it('should allow to use any symbol as delimiter between date tokens', () => {
             const targetDate = (new Date(2017, 0, 1)).getTime();
 
-            expect(parse('01_01_2017', 'DD_MM_YYYY').getTime()).toEqual(targetDate);
-            expect(parse('day: 01, month: 01, year: 2017', 'day: DD, month: MM, year: YYYY').getTime())
+            expect(parse('01_01_2017', 'dd_MM_yyyy').getTime()).toEqual(targetDate);
+            expect(parse('day: 01, month: 01, year: 2017', 'day: dd, month: MM, year: yyyy').getTime())
                 .toEqual(targetDate);
-            expect(parse('2017, 01, 01', 'YYYY, MM, DD').getTime()).toEqual(targetDate);
+            expect(parse('2017, 01, 01', 'yyyy, MM, dd').getTime()).toEqual(targetDate);
         });
 
-        it('should return start of the month if only YYYY and MM is presented in format', () => {
+        it('should return start of the month if only yyyy and MM is presented in format', () => {
             const targetDate = (new Date(2017, 0, 1)).getTime();
 
-            expect(parse('01 2017', 'MM YYYY').getTime()).toEqual(targetDate);
+            expect(parse('01 2017', 'MM yyyy').getTime()).toEqual(targetDate);
         });
 
         /* eslint-disable no-restricted-globals */
@@ -74,8 +74,8 @@ describe('date utils', () => {
         it('should return valid date if date token is out of range and strict = false', () => {
             const targetDate = (new Date(2017, 0, 1)).getTime();
 
-            expect(parse('32.12.2016', 'DD.MM.YYYY', false).getTime()).toEqual(targetDate);
-            expect(parse('01.13.2016', 'DD.MM.YYYY', false).getTime()).toEqual(targetDate);
+            expect(parse('32.12.2016', 'dd.MM.yyyy', false).getTime()).toEqual(targetDate);
+            expect(parse('01.13.2016', 'dd.MM.yyyy', false).getTime()).toEqual(targetDate);
         });
     });
 });

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -4,7 +4,7 @@
 
 /* eslint no-continue: 0 */
 
-import getDaysInMonth from 'date-fns/get_days_in_month';
+import getDaysInMonth from 'date-fns/getDaysInMonth';
 
 const DAYS_IN_WEEK = 7;
 
@@ -32,11 +32,11 @@ export function getRussianWeekDay(date: Date): number {
 }
 
 const PARSE_TOKENS: DateParserToken[] = [
-    { type: 'date', regex: /^\d{2}/, formatRegex: /^DD/ },
-    { type: 'date', regex: /^\d{1,2}/, formatRegex: /^D/ },
+    { type: 'date', regex: /^\d{2}/, formatRegex: /^dd/ },
+    { type: 'date', regex: /^\d{1,2}/, formatRegex: /^\bd\b|^d_/ },
     { type: 'month', regex: /^\d{2}/, formatRegex: /^MM/ },
-    { type: 'month', regex: /^\d{1,2}/, formatRegex: /^M/ },
-    { type: 'year', regex: /^\d{4}/, formatRegex: /^YYYY/ },
+    { type: 'month', regex: /^\d{1,2}/, formatRegex: /^\bM\b|^M_/ },
+    { type: 'year', regex: /^\d{4}/, formatRegex: /^yyyy/ },
 ];
 
 type Limit = {
@@ -146,11 +146,11 @@ function parseFormat(format: string): FormatParserToken[] {
 /**
  * Разбирает дату из строки по заданному формату.
  * Допустимые элементы формата:
- * D - дата, в формате 1-31
- * DD - дата, в формате 01-31,
+ * d - дата, в формате 1-31
+ * dd - дата, в формате 01-31,
  * M - месяц, в формате 1-12,
  * MM - месяц, в формате 01-12
- * YYYY - год
+ * yyyy - год
  * В качестве разделителей между элементами даты могут выступать любые символы, не являющиеся частью формата.
  *
  * @param input Входная строка для разбора.
@@ -158,7 +158,7 @@ function parseFormat(format: string): FormatParserToken[] {
  * @param strict Запрещать ли значения, выходящие за пределы логических ограничений месяцев/дней.
  * В случае если strict=false 22 месяц будет интерпретироваться как год и 10 месяцев.
  */
-export function parse(input: string, format = 'DD.MM.YYYY', strict = true): Date {
+export function parse(input: string, format = 'dd.MM.yyyy', strict = true): Date {
     const parsedFormat = parseFormat(format);
     const parsedResult: Partial<Record<DateType, number>> = {};
 
@@ -171,6 +171,7 @@ export function parse(input: string, format = 'DD.MM.YYYY', strict = true): Date
             }
             // eslint-disable-next-line no-param-reassign
             input = input.substring(1);
+
             continue;
         }
 


### PR DESCRIPTION
Обновил версию date-fns до второй версии.

Изменения, коснувшиеся фижера

1. Названия сабмодулей были переписаны c snake_case в camelCase
2. Формат дней и года сменились с DD на dd, YYYY на yyyy
3. Модуль each_day был переименован на eachDayOfInterval, и принимает в аргументах объект типа
{ start: Date; end: Date; } 

Также:

Обернул токен дня и месяца в границы, а то если в предложении имеется слова с d или M, то регулярка берет первое попавшиеся совпадение и это может привести к багам при парсинге.