### PR TITLE
Fix/input styles

### DIFF
--- a/src/input/input_theme_alfa-dark.css
+++ b/src/input/input_theme_alfa-dark.css
@@ -86,7 +86,8 @@
             }
         }
 
-        .input__control::placeholder {
+        .input__control::placeholder,
+        .input__top {
             color: var(--color-light-text-secondary);
         }
 

--- a/src/input/input_theme_alfa-light.css
+++ b/src/input/input_theme_alfa-light.css
@@ -69,9 +69,14 @@
 
     &.input_disabled {
         .input__box {
-            border-bottom-color: var(--color-dark-bg-secondary-inverted);
+            background-color: var(--color-light-bg-tertiary);
+            border-bottom-color: var(--color-light-graphic-tertiary);
             border-bottom-style: var(--border-style-control-disabled);
             box-shadow: none;
+
+            &:hover {
+                background-color: var(--color-light-bg-tertiary);
+            }
         }
 
         &,
@@ -86,7 +91,8 @@
             }
         }
 
-        .input__control::placeholder {
+        .input__control::placeholder,
+        .input__top {
             color: var(--color-light-text-secondary);
         }
 

--- a/src/input/input_theme_alfa-on-color.css
+++ b/src/input/input_theme_alfa-on-color.css
@@ -82,7 +82,8 @@
             }
         }
 
-        .input__control::placeholder {
+        .input__control::placeholder,
+        .input__top {
             color: var(--color-content-disabled-alfa-on-color);
         }
 

--- a/src/vars/shadow.css
+++ b/src/vars/shadow.css
@@ -24,7 +24,6 @@
      * и приподнять компонент над контентом. Используется, например, в попапах и нотификейшенах.
      */
     --shadow-light: 0 1px 5px 0 var(--shadow-light-color);
-
     --shadow-dark: 0 1px 5px 0 var(--shadow-color-dark);
 
     /**


### PR DESCRIPTION
Подправил стили для Input в разных темах

## Мотивация и контекст
До:
<img width="1440" alt="Screenshot 2021-05-07 at 18 25 37" src="https://user-images.githubusercontent.com/30253042/117496673-0df88e80-af80-11eb-8f21-482808e05774.png">
<img width="1440" alt="Screenshot 2021-05-07 at 18 26 46" src="https://user-images.githubusercontent.com/30253042/117496680-105ae880-af80-11eb-8e7e-0a6362bc7707.png">
<img width="1440" alt="Screenshot 2021-05-07 at 18 27 12" src="https://user-images.githubusercontent.com/30253042/117496691-12bd4280-af80-11eb-8032-37c75ab5081a.png">
<img width="1439" alt="Screenshot 2021-05-07 at 18 27 33" src="https://user-images.githubusercontent.com/30253042/117496694-1355d900-af80-11eb-9cfc-a3ad54f142bb.png">

После:
<img width="1437" alt="Screenshot 2021-05-07 at 22 13 59" src="https://user-images.githubusercontent.com/30253042/117497777-962b6380-af81-11eb-8e0b-fd8a47ee725a.png">
<img width="1440" alt="Screenshot 2021-05-07 at 22 13 48" src="https://user-images.githubusercontent.com/30253042/117497779-975c9080-af81-11eb-892c-71690ea94513.png">
<img width="1440" alt="Screenshot 2021-05-07 at 22 13 38" src="https://user-images.githubusercontent.com/30253042/117497781-975c9080-af81-11eb-8587-c347f5f89ccf.png">
<img width="1440" alt="Screenshot 2021-05-07 at 22 13 25" src="https://user-images.githubusercontent.com/30253042/117497785-97f52700-af81-11eb-848e-fcfe90a68eb2.png">
