### PR TITLE
fix(icons-import): fix wrong import, that caused import of whole library instead of one icon

### DIFF
--- a/gemini/webpack.gemini.config.js
+++ b/gemini/webpack.gemini.config.js
@@ -18,7 +18,7 @@ module.exports = merge.smart(WEBPACK_BASE_TEMPLATE, {
                 loader: 'ts-loader',
                 options: {
                     transpileOnly: true,
-                }
+                },
             },
         ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "dev": true
     },
     "@alfalab/icons-classic": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@alfalab/icons-classic/-/icons-classic-1.56.0.tgz",
-      "integrity": "sha512-RezEx/XHzV5nE9G9afx2oS9RFmBwH1FTHSvZJ2EXqJn0h5+lhFkRPuaPkVH2pYNDPewKbke+Bl2It3tacXoUhg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@alfalab/icons-classic/-/icons-classic-2.1.0.tgz",
+      "integrity": "sha512-DRE1WHRetLo77n5ZjBF4/voMKPDAMoy1QPyMwmQ0MNIbHqmjpdsEBletO7bUbtjgghfY+wrwR6UYM01W9cTfPQ=="
     },
     "@alfalab/icons-glyph": {
-      "version": "1.143.0",
-      "resolved": "https://registry.npmjs.org/@alfalab/icons-glyph/-/icons-glyph-1.143.0.tgz",
-      "integrity": "sha512-/KQBouaBNFyAbUOHx1WrkUSByjwVrFMDMhYU5a4WuPskPyW7va8mtt7rO8ye/AYmgcK4CeVmKkYL0LN8OMkXQA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@alfalab/icons-glyph/-/icons-glyph-2.3.0.tgz",
+      "integrity": "sha512-BSAVCrCo7DJAvGM74Fi8p3r4pHBeY/tJeMM+TW+XSjnMtmPOFAGSLTb/AIsmwuthintvmvw8hk3vQKJ1pBojTg=="
     },
     "@babel/code-frame": {
       "version": "7.12.11",

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
   "author": "Good guys from Alfa Laboratory",
   "license": "MPL-2.0",
   "dependencies": {
-    "@alfalab/icons-classic": "^1.56.0",
-    "@alfalab/icons-glyph": "^1.143.0",
+    "@alfalab/icons-classic": "^2.1.0",
+    "@alfalab/icons-glyph": "^2.3.0",
     "@babel/runtime-corejs2": "^7.7.6",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/lodash.sortedindexby": "^4.6.6",

--- a/src/attach/__snapshots__/attach.test.tsx.snap
+++ b/src/attach/__snapshots__/attach.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`attach should render without problems 1`] = `
       className="attach__button"
       disabled={false}
       focused={false}
-      icon={<r />}
+      icon={<a />}
       leftAddons={
         <label
           className="attach__label"
@@ -45,7 +45,7 @@ exports[`attach should render without problems 1`] = `
         disabled={false}
         focused={false}
         formNoValidate={false}
-        icon={<r />}
+        icon={<a />}
         leftAddons={
           <label
             className="attach__label"
@@ -113,11 +113,12 @@ exports[`attach should render without problems 1`] = `
               className="button__icon"
               key="icon"
             >
-              <r>
+              <a>
                 <svg
                   fill="currentColor"
                   focusable="false"
                   height="18"
+                  role="img"
                   viewBox="0 0 17 18"
                   width="17"
                 >
@@ -125,7 +126,7 @@ exports[`attach should render without problems 1`] = `
                     d="M8.508 16.07a5.002 5.002 0 007.026-.044A4.998 4.998 0 0015.578 9L7.8 1.222a3.996 3.996 0 00-6.69 1.793 3.999 3.999 0 001.034 3.864l6.364 6.363a3 3 0 005.037-1.337 2.998 2.998 0 00-.795-2.907L9.92 6.172l-.706.707 2.83 2.827a2.002 2.002 0 01-2.831 2.829l-6.36-6.364a2.996 2.996 0 01-.001-4.241 2.997 2.997 0 014.242 0l7.778 7.777a4 4 0 01-5.657 5.658L2.85 9l-.707.707 6.365 6.364z"
                   />
                 </svg>
-              </r>
+              </a>
             </span>
             <span
               className="button__text"

--- a/src/attach/attach.tsx
+++ b/src/attach/attach.tsx
@@ -6,13 +6,13 @@
 import React from 'react';
 import { createCn } from 'bem-react-classname';
 import {
-    AttachmentSIcon
+    AttachmentSIcon,
 } from '@alfalab/icons-classic/AttachmentSIcon';
 import {
-    AttachmentMIcon
+    AttachmentMIcon,
 } from '@alfalab/icons-classic/AttachmentMIcon';
 import {
-    AttachmentLIcon
+    AttachmentLIcon,
 } from '@alfalab/icons-classic/AttachmentLIcon';
 import {
     AttachmentXlIcon,

--- a/src/calendar-input/calendar-input.tsx
+++ b/src/calendar-input/calendar-input.tsx
@@ -8,13 +8,13 @@ import React from 'react';
 import formatDate from 'date-fns/format';
 import { createCn } from 'bem-react-classname';
 import {
-    CalendarMIcon
+    CalendarMIcon,
 } from '@alfalab/icons-classic/CalendarMIcon';
 import {
-    CalendarLIcon
+    CalendarLIcon,
 } from '@alfalab/icons-classic/CalendarLIcon';
 import {
-    CalendarSIcon
+    CalendarSIcon,
 } from '@alfalab/icons-classic/CalendarSIcon';
 import {
     CalendarXlIcon,

--- a/src/calendar/__snapshots__/calendar.test.tsx.snap
+++ b/src/calendar/__snapshots__/calendar.test.tsx.snap
@@ -120,6 +120,7 @@ exports[`calendar should render without problems 1`] = `
                 fill="currentColor"
                 focusable="false"
                 height="24"
+                role="img"
                 viewBox="0 0 24 24"
                 width="24"
               >
@@ -151,6 +152,7 @@ exports[`calendar should render without problems 1`] = `
                 fill="currentColor"
                 focusable="false"
                 height="24"
+                role="img"
                 viewBox="0 0 24 24"
                 width="24"
               >

--- a/src/calendar/calendar.test.tsx
+++ b/src/calendar/calendar.test.tsx
@@ -371,10 +371,10 @@ describe('calendar', () => {
         ];
         const calendar = mount(
             <Calendar
-                value={startOfDay(new Date('2020-11-15')).valueOf()}
+                value={ startOfDay(new Date('2020-11-15')).valueOf() }
                 ignoreTimezone={ true }
                 eventDays={ eventDays }
-            />
+            />,
         );
 
         const days = calendar.find('.calendar__event');
@@ -390,10 +390,10 @@ describe('calendar', () => {
         ];
         const calendar = mount(
             <Calendar
-                value={startOfDay(new Date('2020-11-15')).valueOf()}
+                value={ startOfDay(new Date('2020-11-15')).valueOf() }
                 ignoreTimezone={ true }
                 offDays={ offDays }
-            />
+            />,
         );
 
         const days = calendar.find('.calendar__day_type_weekend-off');

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -25,10 +25,9 @@ import eachDay from 'date-fns/each_day';
 import sortedIndexOf from 'lodash.sortedindexof';
 import sortedIndexBy from 'lodash.sortedindexby';
 
-import { ArrowBackMIcon, ArrowForwardMIcon } from '@alfalab/icons-glyph';
-import {
-    ArrowSelectMIcon
-} from '@alfalab/icons-classic/ArrowSelectMIcon';
+import { ArrowBackMIcon } from '@alfalab/icons-glyph/ArrowBackMIcon';
+import { ArrowForwardMIcon } from '@alfalab/icons-glyph/ArrowForwardMIcon';
+import { ArrowSelectMIcon } from '@alfalab/icons-classic/ArrowSelectMIcon';
 import keyboardCode from '../lib/keyboard-code';
 import performance from '../performance';
 import { isCurrentDay, getYearsRange } from './utils';
@@ -44,7 +43,6 @@ const SUNDAY_INDEX = 6;
 const WITHOUT_TIME_FORMAT = 'YYYY-MM-DD';
 
 export type CalendarProps = {
-
     /**
      * Выбранная дата, в формате unix timestamp
      */
@@ -78,7 +76,11 @@ export type CalendarProps = {
     /**
      * Обработчик смены даты
      */
-    onValueChange?: (timestamp?: number, dateString?: string, isTriggeredByKeyboard?: boolean) => void;
+    onValueChange?: (
+        timestamp?: number,
+        dateString?: string,
+        isTriggeredByKeyboard?: boolean
+    ) => void;
 
     /**
      * Обработчик смены месяца
@@ -180,14 +182,13 @@ export type CalendarProps = {
      * Идентификатор для систем автоматизированного тестирования
      */
     'data-test-id'?: string;
-
 };
 
 type CalendarState = {
     isMonthSelection?: boolean;
     isYearSelection?: boolean;
     month: Date | number;
-}
+};
 /**
  * Компонент календаря.
  */
@@ -200,8 +201,20 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         selectedTo: null,
         outputFormat: 'DD.MM.YYYY',
         weekdays: ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'],
-        months: ['Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь',
-            'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь'],
+        months: [
+            'Январь',
+            'Февраль',
+            'Март',
+            'Апрель',
+            'Май',
+            'Июнь',
+            'Июль',
+            'Август',
+            'Сентябрь',
+            'Октябрь',
+            'Ноябрь',
+            'Декабрь',
+        ],
         offDays: [],
         eventDays: [],
         showToday: false,
@@ -277,60 +290,48 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         const month = new Date(this.state.month);
         const isPrevMonthEnabled = !this.earlierLimit
             || differenceInMonths(month, startOfMonth(this.earlierLimit)) > 0;
-        const isNextMonthEnabled = !this.laterLimit
-            || differenceInMonths(month, this.laterLimit) < 0;
+        const isNextMonthEnabled = !this.laterLimit || differenceInMonths(month, this.laterLimit) < 0;
         const areArrowsVisible = this.props.showArrows
             && !this.state.isMonthSelection
             && !this.state.isYearSelection;
 
         return (
             <div className={ this.cn('title') }>
-                {
-                    areArrowsVisible && (
-                        <div
-                            className={
-                                this.cn('arrow', {
-                                    direction: 'left',
-                                    disabled: !isPrevMonthEnabled,
-                                })
-                            }
-                            data-step="-1"
-                            data-disabled={ !isPrevMonthEnabled }
-                            role="button"
-                            tabIndex={ 0 }
-                            onClick={ this.handleArrowClick }
-                        >
-                            <ArrowBackMIcon />
-                        </div>
-                    )
-                }
-                {
-                    areArrowsVisible && (
-                        <div
-                            className={
-                                this.cn('arrow', {
-                                    direction: 'right',
-                                    disabled: !isNextMonthEnabled,
-                                })
-                            }
-                            data-step="1"
-                            data-disabled={ !isNextMonthEnabled }
-                            role="button"
-                            tabIndex={ 0 }
-                            onClick={ this.handleArrowClick }
-                        >
-                            <ArrowForwardMIcon />
-                        </div>
-                    )
-                }
-                <div className={ this.cn('select-buttons') }>
-
+                { areArrowsVisible && (
                     <div
-                        className={
-                            this.cn('name', {
-                                month: true,
-                            })
-                        }
+                        className={ this.cn('arrow', {
+                            direction: 'left',
+                            disabled: !isPrevMonthEnabled,
+                        }) }
+                        data-step="-1"
+                        data-disabled={ !isPrevMonthEnabled }
+                        role="button"
+                        tabIndex={ 0 }
+                        onClick={ this.handleArrowClick }
+                    >
+                        <ArrowBackMIcon />
+                    </div>
+                ) }
+                { areArrowsVisible && (
+                    <div
+                        className={ this.cn('arrow', {
+                            direction: 'right',
+                            disabled: !isNextMonthEnabled,
+                        }) }
+                        data-step="1"
+                        data-disabled={ !isNextMonthEnabled }
+                        role="button"
+                        tabIndex={ 0 }
+                        onClick={ this.handleArrowClick }
+                    >
+                        <ArrowForwardMIcon />
+                    </div>
+                ) }
+                <div className={ this.cn('select-buttons') }>
+                    <div
+                        className={ this.cn('name', {
+                            month: true,
+                        }) }
                         role="button"
                         tabIndex={ 0 }
                         onClick={ this.handleMonthClick }
@@ -344,16 +345,18 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
                     </div>
 
                     <div
-                        className={
-                            this.cn('name', {
-                                year: true,
-                            })
-                        }
+                        className={ this.cn('name', {
+                            year: true,
+                        }) }
                         role="button"
                         tabIndex={ 0 }
                         onClick={ this.handleYearClick }
                     >
-                        <div className={ this.cn('select-text') }>{ `${month.getFullYear()}` }</div>
+                        <div
+                            className={ this.cn('select-text') }
+                        >
+                            { `${month.getFullYear()}` }
+                        </div>
                         <div className={ this.cn('select-arrows') }>
                             <ArrowSelectMIcon />
                         </div>
@@ -372,11 +375,14 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     };
 
     private handleYearClick = () => {
-        this.setState({
-            isMonthSelection: false,
-            // eslint-disable-next-line react/no-access-state-in-setstate
-            isYearSelection: !this.state.isYearSelection,
-        }, this.scrollToSelectedYear);
+        this.setState(
+            {
+                isMonthSelection: false,
+                // eslint-disable-next-line react/no-access-state-in-setstate
+                isYearSelection: !this.state.isYearSelection,
+            },
+            this.scrollToSelectedYear,
+        );
     };
 
     renderContent() {
@@ -393,37 +399,40 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         return (
             <div className={ this.cn('wrapper') }>
                 <div className={ this.cn('months') }>
-                    {
-                        this.props.months.map((month, index) => {
-                            const monthStart = startOfMonth(setMonth(this.state.month, index));
-                            const monthEnd = endOfMonth(monthStart);
-                            const allMonthDays = eachDay(monthStart, monthEnd);
-                            const off = !allMonthDays.find((day) => this.isValidDate(day));
-                            const selectedDate = new Date(this.state.month);
-                            const isSameMonth = selectedDate
-                                && selectedDate.getMonth() === monthStart.getMonth();
+                    { this.props.months.map((month, index) => {
+                        const monthStart = startOfMonth(
+                            setMonth(this.state.month, index),
+                        );
+                        const monthEnd = endOfMonth(monthStart);
+                        const allMonthDays = eachDay(monthStart, monthEnd);
+                        const off = !allMonthDays.find((day) => this.isValidDate(day));
+                        const selectedDate = new Date(this.state.month);
+                        const isSameMonth = selectedDate
+                            && selectedDate.getMonth() === monthStart.getMonth();
 
-                            const dataMonth = off ? null : monthStart.getTime();
+                        const dataMonth = off ? null : monthStart.getTime();
 
-                            const mods = {
-                                type: off ? 'off' : null,
-                                state: isSameMonth ? 'current' : null,
-                            };
+                        const mods = {
+                            type: off ? 'off' : null,
+                            state: isSameMonth ? 'current' : null,
+                        };
 
-                            return (
-                                <div
-                                    className={ this.cn('select', { month: true, ...mods }) }
-                                    key={ `month_${index + 1}` }
-                                    role="gridcell"
-                                    tabIndex={ 0 }
-                                    data-month={ dataMonth }
-                                    onClick={ this.handleSelectMonthClick }
-                                >
-                                    { month }
-                                </div>
-                            );
-                        })
-                    }
+                        return (
+                            <div
+                                className={ this.cn('select', {
+                                    month: true,
+                                    ...mods,
+                                }) }
+                                key={ `month_${index + 1}` }
+                                role="gridcell"
+                                tabIndex={ 0 }
+                                data-month={ dataMonth }
+                                onClick={ this.handleSelectMonthClick }
+                            >
+                                { month }
+                            </div>
+                        );
+                    }) }
                 </div>
             </div>
         );
@@ -457,13 +466,14 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         return (
             <div className={ this.cn('wrapper') }>
                 <div className={ this.cn('years') } ref={ this.yearsListRef }>
-                    {
-                        (reverse ? this.years.reverse() : this.years).map((year, index) => {
+                    { (reverse ? this.years.reverse() : this.years).map(
+                        (year, index) => {
                             const newYear = setYear(this.state.month, year);
                             const dataYear = newYear.getTime();
                             const selectedDate = new Date(this.state.month);
                             const isSameYear = selectedDate
-                                && selectedDate.getFullYear() === newYear.getFullYear();
+                                && selectedDate.getFullYear()
+                                    === newYear.getFullYear();
 
                             const mods = {
                                 state: isSameYear ? 'current' : null,
@@ -471,19 +481,26 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
 
                             return (
                                 <div
-                                    className={ this.cn('select', { year: true, ...mods }) }
+                                    className={ this.cn('select', {
+                                        year: true,
+                                        ...mods,
+                                    }) }
                                     key={ `year_${index + 1}` }
                                     role="gridcell"
                                     tabIndex={ 0 }
                                     data-year={ dataYear }
                                     onClick={ this.handleSelectYearClick }
-                                    ref={ isSameYear ? this.selectedYearRef : undefined }
+                                    ref={
+                                        isSameYear
+                                            ? this.selectedYearRef
+                                            : undefined
+                                    }
                                 >
                                     { year }
                                 </div>
                             );
-                        })
-                    }
+                        },
+                    ) }
                 </div>
             </div>
         );
@@ -512,24 +529,16 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     };
 
     renderDays() {
-        const rows = [
-            this.renderShortWeekdays(),
-            ...this.renderMonth(),
-        ];
+        const rows = [this.renderShortWeekdays(), ...this.renderMonth()];
 
         return (
             <table className={ this.cn('layout') }>
                 <tbody>
-                    {
-                        rows.map((row, index) => (
-                            <tr
-                                className={ this.cn('row') }
-                                key={ `row_${index + 1}` }
-                            >
-                                { row }
-                            </tr>
-                        ))
-                    }
+                    { rows.map((row, index) => (
+                        <tr className={ this.cn('row') } key={ `row_${index + 1}` }>
+                            { row }
+                        </tr>
+                    )) }
                 </tbody>
             </table>
         );
@@ -538,7 +547,9 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     renderShortWeekdays() {
         return this.props.weekdays.map((weekdayName, index) => (
             <th
-                className={ this.cn('dayname', { type: index > 4 ? 'weekend' : false }) }
+                className={ this.cn('dayname', {
+                    type: index > 4 ? 'weekend' : false,
+                }) }
                 key={ weekdayName }
             >
                 { weekdayName }
@@ -566,8 +577,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
 
             if (day) {
                 const isSameDate = val && val.getTime() === day.getTime();
-                const isBetweenPeriod = this.selectedFrom && this.selectedTo
-                    && this.selectedFrom <= day && this.selectedTo >= day;
+                const isBetweenPeriod = this.selectedFrom
+                    && this.selectedTo
+                    && this.selectedFrom <= day
+                    && this.selectedTo >= day;
 
                 if (off || weekend) {
                     if (weekend) {
@@ -590,14 +603,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
                 mods.empty = true;
             }
 
-            const dataDay = day && !off
-                ? day.getTime()
-                : null;
+            const dataDay = day && !off ? day.getTime() : null;
 
             return (
-                <td
-                    key={ day || `day_${index + 1}` }
-                >
+                <td key={ day || `day_${index + 1}` }>
                     <div
                         className={ this.cn('day', mods) }
                         role="gridcell"
@@ -607,7 +616,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
                     >
                         { day ? day.getDate() : '' }
                         { mods.event && (
-                            <span data-day={ dataDay } className={ this.cn('event') } />
+                            <span
+                                data-day={ dataDay }
+                                className={ this.cn('event') }
+                            />
                         ) }
                     </div>
                 </td>
@@ -641,7 +653,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         }
 
         this.blurTimeoutId = window.setTimeout(() => {
-            if (isNodeOutsideElement(document.activeElement, this.root) && this.props.onBlur) {
+            if (
+                isNodeOutsideElement(document.activeElement, this.root)
+                && this.props.onBlur
+            ) {
                 this.props.onBlur(event);
             }
             this.blurTimeoutId = null;
@@ -649,7 +664,9 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     };
 
     private handleArrowClick = (event) => {
-        if (event.currentTarget.attributes['data-disabled'].nodeValue === 'true') {
+        if (
+            event.currentTarget.attributes['data-disabled'].nodeValue === 'true'
+        ) {
             return;
         }
 
@@ -771,7 +788,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     private isOffDay(date: Date | number) {
         if (this.props.offDays && Array.isArray(this.props.offDays)) {
             if (this.props.ignoreTimezone) {
-                return Calendar.checkDaysIgnoringTimezone(this.props.offDays, date);
+                return Calendar.checkDaysIgnoringTimezone(
+                    this.props.offDays,
+                    date,
+                );
             }
             const timestamp = date.valueOf();
 
@@ -788,9 +808,16 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
      * @param date Дата для проверки
      */
     private isEventDay(date: Date | number) {
-        if (this.props.eventDays && Array.isArray(this.props.eventDays) && date !== null) {
+        if (
+            this.props.eventDays
+            && Array.isArray(this.props.eventDays)
+            && date !== null
+        ) {
             if (this.props.ignoreTimezone) {
-                return Calendar.checkDaysIgnoringTimezone(this.props.eventDays, date);
+                return Calendar.checkDaysIgnoringTimezone(
+                    this.props.eventDays,
+                    date,
+                );
             }
             const timestamp = date.valueOf();
 
@@ -808,7 +835,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
      * @param isTriggeredByKeyboard Флаг, что событие
      * произошло из-за нажатия пользователем кнопки на клавиатуре
      */
-    private performChange(timestamp: number | Date, isTriggeredByKeyboard = false) {
+    private performChange(
+        timestamp: number | Date,
+        isTriggeredByKeyboard = false,
+    ) {
         if (!this.props.onValueChange) {
             return;
         }
@@ -833,7 +863,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
      * @param isTriggeredByKeyboard Флаг, что событие
      * произошло из-за нажатия пользователем кнопки на клавиатуре
      */
-    private performChangeWithShift(dayShift: number, isTriggeredByKeyboard: boolean) {
+    private performChangeWithShift(
+        dayShift: number,
+        isTriggeredByKeyboard: boolean,
+    ) {
         if (!this.ensureValueInLimits(dayShift)) {
             return;
         }
@@ -847,7 +880,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
 
             this.performChange(shiftedValue.valueOf(), isTriggeredByKeyboard);
 
-            if (this.props.onMonthChange && !isSameMonth(shiftedValue, this.value)) {
+            if (
+                this.props.onMonthChange
+                && !isSameMonth(shiftedValue, this.value)
+            ) {
                 this.props.onMonthChange(shiftedValue.valueOf());
             }
         } else {
@@ -858,8 +894,12 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     private ensureValueInLimits(dayShift) {
         const shiftedDay = addDays(this.value, dayShift);
 
-        return (!this.earlierLimit || differenceInMilliseconds(shiftedDay, this.earlierLimit) >= 0)
-            && (!this.laterLimit || differenceInMilliseconds(shiftedDay, this.laterLimit) <= 0);
+        return (
+            (!this.earlierLimit
+                || differenceInMilliseconds(shiftedDay, this.earlierLimit) >= 0)
+            && (!this.laterLimit
+                || differenceInMilliseconds(shiftedDay, this.laterLimit) <= 0)
+        );
     }
 
     private calculateWeeks() {
@@ -874,7 +914,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         // map не вызывает колбек, для ключей, к которым не были приассигнены значения
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
         // соответственно пропадают undefined значения, поэтому:
-        let week = (new Array(DAYS_IN_WEEK)).fill(null);
+        let week = new Array(DAYS_IN_WEEK).fill(null);
 
         dateIterator.setDate(1);
 
@@ -888,7 +928,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             if (weekDay === lastDay) {
                 weeks.push(week);
                 weekCounter -= 1;
-                week = (new Array(DAYS_IN_WEEK)).fill(null);
+                week = new Array(DAYS_IN_WEEK).fill(null);
             }
 
             dateIterator.setDate(dateIterator.getDate() + 1);
@@ -931,11 +971,17 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             month: startOfMonth(month),
         });
 
-        if (isInitializing || this.props.earlierLimit !== nextProps.earlierLimit) {
+        if (
+            isInitializing
+            || this.props.earlierLimit !== nextProps.earlierLimit
+        ) {
             if (nextProps.earlierLimit) {
                 this.earlierLimit = normalizeDate(nextProps.earlierLimit);
             } else {
-                this.earlierLimit = subtractYears(new Date(), EARLY_YEARS_LIMIT);
+                this.earlierLimit = subtractYears(
+                    new Date(),
+                    EARLY_YEARS_LIMIT,
+                );
             }
 
             this.earlierLimit = startOfDay(this.earlierLimit);
@@ -970,12 +1016,18 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         this.years = getYearsRange(this.earlierLimit, this.laterLimit);
 
         if (isInitializing || this.props.selectedTo !== nextProps.selectedTo) {
-            this.selectedTo = nextProps.selectedTo ? normalizeDate(nextProps.selectedTo) : null;
+            this.selectedTo = nextProps.selectedTo
+                ? normalizeDate(nextProps.selectedTo)
+                : null;
         }
 
-        if (isInitializing || this.props.selectedFrom !== nextProps.selectedFrom) {
+        if (
+            isInitializing
+            || this.props.selectedFrom !== nextProps.selectedFrom
+        ) {
             this.selectedFrom = nextProps.selectedFrom
-                ? normalizeDate(nextProps.selectedFrom) : null;
+                ? normalizeDate(nextProps.selectedFrom)
+                : null;
         }
     }
 
@@ -985,11 +1037,21 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
      * @param date Дата
      * @param daysToСheck Список дат для проверки
      */
-    private static checkDaysIgnoringTimezone(daysToCheck: readonly number[], date: Date | number) {
+    private static checkDaysIgnoringTimezone(
+        daysToCheck: readonly number[],
+        date: Date | number,
+    ) {
         const dateWithoutTime = formatDate(date, WITHOUT_TIME_FORMAT);
         /* Используем бинарный поиск */
-        const index = sortedIndexBy<string | number>(daysToCheck, dateWithoutTime, (day) => formatDate(day, WITHOUT_TIME_FORMAT));
-        return dateWithoutTime === formatDate(daysToCheck[index], WITHOUT_TIME_FORMAT);
+        const index = sortedIndexBy<string | number>(
+            daysToCheck,
+            dateWithoutTime,
+            (day) => formatDate(day, WITHOUT_TIME_FORMAT),
+        );
+        return (
+            dateWithoutTime
+            === formatDate(daysToCheck[index], WITHOUT_TIME_FORMAT)
+        );
     }
 }
 

--- a/src/checkbox/__snapshots__/checkbox.test.tsx.snap
+++ b/src/checkbox/__snapshots__/checkbox.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`checkbox should render without problems 1`] = `
       onClick={[Function]}
       type="checkbox"
     />
-    <s
+    <l
       className="checkbox__icon"
     />
   </span>

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -5,13 +5,13 @@
 import React from 'react';
 import { createCn } from 'bem-react-classname';
 import {
-    TickXsIcon
+    TickXsIcon,
 } from '@alfalab/icons-classic/TickXsIcon';
 import {
-    TickSIcon
+    TickSIcon,
 } from '@alfalab/icons-classic/TickSIcon';
 import {
-    CheckIndeterminateMIcon
+    CheckIndeterminateMIcon,
 } from '@alfalab/icons-classic/CheckIndeterminateMIcon';
 import {
     CheckIndeterminateSIcon,

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -7,13 +7,13 @@
 import React from 'react';
 import { createCn } from 'bem-react-classname';
 import {
-    CloseSIcon
+    CloseSIcon,
 } from '@alfalab/icons-classic/CloseSIcon';
 import {
-    CloseMIcon
+    CloseMIcon,
 } from '@alfalab/icons-classic/CloseMIcon';
 import {
-    CloseLIcon
+    CloseLIcon,
 } from '@alfalab/icons-classic/CloseLIcon';
 import {
     CloseXlIcon,

--- a/src/menu/menu.tsx
+++ b/src/menu/menu.tsx
@@ -7,10 +7,10 @@
 import React from 'react';
 import { createCn } from 'bem-react-classname';
 import {
-    TickMIcon
+    TickMIcon,
 } from '@alfalab/icons-classic/TickMIcon';
 import {
-    TickSIcon
+    TickSIcon,
 } from '@alfalab/icons-classic/TickSIcon';
 import { withTheme, Theme } from '../cn';
 

--- a/src/notification/notification.tsx
+++ b/src/notification/notification.tsx
@@ -7,13 +7,13 @@
 import React from 'react';
 import { createCn } from 'bem-react-classname';
 import {
-    CloseSIcon
+    CloseSIcon,
 } from '@alfalab/icons-classic/CloseSIcon';
 import {
-    ErrorMColorIcon
+    ErrorMColorIcon,
 } from '@alfalab/icons-classic/ErrorMColorIcon';
 import {
-    FailMIcon
+    FailMIcon,
 } from '@alfalab/icons-classic/FailMIcon';
 import {
     OkMColorIcon,

--- a/src/plate/plate.tsx
+++ b/src/plate/plate.tsx
@@ -7,13 +7,13 @@
 import React from 'react';
 import { createCn } from 'bem-react-classname';
 import {
-    CloseMIcon
+    CloseMIcon,
 } from '@alfalab/icons-classic/CloseMIcon';
 import {
-    ArrowUpMIcon
+    ArrowUpMIcon,
 } from '@alfalab/icons-classic/ArrowUpMIcon';
 import {
-    ArrowDownMIcon
+    ArrowDownMIcon,
 } from '@alfalab/icons-classic/ArrowDownMIcon';
 import { withTheme, Theme } from '../cn';
 

--- a/src/popup-header/popup-header.tsx
+++ b/src/popup-header/popup-header.tsx
@@ -5,13 +5,13 @@
 import React from 'react';
 import { createCn } from 'bem-react-classname';
 import {
-    CloseXsIcon
+    CloseXsIcon,
 } from '@alfalab/icons-classic/CloseXsIcon';
 import {
-    CloseSIcon
+    CloseSIcon,
 } from '@alfalab/icons-classic/CloseSIcon';
 import {
-    CloseMIcon
+    CloseMIcon,
 } from '@alfalab/icons-classic/CloseMIcon';
 import {
     CloseLIcon,

--- a/src/select/__snapshots__/select.test.tsx.snap
+++ b/src/select/__snapshots__/select.test.tsx.snap
@@ -144,6 +144,7 @@ exports[`select should render without problem 1`] = `
                               fill="currentColor"
                               focusable="false"
                               height="18"
+                              role="img"
                               viewBox="0 0 18 18"
                               width="18"
                             >

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -6,13 +6,13 @@ import createFragment from 'react-addons-create-fragment';
 import React from 'react';
 import { createCn } from 'bem-react-classname';
 import {
-    ArrowUpSIcon
+    ArrowUpSIcon,
 } from '@alfalab/icons-classic/ArrowUpSIcon';
 import {
-    ArrowUpMIcon
+    ArrowUpMIcon,
 } from '@alfalab/icons-classic/ArrowUpMIcon';
 import {
-    ArrowUpLIcon
+    ArrowUpLIcon,
 } from '@alfalab/icons-classic/ArrowUpLIcon';
 import {
     ArrowDownSIcon,
@@ -21,7 +21,7 @@ import {
     ArrowDownMIcon,
 } from '@alfalab/icons-classic/ArrowDownMIcon';
 import {
-    ArrowDownLIcon
+    ArrowDownLIcon,
 } from '@alfalab/icons-classic/ArrowDownLIcon';
 import { withTheme, Theme } from '../cn';
 

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -236,7 +236,7 @@ export class Textarea extends React.PureComponent<TextareaProps> {
                     invalid: !!this.props.error,
                     'has-label': !!this.props.label,
                     'has-value': !!value,
-                    'has-icon': !!this.props.icon
+                    'has-icon': !!this.props.icon,
                 }) }
                 ref={ (root) => {
                     this.root = root;


### PR DESCRIPTION
<!--- Название для изменений -->
Фикс импорта иконок в библиотеку

## Мотивация и контекст
<!--- Почему эти изменения необходимы? Какую проблему они решают? -->
<!--- Если изменения исправляют открытый issue, прикрепите на него ссылку -->
При импорте иконок из корня ('@alfalab/icons-glyph') импортилась вся библиотека из-за наличия в иконках esm. В итоге один импорт 2 иконок из одной библиотеки импортил всю библиотеку и увеличивал размер бандла клиентских приложений на 54кб. 

![2021-12-12 at 19](https://user-images.githubusercontent.com/22435711/145724295-2c459924-49d7-4ba3-85b6-ba72958567a1.jpeg)
![2021-12-12 at 18](https://user-images.githubusercontent.com/22435711/145724292-bed8d6b4-aae4-4ea2-aee8-f9bd5b3e9f48.jpeg)

Пофиксил импорт, обновил либы иконок (в версиях 2+ убрали esm и импорт из корня библиотеки, что убирает возможность появления ошибки в будущем). Еще запустил eslint, поэтому изменения есть и в других файлах, кроме package.json, package-lock.json и calendar.tsx.
