### PR TITLE
fix(money-input): add check for leading zeros

### DIFF
--- a/src/money-input/money-input.tsx
+++ b/src/money-input/money-input.tsx
@@ -201,6 +201,11 @@ export class MoneyInput extends React.PureComponent<MoneyInputProps, MoneyInputS
     };
 
     private handleChange = (value) => {
+        // если значение начинается с нуля, то следом за ним может быть только десятичный разделитель
+        if (/^0\d+/.test(value)) {
+            return;
+        }
+
         this.setState({ value });
 
         if (this.props.onChange) {


### PR DESCRIPTION
Добавил проверку на лишние нули в начале значения в MoneyInput. Если первая цифра ноль, то следующим символом может быть только десятичный разделитель. 
Fixes #1186 
