### PR TITLE
feat(calendar): add reverseYearsOrder prop to change order of years

### DIFF
--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -130,6 +130,11 @@ export type CalendarProps = {
     ignoreTimezone?: boolean;
 
     /**
+     * Отображать список лет в порядке возрастания (по-умолчанию в порядке убывания)
+     */
+    reverseYearsOrder?: boolean;
+
+    /**
      * Управление шириной календаря. При значении 'available' растягивает кнопку на ширину родителя
      */
     width?: 'default' | 'available';
@@ -445,11 +450,13 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     };
 
     renderYears() {
+        const reverse = this.props.reverseYearsOrder;
+
         return (
             <div className={ this.cn('wrapper') }>
                 <div className={ this.cn('years') } ref={ this.yearsListRef }>
                     {
-                        this.years.map((year, index) => {
+                        (reverse ? this.years.reverse() : this.years).map((year, index) => {
                             const newYear = setYear(this.state.month, year);
                             const dataYear = newYear.getTime();
                             const selectedDate = new Date(this.state.month);


### PR DESCRIPTION
Добавлен reverseYearsOrder параметр для изменения последовательности лет в селекте

По-умолчанию года в селекте отображаются по убыванию.
Есть кейс когда нужно отображать года по возрастанию
<img width="356" alt="Screenshot 2021-08-18 at 6 00 31 PM" src="https://user-images.githubusercontent.com/3326345/129922078-050d01ec-123f-44a7-a63f-03464489737f.png">
